### PR TITLE
Render data-driven tactical dashboard in WPF shell

### DIFF
--- a/WPF/FMUI.Wpf.sln
+++ b/WPF/FMUI.Wpf.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34622.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FMUI.Wpf", "FMUI.Wpf\FMUI.Wpf.csproj", "{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/WPF/FMUI.Wpf/App.xaml
+++ b/WPF/FMUI.Wpf/App.xaml
@@ -1,0 +1,12 @@
+<Application x:Class="FMUI.Wpf.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="Views/MainWindow.xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Theme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/WPF/FMUI.Wpf/App.xaml.cs
+++ b/WPF/FMUI.Wpf/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace FMUI.Wpf;
+
+public partial class App : Application
+{
+}

--- a/WPF/FMUI.Wpf/FMUI.Wpf.csproj
+++ b/WPF/FMUI.Wpf/FMUI.Wpf.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="app.manifest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="Views\MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\CardSurfaceView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Resources\Theme.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+</Project>

--- a/WPF/FMUI.Wpf/Infrastructure/AsyncRelayCommand.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/AsyncRelayCommand.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public sealed class AsyncRelayCommand : ICommand
+{
+    private readonly Func<object?, Task> _execute;
+    private readonly Func<object?, bool>? _canExecute;
+    private bool _isExecuting;
+
+    public AsyncRelayCommand(Func<Task> execute)
+        : this(_ => execute(), _ => true)
+    {
+    }
+
+    public AsyncRelayCommand(Func<Task> execute, Func<bool> canExecute)
+        : this(_ => execute(), _ => canExecute())
+    {
+    }
+
+    public AsyncRelayCommand(Func<object?, Task> execute)
+        : this(execute, _ => true)
+    {
+    }
+
+    public AsyncRelayCommand(Func<object?, Task> execute, Func<object?, bool>? canExecute)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter)
+    {
+        if (_isExecuting)
+        {
+            return false;
+        }
+
+        return _canExecute?.Invoke(parameter) ?? true;
+    }
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute(parameter);
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    private void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/WPF/FMUI.Wpf/Infrastructure/ObservableObject.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/ObservableObject.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public abstract class ObservableObject : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(storage, value))
+        {
+            return false;
+        }
+
+        storage = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/WPF/FMUI.Wpf/Infrastructure/RelayCommand.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/RelayCommand.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Windows.Input;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public sealed class RelayCommand : ICommand
+{
+    private readonly Action<object?> _execute;
+    private readonly Func<object?, bool>? _canExecute;
+
+    public RelayCommand(Action execute)
+        : this(_ => execute(), _ => true)
+    {
+    }
+
+    public RelayCommand(Action execute, Func<bool> canExecute)
+        : this(_ => execute(), _ => canExecute())
+    {
+    }
+
+    public RelayCommand(Action<object?> execute)
+        : this(execute, _ => true)
+    {
+    }
+
+    public RelayCommand(Action<object?> execute, Func<object?, bool>? canExecute)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
+
+    public void Execute(object? parameter) => _execute(parameter);
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/WPF/FMUI.Wpf/Models/CardModels.cs
+++ b/WPF/FMUI.Wpf/Models/CardModels.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace FMUI.Wpf.Models;
+
+public enum CardKind
+{
+    Metric,
+    List,
+    Formation,
+    Fixture,
+    Status
+}
+
+public sealed record CardListItem(string Primary, string? Secondary = null, string? Tertiary = null, string? Accent = null);
+
+public sealed record FormationLineDefinition(string Role, IReadOnlyList<string> Players);
+
+public sealed record CardDefinition(
+    string Id,
+    string Title,
+    string? Subtitle,
+    CardKind Kind,
+    int Column,
+    int Row,
+    int ColumnSpan,
+    int RowSpan,
+    string? MetricValue = null,
+    string? MetricLabel = null,
+    string? Description = null,
+    string? PillText = null,
+    IReadOnlyList<CardListItem>? ListItems = null,
+    IReadOnlyList<FormationLineDefinition>? FormationLines = null);
+
+public sealed record CardLayout(string TabIdentifier, string SectionIdentifier, IReadOnlyList<CardDefinition> Cards)
+{
+    public static CardLayout Empty { get; } = new(string.Empty, string.Empty, System.Array.Empty<CardDefinition>());
+}

--- a/WPF/FMUI.Wpf/Models/NavigationModels.cs
+++ b/WPF/FMUI.Wpf/Models/NavigationModels.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+namespace FMUI.Wpf.Models;
+
+public sealed record NavigationSubItem(string Title, string Identifier);
+
+public sealed record NavigationTab(string Title, string Identifier, IReadOnlyList<NavigationSubItem> SubItems);

--- a/WPF/FMUI.Wpf/Resources/Theme.xaml
+++ b/WPF/FMUI.Wpf/Resources/Theme.xaml
@@ -1,0 +1,121 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="SurfaceDarkColor">#0D1117</Color>
+    <Color x:Key="SurfaceMediumColor">#151B24</Color>
+    <Color x:Key="SurfaceLightColor">#1E2632</Color>
+    <Color x:Key="AccentPrimaryColor">#FF2EC4B6</Color>
+    <Color x:Key="AccentSecondaryColor">#FF3AA0FF</Color>
+    <Color x:Key="WarningColor">#FFE4B123</Color>
+    <Color x:Key="SuccessColor">#FF4CE577</Color>
+    <Color x:Key="NeutralTextColor">#FF8EA1B5</Color>
+    <Color x:Key="PrimaryTextColor">#FFF7FAFF</Color>
+
+    <SolidColorBrush x:Key="SurfaceDarkBrush" Color="{StaticResource SurfaceDarkColor}" />
+    <SolidColorBrush x:Key="SurfaceMediumBrush" Color="{StaticResource SurfaceMediumColor}" />
+    <SolidColorBrush x:Key="SurfaceLightBrush" Color="{StaticResource SurfaceLightColor}" />
+    <SolidColorBrush x:Key="AccentPrimaryBrush" Color="{StaticResource AccentPrimaryColor}" />
+    <SolidColorBrush x:Key="AccentSecondaryBrush" Color="{StaticResource AccentSecondaryColor}" />
+    <SolidColorBrush x:Key="NeutralTextBrush" Color="{StaticResource NeutralTextColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+
+    <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FF161A24" Offset="0" />
+        <GradientStop Color="#FF0D1117" Offset="1" />
+    </LinearGradientBrush>
+
+    <LinearGradientBrush x:Key="ContentGradientBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#FF080B11" Offset="0" />
+        <GradientStop Color="#FF0F1620" Offset="1" />
+    </LinearGradientBrush>
+
+    <Style x:Key="ContinueButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource AccentPrimaryBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Padding" Value="18,10" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border CornerRadius="6"
+                            Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{StaticResource AccentSecondaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="{StaticResource AccentPrimaryBrush}" />
+                            <Setter Property="Opacity" Value="0.85" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="NavigationTabContainerStyle" TargetType="Border">
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="Padding" Value="14,12" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+    <Style x:Key="NavigationTabTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
+        <Setter Property="TextOptions.TextRenderingMode" Value="Auto" />
+    </Style>
+
+    <Style x:Key="NavigationSubItemTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+
+    <Style x:Key="SubNavigationButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        <Setter Property="Padding" Value="12,6" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border CornerRadius="6" Background="{TemplateBinding Background}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#332EC4B6" />
+                            <Setter Property="Foreground" Value="White" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="#552EC4B6" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="#668EA1B5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="GridOverlayRectangleStyle" TargetType="Rectangle">
+        <Setter Property="Stroke" Value="#112EC4B6" />
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+    </Style>
+</ResourceDictionary>

--- a/WPF/FMUI.Wpf/Services/CardLayoutCatalog.cs
+++ b/WPF/FMUI.Wpf/Services/CardLayoutCatalog.cs
@@ -1,0 +1,364 @@
+using System.Collections.Generic;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public sealed class CardLayoutCatalog
+{
+    private readonly Dictionary<(string Tab, string Section), CardLayout> _layouts;
+
+    public CardLayoutCatalog()
+    {
+        _layouts = new Dictionary<(string, string), CardLayout>
+        {
+            [("tactics", "tactics-overview")] = BuildTacticsOverview(),
+            [("overview", "club-vision")] = BuildClubVisionOverview(),
+            [("training", "training-overview")] = BuildTrainingOverview(),
+        };
+    }
+
+    public bool TryGetLayout(string tabIdentifier, string sectionIdentifier, out CardLayout layout)
+    {
+        return _layouts.TryGetValue((tabIdentifier, sectionIdentifier), out layout);
+    }
+
+    private static CardLayout BuildTacticsOverview()
+    {
+        var cards = new List<CardDefinition>
+        {
+            new(
+                Id: "formation-overview",
+                Title: "4-2-3-1 Wide",
+                Subtitle: "Starting XI",
+                Kind: CardKind.Formation,
+                Column: 0,
+                Row: 0,
+                ColumnSpan: 22,
+                RowSpan: 14,
+                Description: "Balanced attacking structure with inverted wingers tucking inside to overload the half-spaces.",
+                PillText: "Positive",
+                FormationLines: new List<FormationLineDefinition>
+                {
+                    new("Striker", new[] { "Ivan Toney (AF)" }),
+                    new("Attacking Midfield", new[] { "Phil Foden (IW)", "Martin Ødegaard (AP)", "Bukayo Saka (IW)" }),
+                    new("Midfield Pivot", new[] { "Declan Rice (HB)", "Youri Tielemans (BBM)" }),
+                    new("Defence", new[] { "Kieran Tierney (WB)", "Gabriel (CD)", "Ben White (BPD)", "Takehiro Tomiyasu (WB)" }),
+                    new("Goalkeeper", new[] { "Aaron Ramsdale (SK)" }),
+                }),
+            new(
+                Id: "team-fluidity",
+                Title: "Team Fluidity",
+                Subtitle: "Shape cohesion",
+                Kind: CardKind.Metric,
+                Column: 22,
+                Row: 0,
+                ColumnSpan: 7,
+                RowSpan: 5,
+                MetricValue: "Highly Fluid",
+                MetricLabel: "Players interchange positions freely, supporting overloads down both flanks.",
+                PillText: "Excellent"),
+            new(
+                Id: "mentality",
+                Title: "Mentality",
+                Subtitle: "In possession mindset",
+                Kind: CardKind.Metric,
+                Column: 29,
+                Row: 0,
+                ColumnSpan: 8,
+                RowSpan: 5,
+                MetricValue: "Positive",
+                MetricLabel: "Balanced risk taking with emphasis on progressive runs and penetrative passing."),
+            new(
+                Id: "in-possession",
+                Title: "In Possession",
+                Subtitle: "Selected instructions",
+                Kind: CardKind.List,
+                Column: 22,
+                Row: 5,
+                ColumnSpan: 15,
+                RowSpan: 7,
+                Description: "Encourage roaming play through the channels to destabilise compact blocks.",
+                ListItems: new List<CardListItem>
+                {
+                    new("Width", "Fairly Wide"),
+                    new("Approach Play", "Play Out Of Defence"),
+                    new("Final Third", "Work Ball Into Box"),
+                    new("Tempo", "Higher"),
+                    new("Passing", "Shorter"),
+                }),
+            new(
+                Id: "in-transition",
+                Title: "In Transition",
+                Subtitle: "Moment reactions",
+                Kind: CardKind.List,
+                Column: 22,
+                Row: 12,
+                ColumnSpan: 15,
+                RowSpan: 7,
+                ListItems: new List<CardListItem>
+                {
+                    new("When Possession Has Been Lost", "Counter-Press"),
+                    new("When Possession Has Been Won", "Counter"),
+                    new("Goalkeeper In Possession", "Distribute Quickly", "Full-Backs"),
+                }),
+            new(
+                Id: "out-of-possession",
+                Title: "Out Of Possession",
+                Subtitle: "Defensive block",
+                Kind: CardKind.List,
+                Column: 0,
+                Row: 14,
+                ColumnSpan: 18,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("Defensive Line", "Higher"),
+                    new("Line Of Engagement", "Higher"),
+                    new("Pressing", "More Often"),
+                    new("Tackling", "Stay On Feet"),
+                }),
+            new(
+                Id: "recent-form",
+                Title: "Recent Form",
+                Subtitle: "Last five fixtures",
+                Kind: CardKind.List,
+                Column: 18,
+                Row: 14,
+                ColumnSpan: 19,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("vs Man City", "W 2-1", "Premier League", "Sat"),
+                    new("vs Chelsea", "D 0-0", "Premier League", "Wed"),
+                    new("vs Everton", "W 3-0", "Premier League", "Sun"),
+                    new("vs PSG", "L 1-2", "Champions League", "Tue"),
+                    new("vs Leicester", "W 4-1", "Premier League", "Sat"),
+                }),
+        };
+
+        return new CardLayout("tactics", "tactics-overview", cards);
+    }
+
+    private static CardLayout BuildClubVisionOverview()
+    {
+        var cards = new List<CardDefinition>
+        {
+            new(
+                Id: "board-confidence",
+                Title: "Board Confidence",
+                Subtitle: "Season to date",
+                Kind: CardKind.Metric,
+                Column: 0,
+                Row: 0,
+                ColumnSpan: 12,
+                RowSpan: 6,
+                MetricValue: "A",
+                MetricLabel: "Board delighted with league position and financial prudence.",
+                PillText: "Secure"),
+            new(
+                Id: "supporter-confidence",
+                Title: "Supporter Confidence",
+                Subtitle: "Mood of the terraces",
+                Kind: CardKind.Metric,
+                Column: 12,
+                Row: 0,
+                ColumnSpan: 12,
+                RowSpan: 6,
+                MetricValue: "A-",
+                MetricLabel: "Fans are thrilled by attacking football and marquee signings."),
+            new(
+                Id: "competition-expectations",
+                Title: "Competition Expectations",
+                Subtitle: "Key objectives",
+                Kind: CardKind.List,
+                Column: 24,
+                Row: 0,
+                ColumnSpan: 13,
+                RowSpan: 9,
+                ListItems: new List<CardListItem>
+                {
+                    new("Premier League", "Qualify for Champions League", "Current: 1st"),
+                    new("Champions League", "Reach Quarter Final", "Current: Group B - 1st"),
+                    new("FA Cup", "Reach Semi Final", "Current: Starts Jan"),
+                    new("Carabao Cup", "Reach Final", "Current: Eliminated"),
+                }),
+            new(
+                Id: "five-year-plan",
+                Title: "Five Year Plan",
+                Subtitle: "Strategic milestones",
+                Kind: CardKind.List,
+                Column: 0,
+                Row: 6,
+                ColumnSpan: 24,
+                RowSpan: 6,
+                ListItems: new List<CardListItem>
+                {
+                    new("2023/24", "Maintain club stature", "Premier League top four"),
+                    new("2024/25", "Expand stadium capacity", "Board planning"),
+                    new("2025/26", "Win a major trophy", "Minimum expectation"),
+                }),
+            new(
+                Id: "finance-snapshot",
+                Title: "Finance Snapshot",
+                Subtitle: "Month to date",
+                Kind: CardKind.List,
+                Column: 0,
+                Row: 12,
+                ColumnSpan: 18,
+                RowSpan: 7,
+                ListItems: new List<CardListItem>
+                {
+                    new("Overall Balance", "£182M"),
+                    new("Transfer Budget", "£48M"),
+                    new("Wage Budget", "£3.2M p/w", "Committed: £3.0M"),
+                    new("Scouting Budget", "£2.4M"),
+                }),
+            new(
+                Id: "top-performers",
+                Title: "Top Performers",
+                Subtitle: "Last five matches",
+                Kind: CardKind.List,
+                Column: 18,
+                Row: 12,
+                ColumnSpan: 19,
+                RowSpan: 7,
+                ListItems: new List<CardListItem>
+                {
+                    new("Bukayo Saka", "3 goals", "Average Rating 7.94"),
+                    new("Martin Ødegaard", "4 assists", "Average Rating 7.71"),
+                    new("Declan Rice", "92% pass completion", "Average Rating 7.48"),
+                }),
+        };
+
+        return new CardLayout("overview", "club-vision", cards);
+    }
+
+    private static CardLayout BuildTrainingOverview()
+    {
+        var cards = new List<CardDefinition>
+        {
+            new(
+                Id: "upcoming-sessions",
+                Title: "Upcoming Sessions",
+                Subtitle: "Next 5 days",
+                Kind: CardKind.List,
+                Column: 0,
+                Row: 0,
+                ColumnSpan: 20,
+                RowSpan: 7,
+                ListItems: new List<CardListItem>
+                {
+                    new("Mon", "Recovery", "Unit split: Senior"),
+                    new("Tue", "Tactical - Shape", "Match Prep Focus"),
+                    new("Wed", "Attacking - Wings", "High Intensity"),
+                    new("Thu", "Match Preview", "Medium Intensity"),
+                    new("Fri", "Match Practice", "Set Pieces"),
+                }),
+            new(
+                Id: "training-intensity",
+                Title: "Training Intensity",
+                Subtitle: "Overall load",
+                Kind: CardKind.Metric,
+                Column: 20,
+                Row: 0,
+                ColumnSpan: 9,
+                RowSpan: 5,
+                MetricValue: "High",
+                MetricLabel: "Condition monitored closely. Two players nearing risk threshold.",
+                PillText: "Alert"),
+            new(
+                Id: "focus-areas",
+                Title: "Focus Areas",
+                Subtitle: "Current emphasis",
+                Kind: CardKind.List,
+                Column: 29,
+                Row: 0,
+                ColumnSpan: 8,
+                RowSpan: 7,
+                ListItems: new List<CardListItem>
+                {
+                    new("Team Focus", "Attacking Movement"),
+                    new("Match Focus", "Counter-Press"),
+                    new("Individual", "Finishing", "6 players"),
+                }),
+            new(
+                Id: "unit-coaches",
+                Title: "Unit Coaches",
+                Subtitle: "Specialist assignments",
+                Kind: CardKind.List,
+                Column: 0,
+                Row: 7,
+                ColumnSpan: 18,
+                RowSpan: 7,
+                ListItems: new List<CardListItem>
+                {
+                    new("Goalkeeping", "Javi García", "Focus: Shot Stopping"),
+                    new("Defence", "Stefan Schwarz", "Focus: Positioning"),
+                    new("Midfield", "Carles Cuadrat", "Focus: Ball Retention"),
+                    new("Attack", "Dennis Bergkamp", "Focus: Off The Ball"),
+                }),
+            new(
+                Id: "medical-workload",
+                Title: "Medical Workload",
+                Subtitle: "Risk watch",
+                Kind: CardKind.List,
+                Column: 18,
+                Row: 7,
+                ColumnSpan: 10,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("High", "Ødegaard", "Tight calf"),
+                    new("Medium", "Tierney", "Match Sharpness 68%"),
+                    new("Medium", "Toney", "Match Sharpness 71%"),
+                }),
+            new(
+                Id: "match-prep",
+                Title: "Match Prep",
+                Subtitle: "Weekend fixture",
+                Kind: CardKind.List,
+                Column: 28,
+                Row: 7,
+                ColumnSpan: 9,
+                RowSpan: 7,
+                ListItems: new List<CardListItem>
+                {
+                    new("Opponent", "Manchester City"),
+                    new("Scout Summary", "Threat: Haaland aerially"),
+                    new("Key Focus", "Limit crosses", "Double up on wings"),
+                }),
+            new(
+                Id: "individual-focus",
+                Title: "Individual Focus",
+                Subtitle: "Highlighted players",
+                Kind: CardKind.List,
+                Column: 0,
+                Row: 14,
+                ColumnSpan: 19,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("Bukayo Saka", "Final Third Runs", "Progress: 73%"),
+                    new("William Saliba", "Marking", "Progress: 61%"),
+                    new("Emile Smith Rowe", "Agility", "Progress: 42%"),
+                }),
+            new(
+                Id: "youth-development",
+                Title: "Youth Development",
+                Subtitle: "Academy focus",
+                Kind: CardKind.List,
+                Column: 19,
+                Row: 14,
+                ColumnSpan: 18,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("U21", "Pressing Triggers", "Lead: Per Mertesacker"),
+                    new("U18", "Technical Passing", "Lead: Jack Wilshere"),
+                    new("U18", "Shape", "5-2-3"),
+                }),
+        };
+
+        return new CardLayout("training", "training-overview", cards);
+    }
+}

--- a/WPF/FMUI.Wpf/Services/NavigationCatalog.cs
+++ b/WPF/FMUI.Wpf/Services/NavigationCatalog.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public static class NavigationCatalog
+{
+    public static IReadOnlyList<NavigationTab> BuildDefaultTabs() => new List<NavigationTab>
+    {
+        new("Overview", "overview", new List<NavigationSubItem>
+        {
+            new("Club Vision", "club-vision"),
+            new("Dynamics", "dynamics"),
+            new("Medical Centre", "medical-centre"),
+            new("Analytics", "analytics"),
+        }),
+        new("Squad", "squad", new List<NavigationSubItem>
+        {
+            new("Selection Info", "selection-info"),
+            new("Players", "players"),
+            new("International", "international"),
+            new("Squad Depth", "squad-depth"),
+        }),
+        new("Tactics", "tactics", new List<NavigationSubItem>
+        {
+            new("Overview", "tactics-overview"),
+            new("Set Pieces", "set-pieces"),
+            new("Analysis", "tactics-analysis"),
+        }),
+        new("Training", "training", new List<NavigationSubItem>
+        {
+            new("Overview", "training-overview"),
+            new("Calendar", "training-calendar"),
+            new("Units", "training-units"),
+        }),
+        new("Transfers", "transfers", new List<NavigationSubItem>
+        {
+            new("Centre", "transfer-centre"),
+            new("Scouting", "scouting"),
+            new("Shortlist", "shortlist"),
+        }),
+        new("Finances", "finances", new List<NavigationSubItem>
+        {
+            new("Summary", "finances-summary"),
+            new("Income", "finances-income"),
+            new("Expenditure", "finances-expenditure"),
+        }),
+        new("Fixtures", "fixtures", new List<NavigationSubItem>
+        {
+            new("Schedule", "fixtures-schedule"),
+            new("Results", "fixtures-results"),
+            new("Calendar", "fixtures-calendar"),
+        }),
+    };
+}

--- a/WPF/FMUI.Wpf/ViewModels/CardSurfaceViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/CardSurfaceViewModel.cs
@@ -1,0 +1,84 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class CardSurfaceViewModel : ObservableObject
+{
+    private readonly CardLayoutCatalog _catalog;
+    private string? _emptyMessage;
+
+    public CardSurfaceViewModel(CardLayoutCatalog catalog)
+    {
+        _catalog = catalog;
+        Metrics = CardSurfaceMetrics.Default;
+        Cards.CollectionChanged += OnCardsCollectionChanged;
+        EmptyMessage = "Select a section to view its tactical dashboard.";
+    }
+
+    public ObservableCollection<CardViewModel> Cards { get; } = new();
+
+    public CardSurfaceMetrics Metrics { get; }
+
+    public double SurfaceWidth => Metrics.SurfaceWidth;
+
+    public double SurfaceHeight => Metrics.SurfaceHeight;
+
+    public bool HasCards => Cards.Count > 0;
+
+    public string? EmptyMessage
+    {
+        get => _emptyMessage;
+        private set => SetProperty(ref _emptyMessage, value);
+    }
+
+    public void Clear()
+    {
+        Cards.Clear();
+        EmptyMessage = "Select a section to view its tactical dashboard.";
+    }
+
+    public void LoadSection(string tabIdentifier, string sectionIdentifier)
+    {
+        if (_catalog.TryGetLayout(tabIdentifier, sectionIdentifier, out var layout) && layout.Cards.Count > 0)
+        {
+            Cards.Clear();
+            foreach (var definition in layout.Cards)
+            {
+                Cards.Add(new CardViewModel(definition, Metrics));
+            }
+
+            EmptyMessage = null;
+        }
+        else
+        {
+            Cards.Clear();
+            EmptyMessage = "Layout coming soon for this section.";
+        }
+    }
+
+    private void OnCardsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasCards));
+    }
+}
+
+public sealed record CardSurfaceMetrics(int Columns, int Rows, double TileSize, double Gap, double Padding)
+{
+    public static CardSurfaceMetrics Default { get; } = new(37, 19, 32, 6, 18);
+
+    public double SurfaceWidth => Padding * 2 + Columns * TileSize + (Columns - 1) * Gap;
+
+    public double SurfaceHeight => Padding * 2 + Rows * TileSize + (Rows - 1) * Gap;
+
+    public double CalculateLeft(int column) => Padding + column * (TileSize + Gap);
+
+    public double CalculateTop(int row) => Padding + row * (TileSize + Gap);
+
+    public double CalculateWidth(int span) => span * TileSize + (span - 1) * Gap;
+
+    public double CalculateHeight(int span) => span * TileSize + (span - 1) * Gap;
+}

--- a/WPF/FMUI.Wpf/ViewModels/CardViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/CardViewModel.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class CardViewModel : ObservableObject
+{
+    private readonly CardDefinition _definition;
+    private readonly CardSurfaceMetrics _metrics;
+
+    public CardViewModel(CardDefinition definition, CardSurfaceMetrics metrics)
+    {
+        _definition = definition;
+        _metrics = metrics;
+        ListItems = definition.ListItems is { Count: > 0 }
+            ? new ReadOnlyCollection<CardListItemViewModel>(CreateListItems(definition.ListItems))
+            : System.Array.Empty<CardListItemViewModel>();
+        FormationLines = definition.FormationLines is { Count: > 0 }
+            ? new ReadOnlyCollection<FormationLineViewModel>(CreateFormationLines(definition.FormationLines))
+            : System.Array.Empty<FormationLineViewModel>();
+    }
+
+    public string Title => _definition.Title;
+
+    public string? Subtitle => _definition.Subtitle;
+
+    public string? Description => _definition.Description;
+
+    public string? PillText => _definition.PillText;
+
+    public string? MetricValue => _definition.MetricValue;
+
+    public string? MetricLabel => _definition.MetricLabel;
+
+    public CardKind Kind => _definition.Kind;
+
+    public IReadOnlyList<CardListItemViewModel> ListItems { get; }
+
+    public IReadOnlyList<FormationLineViewModel> FormationLines { get; }
+
+    public bool HasSubtitle => !string.IsNullOrWhiteSpace(Subtitle);
+
+    public bool HasDescription => !string.IsNullOrWhiteSpace(Description);
+
+    public bool HasPill => !string.IsNullOrWhiteSpace(PillText);
+
+    public bool HasMetric => !string.IsNullOrWhiteSpace(MetricValue);
+
+    public bool HasListItems => ListItems.Count > 0;
+
+    public bool HasFormation => FormationLines.Count > 0;
+
+    public double Left => _metrics.CalculateLeft(_definition.Column);
+
+    public double Top => _metrics.CalculateTop(_definition.Row);
+
+    public double Width => _metrics.CalculateWidth(_definition.ColumnSpan);
+
+    public double Height => _metrics.CalculateHeight(_definition.RowSpan);
+
+    private static IList<CardListItemViewModel> CreateListItems(IReadOnlyList<CardListItem> items)
+    {
+        var list = new List<CardListItemViewModel>(items.Count);
+        foreach (var item in items)
+        {
+            list.Add(new CardListItemViewModel(item));
+        }
+
+        return list;
+    }
+
+    private static IList<FormationLineViewModel> CreateFormationLines(IReadOnlyList<FormationLineDefinition> definitions)
+    {
+        var lines = new List<FormationLineViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            lines.Add(new FormationLineViewModel(definition.Role, definition.Players));
+        }
+
+        return lines;
+    }
+}
+
+public sealed class CardListItemViewModel
+{
+    private readonly CardListItem _model;
+
+    public CardListItemViewModel(CardListItem model)
+    {
+        _model = model;
+    }
+
+    public string Primary => _model.Primary;
+
+    public string? Secondary => _model.Secondary;
+
+    public string? Tertiary => _model.Tertiary;
+
+    public string? Accent => _model.Accent;
+
+    public bool HasSecondary => !string.IsNullOrWhiteSpace(Secondary);
+
+    public bool HasTertiary => !string.IsNullOrWhiteSpace(Tertiary);
+
+    public bool HasAccent => !string.IsNullOrWhiteSpace(Accent);
+}
+
+public sealed class FormationLineViewModel
+{
+    public FormationLineViewModel(string role, IReadOnlyList<string> players)
+    {
+        Role = role;
+        Players = new ReadOnlyCollection<string>(new List<string>(players));
+    }
+
+    public string Role { get; }
+
+    public IReadOnlyList<string> Players { get; }
+}

--- a/WPF/FMUI.Wpf/ViewModels/MainViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/MainViewModel.cs
@@ -1,0 +1,89 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class MainViewModel : ObservableObject
+{
+    private NavigationTabViewModel? _selectedTab;
+    private readonly CardLayoutCatalog _cardCatalog;
+
+    public MainViewModel()
+    {
+        _cardCatalog = new CardLayoutCatalog();
+        var tabs = NavigationCatalog.BuildDefaultTabs()
+            .Select(model => new NavigationTabViewModel(model))
+            .ToList();
+
+        Tabs = new ObservableCollection<NavigationTabViewModel>(tabs);
+        CardSurface = new CardSurfaceViewModel(_cardCatalog);
+
+        SelectTabCommand = new RelayCommand(param =>
+        {
+            if (param is NavigationTabViewModel tab)
+            {
+                SelectTab(tab);
+            }
+        });
+
+        if (Tabs.Count > 0)
+        {
+            SelectTab(Tabs[0]);
+        }
+    }
+
+    public ObservableCollection<NavigationTabViewModel> Tabs { get; }
+
+    public NavigationTabViewModel? SelectedTab
+    {
+        get => _selectedTab;
+        private set => SetProperty(ref _selectedTab, value);
+    }
+
+    public CardSurfaceViewModel CardSurface { get; }
+
+    public ICommand SelectTabCommand { get; }
+
+    private void SelectTab(NavigationTabViewModel tab)
+    {
+        if (SelectedTab is not null)
+        {
+            SelectedTab.PropertyChanged -= OnSelectedTabPropertyChanged;
+        }
+
+        foreach (var t in Tabs)
+        {
+            t.IsSelected = ReferenceEquals(t, tab);
+        }
+
+        SelectedTab = tab;
+        SelectedTab.PropertyChanged += OnSelectedTabPropertyChanged;
+
+        UpdateSurfaceFromSelection();
+    }
+
+    private void OnSelectedTabPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(NavigationTabViewModel.ActiveSubItem))
+        {
+            UpdateSurfaceFromSelection();
+        }
+    }
+
+    private void UpdateSurfaceFromSelection()
+    {
+        var subItem = SelectedTab?.ActiveSubItem;
+        if (SelectedTab is null || subItem is null)
+        {
+            CardSurface.Clear();
+            return;
+        }
+
+        CardSurface.LoadSection(SelectedTab.Identifier, subItem.Identifier);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/NavigationSubItemViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/NavigationSubItemViewModel.cs
@@ -1,0 +1,26 @@
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class NavigationSubItemViewModel : ObservableObject
+{
+    private bool _isActive;
+
+    public NavigationSubItemViewModel(NavigationSubItem model)
+    {
+        Model = model;
+    }
+
+    public NavigationSubItem Model { get; }
+
+    public string Title => Model.Title;
+
+    public string Identifier => Model.Identifier;
+
+    public bool IsActive
+    {
+        get => _isActive;
+        set => SetProperty(ref _isActive, value);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/NavigationTabViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/NavigationTabViewModel.cs
@@ -1,0 +1,65 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class NavigationTabViewModel : ObservableObject
+{
+    private bool _isSelected;
+    private NavigationSubItemViewModel? _activeSubItem;
+
+    public NavigationTabViewModel(NavigationTab model)
+    {
+        Model = model;
+        SubItems = new ObservableCollection<NavigationSubItemViewModel>(
+            model.SubItems.Select(sub => new NavigationSubItemViewModel(sub)));
+
+        SelectSubItemCommand = new RelayCommand(param =>
+        {
+            if (param is NavigationSubItemViewModel subItem)
+            {
+                ActivateSubItem(subItem);
+            }
+        });
+
+        if (SubItems.Count > 0)
+        {
+            ActivateSubItem(SubItems[0]);
+        }
+    }
+
+    public NavigationTab Model { get; }
+
+    public string Title => Model.Title;
+
+    public string Identifier => Model.Identifier;
+
+    public ObservableCollection<NavigationSubItemViewModel> SubItems { get; }
+
+    public ICommand SelectSubItemCommand { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+
+    public NavigationSubItemViewModel? ActiveSubItem
+    {
+        get => _activeSubItem;
+        private set => SetProperty(ref _activeSubItem, value);
+    }
+
+    public void ActivateSubItem(NavigationSubItemViewModel target)
+    {
+        foreach (var item in SubItems)
+        {
+            item.IsActive = ReferenceEquals(item, target);
+        }
+
+        ActiveSubItem = target;
+    }
+}

--- a/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml
+++ b/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml
@@ -1,0 +1,288 @@
+<UserControl x:Class="FMUI.Wpf.Views.CardSurfaceView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=vm:CardSurfaceViewModel}">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+        <Style x:Key="CardBorderStyle" TargetType="Border">
+            <Setter Property="Padding" Value="20" />
+            <Setter Property="CornerRadius" Value="18" />
+            <Setter Property="Background">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Color="#1C2431" Offset="0" />
+                        <GradientStop Color="#141A24" Offset="1" />
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="BorderBrush" Value="#222D3C" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+            <Setter Property="Effect">
+                <Setter.Value>
+                    <DropShadowEffect BlurRadius="18" ShadowDepth="0" Opacity="0.22" Color="#000000" />
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="CardTitleTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="18" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardSubtitleTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardMetricValueTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="42" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+            <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
+        </Style>
+
+        <Style x:Key="CardMetricLabelTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardListPrimaryTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardListSecondaryTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        </Style>
+
+        <DataTemplate DataType="{x:Type vm:CardListItemViewModel}">
+            <Border Margin="0,0,0,10"
+                    Padding="0,0,0,8"
+                    BorderBrush="#1F2A39"
+                    BorderThickness="0 0 0 1">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="{Binding Primary}"
+                               Style="{StaticResource CardListPrimaryTextStyle}" />
+
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding Secondary}"
+                               Style="{StaticResource CardListSecondaryTextStyle}"
+                               TextAlignment="Right">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource CardListSecondaryTextStyle}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Setter Property="TextAlignment" Value="Right" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasSecondary}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <StackPanel Grid.Column="2" Orientation="Horizontal">
+                        <Border Background="#2EC4B622"
+                                Padding="8,2"
+                                CornerRadius="10"
+                                Margin="0,0,8,0">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasAccent}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <TextBlock Text="{Binding Accent}"
+                                       Foreground="{StaticResource AccentPrimaryBrush}"
+                                       FontSize="11"
+                                       FontWeight="SemiBold" />
+                        </Border>
+                        <TextBlock Text="{Binding Tertiary}"
+                                   Style="{StaticResource CardListSecondaryTextStyle}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource CardListSecondaryTextStyle}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasTertiary}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type vm:CardViewModel}">
+            <Border Style="{StaticResource CardBorderStyle}"
+                    Width="{Binding Width}"
+                    Height="{Binding Height}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding Title}" Style="{StaticResource CardTitleTextStyle}" />
+                        <Border Margin="12,0,0,0"
+                                Padding="10,4"
+                                Background="#2EC4B622"
+                                CornerRadius="12"
+                                Visibility="{Binding HasPill, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <TextBlock Text="{Binding PillText}"
+                                       Foreground="{StaticResource AccentPrimaryBrush}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold" />
+                        </Border>
+                    </StackPanel>
+
+                    <TextBlock Grid.Row="1"
+                               Margin="0,8,0,0"
+                               Text="{Binding Subtitle}"
+                               Style="{StaticResource CardSubtitleTextStyle}"
+                               Visibility="{Binding HasSubtitle, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                    <Grid Grid.Row="2" Margin="0,16,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Text="{Binding Description}"
+                                   Foreground="{StaticResource NeutralTextBrush}"
+                                   FontSize="13"
+                                   TextWrapping="Wrap"
+                                   Visibility="{Binding HasDescription, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                        <Grid Grid.Row="1">
+                            <StackPanel Visibility="{Binding HasMetric, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        VerticalAlignment="Center">
+                                <TextBlock Text="{Binding MetricValue}"
+                                           Style="{StaticResource CardMetricValueTextStyle}" />
+                                <TextBlock Text="{Binding MetricLabel}"
+                                           Margin="0,8,0,0"
+                                           Style="{StaticResource CardMetricLabelTextStyle}" />
+                            </StackPanel>
+
+                            <ItemsControl ItemsSource="{Binding ListItems}"
+                                          Margin="0,0,0,4"
+                                          Visibility="{Binding HasListItems, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                            <ItemsControl ItemsSource="{Binding FormationLines}"
+                                          Visibility="{Binding HasFormation, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:FormationLineViewModel}">
+                                        <StackPanel Margin="0,0,0,12">
+                                            <TextBlock Text="{Binding Role}"
+                                                       Style="{StaticResource CardListSecondaryTextStyle}" />
+                                            <ItemsControl ItemsSource="{Binding Players}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Padding="10,6"
+                                                                Margin="0,6,6,0"
+                                                                Background="#1F2A39"
+                                                                CornerRadius="12">
+                                                            <TextBlock Text="{Binding .}"
+                                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                                       FontSize="13" />
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Border Background="#111622"
+            CornerRadius="18"
+            SnapsToDevicePixels="True">
+        <Grid>
+            <Grid.Background>
+                <DrawingBrush TileMode="Tile"
+                              Viewport="0,0,32,32"
+                              ViewportUnits="Absolute"
+                              Stretch="None">
+                    <DrawingBrush.Drawing>
+                        <GeometryDrawing Brush="Transparent">
+                            <GeometryDrawing.Pen>
+                                <Pen Brush="#112EC4B6" Thickness="1" />
+                            </GeometryDrawing.Pen>
+                            <GeometryDrawing.Geometry>
+                                <RectangleGeometry Rect="0,0,32,32" />
+                            </GeometryDrawing.Geometry>
+                        </GeometryDrawing>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Grid.Background>
+
+            <ItemsControl ItemsSource="{Binding Cards}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <Canvas Width="{Binding SurfaceWidth}"
+                                Height="{Binding SurfaceHeight}" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Canvas.Left" Value="{Binding Left}" />
+                        <Setter Property="Canvas.Top" Value="{Binding Top}" />
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+            </ItemsControl>
+
+            <StackPanel HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasCards}" Value="False">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <TextBlock Text="{Binding EmptyMessage}"
+                           Foreground="{StaticResource NeutralTextBrush}"
+                           FontSize="16"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           MaxWidth="520" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class CardSurfaceView : UserControl
+{
+    public CardSurfaceView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/MainWindow.xaml
+++ b/WPF/FMUI.Wpf/Views/MainWindow.xaml
@@ -1,0 +1,193 @@
+<Window x:Class="FMUI.Wpf.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+        xmlns:views="clr-namespace:FMUI.Wpf.Views"
+        mc:Ignorable="d"
+        Title="Football Manager UI"
+        Height="900"
+        Width="1600"
+        WindowStartupLocation="CenterScreen"
+        Background="{StaticResource SurfaceDarkBrush}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
+                Background="{StaticResource HeaderGradientBrush}">
+            <Grid Margin="32,28,32,16">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="16" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Width="68" Height="68" Background="{StaticResource SurfaceLightBrush}" CornerRadius="18">
+                        <Ellipse Fill="{StaticResource AccentPrimaryBrush}" />
+                    </Border>
+
+                    <StackPanel Grid.Column="2" Orientation="Vertical" VerticalAlignment="Center">
+                        <TextBlock Text="AFC Richmond"
+                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   FontSize="28"
+                                   FontWeight="Bold" />
+                        <TextBlock Text="Premier League – 1st"
+                                   Margin="0,4,0,0"
+                                   Foreground="{StaticResource NeutralTextBrush}"
+                                   FontSize="15" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center" Spacing="20">
+                        <StackPanel Orientation="Vertical" VerticalAlignment="Center">
+                            <TextBlock Text="Next Match"
+                                       Foreground="{StaticResource NeutralTextBrush}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       TextAlignment="Right" />
+                            <TextBlock Text="Sat 18:00 vs Man City"
+                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       FontSize="16"
+                                       FontWeight="SemiBold" />
+                        </StackPanel>
+                        <Button Content="Continue"
+                                Width="140"
+                                Style="{StaticResource ContinueButtonStyle}" />
+                    </StackPanel>
+                </Grid>
+
+                <ItemsControl Grid.Row="1"
+                              Margin="0,28,0,10"
+                              ItemsSource="{Binding Tabs}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal" Spacing="8" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:NavigationTabViewModel}">
+                            <Button Command="{Binding DataContext.SelectTabCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                    CommandParameter="{Binding}"
+                                    Padding="18,12"
+                                    Cursor="Hand"
+                                    BorderThickness="1"
+                                    BorderBrush="Transparent"
+                                    Background="Transparent"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center">
+                                <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="Button">
+                                                    <Border x:Name="Root"
+                                                            CornerRadius="12"
+                                                            Padding="18,12"
+                                                            Background="{TemplateBinding Background}"
+                                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                                            BorderThickness="{TemplateBinding BorderThickness}">
+                                                        <ContentPresenter HorizontalAlignment="Center"
+                                                                          VerticalAlignment="Center" />
+                                                    </Border>
+                                                    <ControlTemplate.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter TargetName="Root" Property="Background" Value="#332EC4B6" />
+                                                        </Trigger>
+                                                        <Trigger Property="IsPressed" Value="True">
+                                                            <Setter TargetName="Root" Property="Background" Value="#552EC4B6" />
+                                                        </Trigger>
+                                                    </ControlTemplate.Triggers>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Setter Property="Background" Value="Transparent" />
+                                        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+                                        <Setter Property="BorderThickness" Value="1" />
+                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                <Setter Property="Background" Value="#552EC4B6" />
+                                                <Setter Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+                                                <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                                <TextBlock Text="{Binding Title}"
+                                           Style="{StaticResource NavigationTabTextStyle}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource NavigationTabTextStyle}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                    <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Button>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <ItemsControl Grid.Row="2"
+                              ItemsSource="{Binding SelectedTab.SubItems}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal" Spacing="6" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:NavigationSubItemViewModel}">
+                            <Button Content="{Binding Title}"
+                                    Command="{Binding DataContext.SelectedTab.SelectSubItemCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                    CommandParameter="{Binding}"
+                                    Style="{StaticResource SubNavigationButtonStyle}">
+                                <Button.Style>
+                                    <Style TargetType="Button" BasedOn="{StaticResource SubNavigationButtonStyle}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsActive}" Value="True">
+                                                <Setter Property="Foreground" Value="White" />
+                                                <Setter Property="Background" Value="#552EC4B6" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="1"
+                Background="{StaticResource ContentGradientBrush}">
+            <Grid Margin="32">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Text="{Binding SelectedTab.ActiveSubItem.Title, FallbackValue=Select a Section}"
+                           Foreground="{StaticResource PrimaryTextBrush}"
+                           FontSize="24"
+                           FontWeight="Bold" />
+
+                <views:CardSurfaceView Grid.Row="1"
+                                       Margin="0,24,0,0"
+                                       DataContext="{Binding CardSurface}" />
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/WPF/FMUI.Wpf/Views/MainWindow.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/MainWindow.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        DataContext = new MainViewModel();
+    }
+}

--- a/WPF/FMUI.Wpf/app.manifest
+++ b/WPF/FMUI.Wpf/app.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="FMUI.Wpf.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/WPF/README.md
+++ b/WPF/README.md
@@ -1,0 +1,52 @@
+# FMUI WPF Conversion Scaffold
+
+This directory contains a manually-authored WPF solution that mirrors the Football Manager-style HTML prototype. The project is structured to provide an immediate visual shell — navigation chrome, theming resources, and placeholder tactical grid — so feature teams can iterate on data-driven modules without reworking the application frame.
+
+## Solution Layout
+
+```
+WPF/
+├── FMUI.Wpf.sln
+├── FMUI.Wpf/
+│   ├── App.xaml
+│   ├── App.xaml.cs
+│   ├── FMUI.Wpf.csproj
+│   ├── Infrastructure/
+│   │   ├── AsyncRelayCommand.cs
+│   │   ├── ObservableObject.cs
+│   │   └── RelayCommand.cs
+│   ├── Models/
+│   │   └── NavigationModels.cs
+│   ├── Services/
+│   │   └── NavigationCatalog.cs
+│   ├── ViewModels/
+│   │   ├── MainViewModel.cs
+│   │   ├── NavigationSubItemViewModel.cs
+│   │   └── NavigationTabViewModel.cs
+│   ├── Resources/
+│   │   └── Theme.xaml
+│   └── Views/
+│       ├── MainWindow.xaml
+│       └── MainWindow.xaml.cs
+└── README.md
+```
+
+## Implemented Features
+
+- **Navigation shell** with the seven Football Manager tabs, contextual sub-navigation, and state-aware styling.
+- **Theming system** that ports the dark palette, gradients, and control styles from the HTML prototype into reusable WPF Resource Dictionaries.
+- **MVVM scaffolding** (models, view-models, relay commands) to keep presentation logic testable and ready for integration with the forthcoming data services.
+- **Data-driven tactical canvas** powered by a 37×19 grid layout service that renders metric, list, and formation cards for the Club Vision, Tactics Overview, and Training Overview sections.
+- **Sample layout catalog** that mirrors real Football Manager content, including formation breakdowns, instructional lists, and metric summaries to guide downstream feature parity work.
+
+## Next Steps
+
+1. Install the .NET 8 SDK locally if it is not already available.
+2. Restore and build the solution:
+   ```bash
+   dotnet build WPF/FMUI.Wpf.sln
+   ```
+3. Replace the placeholder tactical grid with live card layouts, formation drag/drop, and data-driven widgets using the MVVM scaffolding provided here.
+4. Introduce persistence and data services aligned with the HTML orchestrators to ensure functional parity across modules.
+
+The scaffold now reflects the navigation, theming, and interaction patterns required for the full Football Manager UI conversion.


### PR DESCRIPTION
## Summary
- add card layout models, catalog service, and view models to drive the 37×19 tactical surface
- render a styled card surface control in the main window with metric, list, and formation templates
- seed sample layouts for Club Vision, Tactics Overview, and Training Overview sections and update project documentation

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dff28123dc8328bc94dbd7a8a22d05