### PR TITLE
Add interactive finance dashboards

### DIFF
--- a/WPF/FMUI.Wpf.sln
+++ b/WPF/FMUI.Wpf.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34622.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FMUI.Wpf", "FMUI.Wpf\FMUI.Wpf.csproj", "{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{2CB85502-47C7-4F6A-9F57-EB2762DB4F70}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/WPF/FMUI.Wpf/App.xaml
+++ b/WPF/FMUI.Wpf/App.xaml
@@ -1,0 +1,11 @@
+<Application x:Class="FMUI.Wpf.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/Theme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/WPF/FMUI.Wpf/App.xaml.cs
+++ b/WPF/FMUI.Wpf/App.xaml.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Windows;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+using FMUI.Wpf.ViewModels;
+using FMUI.Wpf.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace FMUI.Wpf;
+
+public partial class App : Application
+{
+    private IHost? _host;
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+
+        _host = Host.CreateDefaultBuilder(e.Args)
+            .ConfigureServices(ConfigureServices)
+            .Build();
+
+        _host.StartAsync().GetAwaiter().GetResult();
+
+        var mainWindow = _host.Services.GetRequiredService<MainWindow>();
+        mainWindow.Show();
+    }
+
+    protected override void OnExit(ExitEventArgs e)
+    {
+        if (_host is not null)
+        {
+            _host.StopAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+            _host.Dispose();
+            _host = null;
+        }
+
+        base.OnExit(e);
+    }
+
+    private static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddSingleton<IEventAggregator, EventAggregator>();
+        services.AddSingleton<IClubDataService, ClubDataService>();
+        services.AddSingleton<ICardLayoutCatalog, CardLayoutCatalog>();
+        services.AddSingleton<ICardEditorCatalog, CardEditorCatalog>();
+        services.AddSingleton<INavigationCatalog, NavigationCatalog>();
+        services.AddSingleton<INavigationPermissionService, NavigationPermissionService>();
+        services.AddSingleton<INavigationIndicatorService, NavigationIndicatorService>();
+        services.AddSingleton(provider =>
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var storagePath = Path.Combine(appData, "FMUI", "layout-state.json");
+            return new CardLayoutStateOptions(storagePath);
+        });
+        services.AddSingleton<ICardLayoutStatePersistence, FileCardLayoutStatePersistence>();
+        services.AddSingleton<ICardLayoutStateService, CardLayoutStateService>();
+        services.AddSingleton<ICardInteractionService, CardInteractionService>();
+
+        services.AddSingleton<CardSurfaceViewModel>();
+        services.AddSingleton<MainViewModel>();
+
+        services.AddTransient<Func<string, NavigationSubItem, NavigationSubItemViewModel>>(provider =>
+        {
+            var indicatorService = provider.GetRequiredService<INavigationIndicatorService>();
+            var permissionService = provider.GetRequiredService<INavigationPermissionService>();
+            return (tabId, subItem) => new NavigationSubItemViewModel(subItem, tabId, indicatorService, permissionService);
+        });
+
+        services.AddTransient<Func<NavigationTab, NavigationTabViewModel>>(provider =>
+        {
+            var aggregator = provider.GetRequiredService<IEventAggregator>();
+            var subItemFactory = provider.GetRequiredService<Func<string, NavigationSubItem, NavigationSubItemViewModel>>();
+            var permissionService = provider.GetRequiredService<INavigationPermissionService>();
+            return tab => new NavigationTabViewModel(tab, aggregator, subItemFactory, permissionService);
+        });
+
+        services.AddSingleton<MainWindow>();
+    }
+}

--- a/WPF/FMUI.Wpf/Controls/CardDragThumb.cs
+++ b/WPF/FMUI.Wpf/Controls/CardDragThumb.cs
@@ -1,0 +1,112 @@
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.ViewModels;
+using FMUI.Wpf.Views;
+
+namespace FMUI.Wpf.Controls;
+
+public class CardDragThumb : Thumb
+{
+    public static readonly DependencyProperty DragStartedCommandProperty = DependencyProperty.Register(
+        nameof(DragStartedCommand),
+        typeof(ICommand),
+        typeof(CardDragThumb));
+
+    public static readonly DependencyProperty DragDeltaCommandProperty = DependencyProperty.Register(
+        nameof(DragDeltaCommand),
+        typeof(ICommand),
+        typeof(CardDragThumb));
+
+    public static readonly DependencyProperty DragCompletedCommandProperty = DependencyProperty.Register(
+        nameof(DragCompletedCommand),
+        typeof(ICommand),
+        typeof(CardDragThumb));
+
+    public ICommand? DragStartedCommand
+    {
+        get => (ICommand?)GetValue(DragStartedCommandProperty);
+        set => SetValue(DragStartedCommandProperty, value);
+    }
+
+    public ICommand? DragDeltaCommand
+    {
+        get => (ICommand?)GetValue(DragDeltaCommandProperty);
+        set => SetValue(DragDeltaCommandProperty, value);
+    }
+
+    public ICommand? DragCompletedCommand
+    {
+        get => (ICommand?)GetValue(DragCompletedCommandProperty);
+        set => SetValue(DragCompletedCommandProperty, value);
+    }
+
+    protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+    {
+        base.OnPreviewMouseLeftButtonDown(e);
+
+        if (DataContext is CardViewModel card)
+        {
+            var modifiers = Keyboard.Modifiers;
+            var selectionModifier = SelectionModifier.Replace;
+
+            if ((modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+            {
+                selectionModifier = SelectionModifier.Toggle;
+            }
+            else if ((modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)
+            {
+                selectionModifier = SelectionModifier.Add;
+            }
+
+            card.RequestSelection(selectionModifier);
+        }
+
+        if (FindAncestor<CardSurfaceView>(this) is { } surface)
+        {
+            surface.Focus();
+        }
+    }
+
+    protected override void OnDragStarted(DragStartedEventArgs e)
+    {
+        base.OnDragStarted(e);
+        if (DragStartedCommand?.CanExecute(null) == true)
+        {
+            DragStartedCommand.Execute(null);
+        }
+    }
+
+    protected override void OnDragDelta(DragDeltaEventArgs e)
+    {
+        base.OnDragDelta(e);
+        var parameter = new CardDragDelta(e.HorizontalChange, e.VerticalChange);
+        if (DragDeltaCommand?.CanExecute(parameter) == true)
+        {
+            DragDeltaCommand.Execute(parameter);
+        }
+    }
+
+    protected override void OnDragCompleted(DragCompletedEventArgs e)
+    {
+        base.OnDragCompleted(e);
+        var parameter = new CardDragCompleted(e.Canceled);
+        if (DragCompletedCommand?.CanExecute(parameter) == true)
+        {
+            DragCompletedCommand.Execute(parameter);
+        }
+    }
+
+    private static T? FindAncestor<T>(DependencyObject? current)
+        where T : DependencyObject
+    {
+        while (current is not null && current is not T)
+        {
+            current = VisualTreeHelper.GetParent(current);
+        }
+
+        return current as T;
+    }
+}

--- a/WPF/FMUI.Wpf/Controls/CardResizeThumb.cs
+++ b/WPF/FMUI.Wpf/Controls/CardResizeThumb.cs
@@ -1,0 +1,83 @@
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Controls;
+
+public sealed class CardResizeThumb : Thumb
+{
+    public static readonly DependencyProperty HandleProperty = DependencyProperty.Register(
+        nameof(Handle),
+        typeof(ResizeHandle),
+        typeof(CardResizeThumb),
+        new PropertyMetadata(ResizeHandle.SouthEast));
+
+    public static readonly DependencyProperty DragStartedCommandProperty = DependencyProperty.Register(
+        nameof(DragStartedCommand),
+        typeof(ICommand),
+        typeof(CardResizeThumb));
+
+    public static readonly DependencyProperty DragDeltaCommandProperty = DependencyProperty.Register(
+        nameof(DragDeltaCommand),
+        typeof(ICommand),
+        typeof(CardResizeThumb));
+
+    public static readonly DependencyProperty DragCompletedCommandProperty = DependencyProperty.Register(
+        nameof(DragCompletedCommand),
+        typeof(ICommand),
+        typeof(CardResizeThumb));
+
+    public ResizeHandle Handle
+    {
+        get => (ResizeHandle)GetValue(HandleProperty);
+        set => SetValue(HandleProperty, value);
+    }
+
+    public ICommand? DragStartedCommand
+    {
+        get => (ICommand?)GetValue(DragStartedCommandProperty);
+        set => SetValue(DragStartedCommandProperty, value);
+    }
+
+    public ICommand? DragDeltaCommand
+    {
+        get => (ICommand?)GetValue(DragDeltaCommandProperty);
+        set => SetValue(DragDeltaCommandProperty, value);
+    }
+
+    public ICommand? DragCompletedCommand
+    {
+        get => (ICommand?)GetValue(DragCompletedCommandProperty);
+        set => SetValue(DragCompletedCommandProperty, value);
+    }
+
+    protected override void OnDragStarted(DragStartedEventArgs e)
+    {
+        base.OnDragStarted(e);
+        if (DragStartedCommand?.CanExecute(Handle) == true)
+        {
+            DragStartedCommand.Execute(Handle);
+        }
+    }
+
+    protected override void OnDragDelta(DragDeltaEventArgs e)
+    {
+        base.OnDragDelta(e);
+        var parameter = new CardResizeDelta(Handle, e.HorizontalChange, e.VerticalChange);
+        if (DragDeltaCommand?.CanExecute(parameter) == true)
+        {
+            DragDeltaCommand.Execute(parameter);
+        }
+    }
+
+    protected override void OnDragCompleted(DragCompletedEventArgs e)
+    {
+        base.OnDragCompleted(e);
+        var parameter = new CardResizeCompleted(Handle, e.Canceled);
+        if (DragCompletedCommand?.CanExecute(parameter) == true)
+        {
+            DragCompletedCommand.Execute(parameter);
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/Controls/FormationPlayerThumb.cs
+++ b/WPF/FMUI.Wpf/Controls/FormationPlayerThumb.cs
@@ -1,0 +1,116 @@
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Controls;
+
+public sealed class FormationPlayerThumb : Thumb
+{
+    public static readonly DependencyProperty BeginDragCommandProperty = DependencyProperty.Register(
+        nameof(BeginDragCommand),
+        typeof(ICommand),
+        typeof(FormationPlayerThumb));
+
+    public static readonly DependencyProperty DragDeltaCommandProperty = DependencyProperty.Register(
+        nameof(DragDeltaCommand),
+        typeof(ICommand),
+        typeof(FormationPlayerThumb));
+
+    public static readonly DependencyProperty DragCompletedCommandProperty = DependencyProperty.Register(
+        nameof(DragCompletedCommand),
+        typeof(ICommand),
+        typeof(FormationPlayerThumb));
+
+    public static readonly DependencyProperty PitchWidthProperty = DependencyProperty.Register(
+        nameof(PitchWidth),
+        typeof(double),
+        typeof(FormationPlayerThumb),
+        new FrameworkPropertyMetadata(double.NaN));
+
+    public static readonly DependencyProperty PitchHeightProperty = DependencyProperty.Register(
+        nameof(PitchHeight),
+        typeof(double),
+        typeof(FormationPlayerThumb),
+        new FrameworkPropertyMetadata(double.NaN));
+
+    public static readonly DependencyProperty TokenSizeProperty = DependencyProperty.Register(
+        nameof(TokenSize),
+        typeof(double),
+        typeof(FormationPlayerThumb),
+        new FrameworkPropertyMetadata(0d));
+
+    public ICommand? BeginDragCommand
+    {
+        get => (ICommand?)GetValue(BeginDragCommandProperty);
+        set => SetValue(BeginDragCommandProperty, value);
+    }
+
+    public ICommand? DragDeltaCommand
+    {
+        get => (ICommand?)GetValue(DragDeltaCommandProperty);
+        set => SetValue(DragDeltaCommandProperty, value);
+    }
+
+    public ICommand? DragCompletedCommand
+    {
+        get => (ICommand?)GetValue(DragCompletedCommandProperty);
+        set => SetValue(DragCompletedCommandProperty, value);
+    }
+
+    public double PitchWidth
+    {
+        get => (double)GetValue(PitchWidthProperty);
+        set => SetValue(PitchWidthProperty, value);
+    }
+
+    public double PitchHeight
+    {
+        get => (double)GetValue(PitchHeightProperty);
+        set => SetValue(PitchHeightProperty, value);
+    }
+
+    public double TokenSize
+    {
+        get => (double)GetValue(TokenSizeProperty);
+        set => SetValue(TokenSizeProperty, value);
+    }
+
+    protected override void OnDragStarted(DragStartedEventArgs e)
+    {
+        base.OnDragStarted(e);
+
+        if (BeginDragCommand?.CanExecute(null) == true)
+        {
+            BeginDragCommand.Execute(null);
+        }
+    }
+
+    protected override void OnDragDelta(DragDeltaEventArgs e)
+    {
+        base.OnDragDelta(e);
+
+        var parameter = new FormationPlayerDragDelta(
+            e.HorizontalChange,
+            e.VerticalChange,
+            double.IsNaN(PitchWidth) ? ActualWidth : PitchWidth,
+            double.IsNaN(PitchHeight) ? ActualHeight : PitchHeight,
+            TokenSize);
+
+        if (DragDeltaCommand?.CanExecute(parameter) == true)
+        {
+            DragDeltaCommand.Execute(parameter);
+        }
+    }
+
+    protected override void OnDragCompleted(DragCompletedEventArgs e)
+    {
+        base.OnDragCompleted(e);
+
+        var parameter = new FormationPlayerDragCompleted(e.Canceled);
+        if (DragCompletedCommand?.CanExecute(parameter) == true)
+        {
+            DragCompletedCommand.Execute(parameter);
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/Controls/LineChartControl.cs
+++ b/WPF/FMUI.Wpf/Controls/LineChartControl.cs
@@ -1,0 +1,445 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Controls;
+
+public sealed class LineChartControl : FrameworkElement
+{
+    public static readonly DependencyProperty SeriesProperty = DependencyProperty.Register(
+        nameof(Series),
+        typeof(IReadOnlyList<ChartSeriesViewModel>),
+        typeof(LineChartControl),
+        new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, OnSeriesChanged));
+
+    public static readonly DependencyProperty AxisBrushProperty = DependencyProperty.Register(
+        nameof(AxisBrush),
+        typeof(Brush),
+        typeof(LineChartControl),
+        new FrameworkPropertyMetadata(BrushUtilities.CreateFrozenBrush("#1F2C3A"), FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public static readonly DependencyProperty GridLineBrushProperty = DependencyProperty.Register(
+        nameof(GridLineBrush),
+        typeof(Brush),
+        typeof(LineChartControl),
+        new FrameworkPropertyMetadata(BrushUtilities.CreateFrozenBrush("#14202D"), FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public static readonly DependencyProperty FillOpacityProperty = DependencyProperty.Register(
+        nameof(FillOpacity),
+        typeof(double),
+        typeof(LineChartControl),
+        new FrameworkPropertyMetadata(0.18, FrameworkPropertyMetadataOptions.AffectsRender));
+
+    private readonly List<PointHitTestInfo> _hitTestPoints = new();
+    private readonly Popup _tooltip;
+    private readonly TextBlock _tooltipText;
+
+    public LineChartControl()
+    {
+        _tooltipText = CreateTooltipTextBlock();
+        _tooltip = CreateTooltipPopup(_tooltipText);
+        MouseMove += OnMouseMove;
+        MouseLeave += OnMouseLeave;
+        IsHitTestVisible = true;
+    }
+
+    public IReadOnlyList<ChartSeriesViewModel>? Series
+    {
+        get => (IReadOnlyList<ChartSeriesViewModel>?)GetValue(SeriesProperty);
+        set => SetValue(SeriesProperty, value);
+    }
+
+    public Brush AxisBrush
+    {
+        get => (Brush)GetValue(AxisBrushProperty);
+        set => SetValue(AxisBrushProperty, value);
+    }
+
+    public Brush GridLineBrush
+    {
+        get => (Brush)GetValue(GridLineBrushProperty);
+        set => SetValue(GridLineBrushProperty, value);
+    }
+
+    public double FillOpacity
+    {
+        get => (double)GetValue(FillOpacityProperty);
+        set => SetValue(FillOpacityProperty, value);
+    }
+
+    public static readonly DependencyProperty AnimationProgressProperty = DependencyProperty.Register(
+        nameof(AnimationProgress),
+        typeof(double),
+        typeof(LineChartControl),
+        new FrameworkPropertyMetadata(1d, FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public double AnimationProgress
+    {
+        get => (double)GetValue(AnimationProgressProperty);
+        set => SetValue(AnimationProgressProperty, value);
+    }
+
+    protected override void OnRender(DrawingContext drawingContext)
+    {
+        base.OnRender(drawingContext);
+
+        if (Series is not { Count: > 0 })
+        {
+            _hitTestPoints.Clear();
+            return;
+        }
+
+        var width = ActualWidth;
+        var height = ActualHeight;
+
+        if (width <= 0 || height <= 0)
+        {
+            _hitTestPoints.Clear();
+            return;
+        }
+
+        var allPoints = Series.SelectMany(s => s.Points).ToList();
+        if (allPoints.Count == 0)
+        {
+            _hitTestPoints.Clear();
+            return;
+        }
+
+        var minValue = Series.Min(s => s.Minimum);
+        var maxValue = Series.Max(s => s.Maximum);
+        if (Math.Abs(maxValue - minValue) < 0.0001)
+        {
+            maxValue = minValue + 1;
+        }
+
+        const double horizontalPadding = 24;
+        const double verticalPadding = 24;
+
+        var chartWidth = Math.Max(0, width - (horizontalPadding * 2));
+        var chartHeight = Math.Max(0, height - (verticalPadding * 2));
+
+        var axisPen = new Pen(AxisBrush, 1.2);
+        axisPen.Freeze();
+
+        var gridPen = new Pen(GridLineBrush, 0.8) { DashStyle = DashStyles.Dot };
+        gridPen.Freeze();
+
+        var origin = new Point(horizontalPadding, height - verticalPadding);
+        var verticalEnd = new Point(horizontalPadding, verticalPadding);
+        var horizontalEnd = new Point(width - horizontalPadding, height - verticalPadding);
+
+        drawingContext.DrawLine(axisPen, origin, verticalEnd);
+        drawingContext.DrawLine(axisPen, origin, horizontalEnd);
+
+        // Draw grid lines at quartiles.
+        for (var i = 1; i <= 3; i++)
+        {
+            var ratio = i / 4.0;
+            var y = verticalPadding + chartHeight * (1 - ratio);
+            drawingContext.DrawLine(gridPen, new Point(horizontalPadding, y), new Point(width - horizontalPadding, y));
+        }
+
+        DrawAxisLabels(drawingContext, minValue, maxValue, origin, horizontalEnd, verticalPadding);
+
+        _hitTestPoints.Clear();
+
+        foreach (var series in Series)
+        {
+            DrawSeries(drawingContext, series, minValue, maxValue, horizontalPadding, verticalPadding, chartWidth, chartHeight);
+        }
+    }
+
+    private static void OnSeriesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is LineChartControl control)
+        {
+            control.StartEntranceAnimation();
+            control.InvalidateVisual();
+        }
+    }
+
+    private void DrawSeries(
+        DrawingContext drawingContext,
+        ChartSeriesViewModel series,
+        double minimum,
+        double maximum,
+        double horizontalPadding,
+        double verticalPadding,
+        double chartWidth,
+        double chartHeight)
+    {
+        if (series.Points.Count == 0)
+        {
+            return;
+        }
+
+        var step = series.Points.Count == 1 ? 0 : chartWidth / (series.Points.Count - 1);
+        var progress = Math.Clamp(AnimationProgress, 0, 1);
+        var geometry = new StreamGeometry();
+
+        using (var context = geometry.Open())
+        {
+            for (var i = 0; i < series.Points.Count; i++)
+            {
+                var point = series.Points[i];
+                var x = horizontalPadding + (step * i);
+                var normalized = (point.Value - minimum) / (maximum - minimum);
+                var animatedNormalized = normalized * progress;
+                var y = verticalPadding + chartHeight * (1 - animatedNormalized);
+
+                if (i == 0)
+                {
+                    context.BeginFigure(new Point(x, y), true, false);
+                }
+                else
+                {
+                    context.LineTo(new Point(x, y), true, false);
+                }
+            }
+
+            var lastPoint = series.Points[^1];
+            var firstPoint = series.Points[0];
+            var lastX = horizontalPadding + step * (series.Points.Count - 1);
+            var lastNormalized = (lastPoint.Value - minimum) / (maximum - minimum);
+            var lastY = verticalPadding + chartHeight * (1 - (lastNormalized * progress));
+            var firstNormalized = (firstPoint.Value - minimum) / (maximum - minimum);
+            var firstY = verticalPadding + chartHeight * (1 - (firstNormalized * progress));
+
+            context.LineTo(new Point(lastX, verticalPadding + chartHeight), true, false);
+            context.LineTo(new Point(horizontalPadding, verticalPadding + chartHeight), true, false);
+            context.LineTo(new Point(horizontalPadding, firstY), true, false);
+        }
+
+        geometry.Freeze();
+
+        var fillBrush = series.Stroke.Clone();
+        fillBrush.Opacity = FillOpacity;
+        fillBrush.Freeze();
+
+        drawingContext.DrawGeometry(fillBrush, null, geometry);
+
+        var pen = new Pen(series.Stroke, 2.2) { LineJoin = PenLineJoin.Round };
+        pen.Freeze();
+
+        var pathGeometry = new StreamGeometry();
+        using (var context = pathGeometry.Open())
+        {
+            for (var i = 0; i < series.Points.Count; i++)
+            {
+                var point = series.Points[i];
+                var x = horizontalPadding + (step * i);
+                var normalized = (point.Value - minimum) / (maximum - minimum);
+                var animatedNormalized = normalized * progress;
+                var y = verticalPadding + chartHeight * (1 - animatedNormalized);
+
+                if (i == 0)
+                {
+                    context.BeginFigure(new Point(x, y), false, false);
+                }
+                else
+                {
+                    context.LineTo(new Point(x, y), true, false);
+                }
+            }
+        }
+
+        pathGeometry.Freeze();
+        drawingContext.DrawGeometry(null, pen, pathGeometry);
+
+        foreach (var (point, index) in series.Points.Select((p, i) => (p, i)))
+        {
+            var x = horizontalPadding + (step * index);
+            var normalized = (point.Value - minimum) / (maximum - minimum);
+            var animatedNormalized = normalized * progress;
+            var y = verticalPadding + chartHeight * (1 - animatedNormalized);
+            drawingContext.DrawEllipse(series.Stroke, null, new Point(x, y), 4, 4);
+
+            var label = new FormattedText(
+                point.Label,
+                CultureInfo.CurrentUICulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Segoe UI"),
+                11,
+                AxisBrush,
+                VisualTreeHelper.GetDpi(this).PixelsPerDip);
+
+            drawingContext.DrawText(label, new Point(x - label.Width / 2, Math.Max(verticalPadding, y - 24)));
+
+            var bounds = new Rect(new Point(x - 8, y - 8), new Size(16, 16));
+            _hitTestPoints.Add(new PointHitTestInfo(bounds, series, point));
+        }
+    }
+
+    private void DrawAxisLabels(
+        DrawingContext drawingContext,
+        double minimum,
+        double maximum,
+        Point origin,
+        Point horizontalEnd,
+        double verticalPadding)
+    {
+        var typeface = new Typeface("Segoe UI");
+        var dpi = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+
+        var minLabel = new FormattedText(
+            minimum.ToString("0.0"),
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            typeface,
+            11,
+            AxisBrush,
+            dpi);
+
+        drawingContext.DrawText(minLabel, new Point(origin.X - minLabel.Width - 6, origin.Y - minLabel.Height));
+
+        var maxLabel = new FormattedText(
+            maximum.ToString("0.0"),
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            typeface,
+            11,
+            AxisBrush,
+            dpi);
+
+        drawingContext.DrawText(maxLabel, new Point(origin.X - maxLabel.Width - 6, verticalPadding - (maxLabel.Height / 2)));
+
+        var firstSeries = Series!.FirstOrDefault(s => s.Points.Count > 0);
+        if (firstSeries is null)
+        {
+            return;
+        }
+
+        var startLabel = new FormattedText(
+            firstSeries.Points.First().Label,
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            typeface,
+            11,
+            AxisBrush,
+            dpi);
+
+        drawingContext.DrawText(startLabel, new Point(origin.X - (startLabel.Width / 2), origin.Y + 6));
+
+        var endLabel = new FormattedText(
+            firstSeries.Points.Last().Label,
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            typeface,
+            11,
+            AxisBrush,
+            dpi);
+
+        drawingContext.DrawText(endLabel, new Point(horizontalEnd.X - (endLabel.Width / 2), origin.Y + 6));
+    }
+
+    private void StartEntranceAnimation()
+    {
+        BeginAnimation(AnimationProgressProperty, null);
+        var animation = new DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(520))
+        {
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+        };
+        BeginAnimation(AnimationProgressProperty, animation);
+    }
+
+    private void OnMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+    {
+        if (_hitTestPoints.Count == 0)
+        {
+            HideTooltip();
+            return;
+        }
+
+        var position = e.GetPosition(this);
+        var hit = _hitTestPoints.FirstOrDefault(info => info.Bounds.Contains(position));
+        if (hit.Series is null)
+        {
+            HideTooltip();
+            return;
+        }
+
+        _tooltipText.Text = $"{hit.Series.Name}: {hit.Point.Value:0.##}\n{hit.Point.Label}";
+        _tooltip.HorizontalOffset = position.X + 12;
+        _tooltip.VerticalOffset = position.Y - 32;
+        if (!_tooltip.IsOpen)
+        {
+            _tooltip.IsOpen = true;
+        }
+    }
+
+    private void OnMouseLeave(object sender, System.Windows.Input.MouseEventArgs e)
+    {
+        HideTooltip();
+    }
+
+    private void HideTooltip()
+    {
+        if (_tooltip.IsOpen)
+        {
+            _tooltip.IsOpen = false;
+        }
+    }
+
+    private static TextBlock CreateTooltipTextBlock()
+    {
+        return new TextBlock
+        {
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = 12,
+            Foreground = Brushes.White,
+            Margin = new Thickness(12, 8, 12, 8),
+            TextWrapping = TextWrapping.Wrap
+        };
+    }
+
+    private Popup CreateTooltipPopup(UIElement content)
+    {
+        var border = new Border
+        {
+            Background = BrushUtilities.CreateFrozenBrush("#1B2734"),
+            BorderBrush = BrushUtilities.CreateFrozenBrush("#2EC4B6"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            Child = content,
+            Effect = new System.Windows.Media.Effects.DropShadowEffect
+            {
+                BlurRadius = 8,
+                ShadowDepth = 0,
+                Opacity = 0.6,
+                Color = Colors.Black
+            }
+        };
+
+        return new Popup
+        {
+            Placement = PlacementMode.Relative,
+            PlacementTarget = this,
+            AllowsTransparency = true,
+            StaysOpen = false,
+            Child = border
+        };
+    }
+
+    private readonly struct PointHitTestInfo
+    {
+        public PointHitTestInfo(Rect bounds, ChartSeriesViewModel series, ChartDataPointViewModel point)
+        {
+            Bounds = bounds;
+            Series = series;
+            Point = point;
+        }
+
+        public Rect Bounds { get; }
+
+        public ChartSeriesViewModel Series { get; }
+
+        public ChartDataPointViewModel Point { get; }
+    }
+}

--- a/WPF/FMUI.Wpf/Controls/RadialGaugeControl.cs
+++ b/WPF/FMUI.Wpf/Controls/RadialGaugeControl.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Controls;
+
+public sealed class RadialGaugeControl : FrameworkElement
+{
+    public static readonly DependencyProperty GaugeProperty = DependencyProperty.Register(
+        nameof(Gauge),
+        typeof(GaugeViewModel),
+        typeof(RadialGaugeControl),
+        new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, OnGaugeChanged));
+
+    public static readonly DependencyProperty AxisBrushProperty = DependencyProperty.Register(
+        nameof(AxisBrush),
+        typeof(Brush),
+        typeof(RadialGaugeControl),
+        new FrameworkPropertyMetadata(BrushUtilities.CreateFrozenBrush("#1F2C3A"), FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public static readonly DependencyProperty ValueBrushProperty = DependencyProperty.Register(
+        nameof(ValueBrush),
+        typeof(Brush),
+        typeof(RadialGaugeControl),
+        new FrameworkPropertyMetadata(BrushUtilities.CreateFrozenBrush("#2EC4B6"), FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public static readonly DependencyProperty DisplayValueProperty = DependencyProperty.Register(
+        nameof(DisplayValue),
+        typeof(double),
+        typeof(RadialGaugeControl),
+        new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.AffectsRender));
+
+    private readonly Popup _tooltip;
+    private readonly TextBlock _tooltipText;
+
+    public RadialGaugeControl()
+    {
+        _tooltipText = CreateTooltipTextBlock();
+        _tooltip = CreateTooltipPopup(_tooltipText);
+        MouseMove += OnMouseMove;
+        MouseLeave += (_, _) => HideTooltip();
+    }
+
+    public GaugeViewModel? Gauge
+    {
+        get => (GaugeViewModel?)GetValue(GaugeProperty);
+        set => SetValue(GaugeProperty, value);
+    }
+
+    public Brush AxisBrush
+    {
+        get => (Brush)GetValue(AxisBrushProperty);
+        set => SetValue(AxisBrushProperty, value);
+    }
+
+    public Brush ValueBrush
+    {
+        get => (Brush)GetValue(ValueBrushProperty);
+        set => SetValue(ValueBrushProperty, value);
+    }
+
+    public double DisplayValue
+    {
+        get => (double)GetValue(DisplayValueProperty);
+        set => SetValue(DisplayValueProperty, value);
+    }
+
+    protected override void OnRender(DrawingContext drawingContext)
+    {
+        base.OnRender(drawingContext);
+
+        if (Gauge is null)
+        {
+            HideTooltip();
+            return;
+        }
+
+        var width = ActualWidth;
+        var height = ActualHeight;
+        if (width <= 0 || height <= 0)
+        {
+            HideTooltip();
+            return;
+        }
+
+        var center = new Point(width / 2, height / 2 + 20);
+        var radius = Math.Min(width, height * 1.6) / 2.6;
+        var innerRadius = radius * 0.68;
+
+        DrawBands(drawingContext, Gauge, center, radius, innerRadius);
+        DrawAxis(drawingContext, center, radius, innerRadius);
+        DrawValue(drawingContext, Gauge, center, radius, innerRadius);
+    }
+
+    private static void OnGaugeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is RadialGaugeControl control)
+        {
+            control.StartAnimation();
+            control.UpdateTooltipContent();
+            control.InvalidateVisual();
+        }
+    }
+
+    private void DrawBands(DrawingContext drawingContext, GaugeViewModel gauge, Point center, double radius, double innerRadius)
+    {
+        foreach (var band in gauge.Bands)
+        {
+            var geometry = CreateArcGeometry(center, radius, innerRadius, band.Start, band.End);
+            drawingContext.DrawGeometry(band.Brush, null, geometry);
+        }
+    }
+
+    private void DrawAxis(DrawingContext drawingContext, Point center, double radius, double innerRadius)
+    {
+        var pen = new Pen(AxisBrush, 2);
+        pen.Freeze();
+
+        var background = BrushUtilities.CreateFrozenBrush("#0C121A");
+        var axisGeometry = CreateArcGeometry(center, radius, innerRadius, 0, 1);
+        drawingContext.DrawGeometry(background, pen, axisGeometry);
+    }
+
+    private void DrawValue(DrawingContext drawingContext, GaugeViewModel gauge, Point center, double radius, double innerRadius)
+    {
+        var ratio = (DisplayValue - gauge.Minimum) / (gauge.Maximum - gauge.Minimum);
+        ratio = Math.Clamp(ratio, 0, 1);
+
+        var geometry = CreateArcGeometry(center, radius, innerRadius, 0, ratio);
+        drawingContext.DrawGeometry(ValueBrush, null, geometry);
+
+        var targetRatio = (gauge.Target - gauge.Minimum) / (gauge.Maximum - gauge.Minimum);
+        targetRatio = Math.Clamp(targetRatio, 0, 1);
+        DrawNeedle(drawingContext, center, radius, targetRatio);
+
+        DrawCenterText(drawingContext, gauge, center);
+    }
+
+    private void DrawCenterText(DrawingContext drawingContext, GaugeViewModel gauge, Point center)
+    {
+        var dpi = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+        var valueText = new FormattedText(
+            gauge.DisplayValue,
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            new Typeface("Segoe UI Semibold"),
+            24,
+            Brushes.White,
+            dpi);
+
+        drawingContext.DrawText(valueText, new Point(center.X - valueText.Width / 2, center.Y - valueText.Height));
+
+        var summary = gauge.DisplaySummary ?? $"Target {gauge.Target:0.#}{gauge.Unit}";
+        var targetText = new FormattedText(
+            summary,
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            new Typeface("Segoe UI"),
+            12,
+            AxisBrush,
+            dpi);
+
+        var summaryOrigin = new Point(center.X - targetText.Width / 2, center.Y + 12);
+        drawingContext.DrawText(targetText, summaryOrigin);
+
+        if (gauge.HasDisplayPill)
+        {
+            DrawPill(drawingContext, gauge.DisplayPill!, new Point(center.X, summaryOrigin.Y + targetText.Height + 6));
+        }
+    }
+
+    private void DrawPill(DrawingContext drawingContext, string text, Point anchor)
+    {
+        var dpi = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+        var pillText = new FormattedText(
+            text,
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            new Typeface("Segoe UI Semibold"),
+            11,
+            Brushes.White,
+            dpi);
+
+        var padding = new Size(12, 5);
+        var rect = new Rect(
+            anchor.X - (pillText.Width / 2) - padding.Width,
+            anchor.Y,
+            pillText.Width + (padding.Width * 2),
+            pillText.Height + (padding.Height * 2));
+
+        var background = BrushUtilities.CreateFrozenBrush("#233447");
+        drawingContext.DrawRoundedRectangle(background, new Pen(ValueBrush, 1.2), rect, 10, 10);
+        drawingContext.DrawText(pillText, new Point(rect.Left + padding.Width, rect.Top + padding.Height - 1));
+    }
+
+    private void DrawNeedle(DrawingContext drawingContext, Point center, double radius, double ratio)
+    {
+        var angle = DegreeToRadian(135 + (270 * ratio));
+        var needleLength = radius * 0.88;
+        var endPoint = new Point(center.X + needleLength * Math.Cos(angle), center.Y + needleLength * Math.Sin(angle));
+
+        var pen = new Pen(BrushUtilities.CreateFrozenBrush("#E5B83F"), 3)
+        {
+            StartLineCap = PenLineCap.Round,
+            EndLineCap = PenLineCap.Round
+        };
+        pen.Freeze();
+
+        drawingContext.DrawLine(pen, center, endPoint);
+    }
+
+    private static Geometry CreateArcGeometry(Point center, double radius, double innerRadius, double startRatio, double endRatio)
+    {
+        var startAngle = DegreeToRadian(135 + (270 * startRatio));
+        var endAngle = DegreeToRadian(135 + (270 * endRatio));
+
+        var outerStart = new Point(center.X + radius * Math.Cos(startAngle), center.Y + radius * Math.Sin(startAngle));
+        var outerEnd = new Point(center.X + radius * Math.Cos(endAngle), center.Y + radius * Math.Sin(endAngle));
+        var innerStart = new Point(center.X + innerRadius * Math.Cos(endAngle), center.Y + innerRadius * Math.Sin(endAngle));
+        var innerEnd = new Point(center.X + innerRadius * Math.Cos(startAngle), center.Y + innerRadius * Math.Sin(startAngle));
+
+        var geometry = new StreamGeometry();
+        using (var context = geometry.Open())
+        {
+            context.BeginFigure(outerStart, true, true);
+            context.ArcTo(outerEnd, new Size(radius, radius), 0, endRatio - startRatio > 0.5, SweepDirection.Clockwise, true, false);
+            context.LineTo(innerStart, true, false);
+            context.ArcTo(innerEnd, new Size(innerRadius, innerRadius), 0, endRatio - startRatio > 0.5, SweepDirection.Counterclockwise, true, false);
+        }
+
+        geometry.Freeze();
+        return geometry;
+    }
+
+    private static double DegreeToRadian(double degree) => degree * (Math.PI / 180);
+
+    private void StartAnimation()
+    {
+        if (Gauge is null)
+        {
+            return;
+        }
+
+        var current = DisplayValue;
+        var target = Gauge.Value;
+        BeginAnimation(DisplayValueProperty, null);
+        var animation = new DoubleAnimation(current, target, TimeSpan.FromMilliseconds(540))
+        {
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+        };
+        BeginAnimation(DisplayValueProperty, animation);
+    }
+
+    private void OnMouseMove(object? sender, System.Windows.Input.MouseEventArgs e)
+    {
+        if (Gauge is null)
+        {
+            HideTooltip();
+            return;
+        }
+
+        var position = e.GetPosition(this);
+        _tooltipText.Text = $"{Gauge.DisplayValue}\nTarget {Gauge.Target:0.#}{Gauge.Unit}";
+        _tooltip.HorizontalOffset = position.X + 16;
+        _tooltip.VerticalOffset = position.Y - 24;
+        if (!_tooltip.IsOpen)
+        {
+            _tooltip.IsOpen = true;
+        }
+    }
+
+    private void HideTooltip()
+    {
+        if (_tooltip.IsOpen)
+        {
+            _tooltip.IsOpen = false;
+        }
+    }
+
+    private void UpdateTooltipContent()
+    {
+        if (Gauge is null)
+        {
+            HideTooltip();
+            return;
+        }
+
+        _tooltipText.Text = $"{Gauge.DisplayValue}\nTarget {Gauge.Target:0.#}{Gauge.Unit}";
+    }
+
+    private static TextBlock CreateTooltipTextBlock()
+    {
+        return new TextBlock
+        {
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = 12,
+            Foreground = Brushes.White,
+            Margin = new Thickness(12, 8, 12, 8)
+        };
+    }
+
+    private Popup CreateTooltipPopup(UIElement content)
+    {
+        var border = new Border
+        {
+            Background = BrushUtilities.CreateFrozenBrush("#1B2734"),
+            BorderBrush = BrushUtilities.CreateFrozenBrush("#E5B83F"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            Child = content,
+            Effect = new System.Windows.Media.Effects.DropShadowEffect
+            {
+                BlurRadius = 8,
+                ShadowDepth = 0,
+                Opacity = 0.6,
+                Color = Colors.Black
+            }
+        };
+
+        return new Popup
+        {
+            Placement = PlacementMode.Relative,
+            PlacementTarget = this,
+            AllowsTransparency = true,
+            StaysOpen = false,
+            Child = border
+        };
+    }
+}

--- a/WPF/FMUI.Wpf/Controls/TimelineControl.cs
+++ b/WPF/FMUI.Wpf/Controls/TimelineControl.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Controls;
+
+public sealed class TimelineControl : FrameworkElement
+{
+    public static readonly DependencyProperty ItemsProperty = DependencyProperty.Register(
+        nameof(Items),
+        typeof(IReadOnlyList<TimelineEntryViewModel>),
+        typeof(TimelineControl),
+        new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, OnItemsChanged));
+
+    public static readonly DependencyProperty AxisBrushProperty = DependencyProperty.Register(
+        nameof(AxisBrush),
+        typeof(Brush),
+        typeof(TimelineControl),
+        new FrameworkPropertyMetadata(BrushUtilities.CreateFrozenBrush("#1F2C3A"), FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public static readonly DependencyProperty PillBackgroundProperty = DependencyProperty.Register(
+        nameof(PillBackground),
+        typeof(Brush),
+        typeof(TimelineControl),
+        new FrameworkPropertyMetadata(BrushUtilities.CreateFrozenBrush("#233447"), FrameworkPropertyMetadataOptions.AffectsRender));
+
+    public static readonly DependencyProperty AnimationProgressProperty = DependencyProperty.Register(
+        nameof(AnimationProgress),
+        typeof(double),
+        typeof(TimelineControl),
+        new FrameworkPropertyMetadata(1d, FrameworkPropertyMetadataOptions.AffectsRender));
+
+    private static readonly QuadraticEase EntryEase = new() { EasingMode = EasingMode.EaseOut };
+
+    private readonly List<TimelineHitTestInfo> _hitTest = new();
+    private readonly Popup _tooltip;
+    private readonly TextBlock _tooltipText;
+
+    public TimelineControl()
+    {
+        _tooltipText = CreateTooltipText();
+        _tooltip = CreateTooltipPopup(_tooltipText);
+        MouseMove += OnMouseMove;
+        MouseLeave += (_, _) => HideTooltip();
+    }
+
+    public IReadOnlyList<TimelineEntryViewModel>? Items
+    {
+        get => (IReadOnlyList<TimelineEntryViewModel>?)GetValue(ItemsProperty);
+        set => SetValue(ItemsProperty, value);
+    }
+
+    public Brush AxisBrush
+    {
+        get => (Brush)GetValue(AxisBrushProperty);
+        set => SetValue(AxisBrushProperty, value);
+    }
+
+    public Brush PillBackground
+    {
+        get => (Brush)GetValue(PillBackgroundProperty);
+        set => SetValue(PillBackgroundProperty, value);
+    }
+
+    public double AnimationProgress
+    {
+        get => (double)GetValue(AnimationProgressProperty);
+        set => SetValue(AnimationProgressProperty, value);
+    }
+
+    protected override void OnRender(DrawingContext drawingContext)
+    {
+        base.OnRender(drawingContext);
+
+        if (Items is not { Count: > 0 })
+        {
+            _hitTest.Clear();
+            HideTooltip();
+            return;
+        }
+
+        var width = ActualWidth;
+        var height = ActualHeight;
+        if (width <= 0 || height <= 0)
+        {
+            _hitTest.Clear();
+            HideTooltip();
+            return;
+        }
+
+        const double horizontalPadding = 36;
+        const double axisY = 0.6;
+        var axisPen = new Pen(AxisBrush, 1.4) { StartLineCap = PenLineCap.Round, EndLineCap = PenLineCap.Round };
+        axisPen.Freeze();
+
+        var axisTop = height * axisY;
+        drawingContext.DrawLine(axisPen, new Point(horizontalPadding, axisTop), new Point(width - horizontalPadding, axisTop));
+
+        var ordered = Items.OrderBy(i => i.Position).ToList();
+        _hitTest.Clear();
+        var total = ordered.Count;
+        var progress = Math.Clamp(AnimationProgress, 0, 1);
+
+        for (var index = 0; index < total; index++)
+        {
+            var item = ordered[index];
+            var start = (double)index / total;
+            var end = (double)(index + 1) / total;
+            var entryProgress = Math.Clamp((progress - start) / Math.Max(0.0001, end - start), 0, 1);
+            DrawEntry(drawingContext, item, horizontalPadding, width, axisTop, entryProgress);
+        }
+    }
+
+    private static void OnItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TimelineControl control)
+        {
+            control.StartEntranceAnimation();
+            control.InvalidateVisual();
+        }
+    }
+
+    private void DrawEntry(
+        DrawingContext drawingContext,
+        TimelineEntryViewModel entry,
+        double horizontalPadding,
+        double width,
+        double axisTop,
+        double progress)
+    {
+        var clamped = Math.Clamp(entry.Position, 0, 1);
+        var x = horizontalPadding + (clamped * (width - (horizontalPadding * 2)));
+
+        var accentBrush = entry.AccentBrush ?? BrushUtilities.CreateFrozenBrush("#2EC4B6");
+        var markerRadius = entry.HasPill ? 8 : 6;
+        var eased = EntryEase.Ease(progress);
+        var verticalOffset = (1 - eased) * 18;
+
+        drawingContext.PushOpacity(eased);
+        drawingContext.DrawEllipse(accentBrush, null, new Point(x, axisTop - verticalOffset), markerRadius, markerRadius);
+
+        var label = CreateText(entry.Label, 14, FontWeights.SemiBold, accentBrush);
+        var labelOrigin = new Point(x - label.Width / 2, axisTop - 48 - verticalOffset);
+        drawingContext.DrawText(label, labelOrigin);
+
+        Rect? bounds = null;
+
+        if (entry.HasDetail)
+        {
+            var detail = CreateText(entry.Detail!, 12, FontWeights.Normal, AxisBrush);
+            var detailOrigin = new Point(x - detail.Width / 2, axisTop - 28 - verticalOffset);
+            drawingContext.DrawText(detail, detailOrigin);
+            bounds = new Rect(new Point(Math.Min(labelOrigin.X, detailOrigin.X), detailOrigin.Y - 8),
+                new Size(Math.Max(label.Width, detail.Width), 56));
+        }
+        else
+        {
+            bounds = new Rect(labelOrigin, new Size(label.Width, 40));
+        }
+
+        if (entry.HasPill)
+        {
+            var pillRect = DrawPill(drawingContext, entry.Pill!, accentBrush, new Point(x, axisTop + 18 - verticalOffset));
+            bounds = bounds.HasValue ? Rect.Union(bounds.Value, pillRect) : pillRect;
+        }
+
+        drawingContext.Pop();
+
+        var hitRect = bounds ?? new Rect(new Point(x - 12, axisTop - 60 - verticalOffset), new Size(24, 72));
+        _hitTest.Add(new TimelineHitTestInfo(hitRect, entry));
+    }
+
+    private FormattedText CreateText(string text, double size, FontWeight weight, Brush brush)
+    {
+        return new FormattedText(
+            text,
+            CultureInfo.CurrentUICulture,
+            FlowDirection.LeftToRight,
+            new Typeface(new FontFamily("Segoe UI"), FontStyles.Normal, weight, FontStretches.Normal),
+            size,
+            brush,
+            VisualTreeHelper.GetDpi(this).PixelsPerDip);
+    }
+
+    private Rect DrawPill(DrawingContext drawingContext, string text, Brush accent, Point origin)
+    {
+        var pillText = CreateText(text, 11, FontWeights.SemiBold, Brushes.White);
+        var padding = new Size(12, 6);
+        var rect = new Rect(
+            origin.X - (pillText.Width / 2) - padding.Width,
+            origin.Y,
+            pillText.Width + (padding.Width * 2),
+            pillText.Height + (padding.Height * 2));
+
+        var baseBrush = PillBackground as SolidColorBrush ?? BrushUtilities.CreateFrozenBrush("#233447");
+        var background = new SolidColorBrush(baseBrush.Color)
+        {
+            Opacity = 0.92
+        };
+        background.Freeze();
+
+        drawingContext.DrawRoundedRectangle(background, null, rect, 12, 12);
+        drawingContext.DrawRoundedRectangle(null, new Pen(accent, 1.2), rect, 12, 12);
+        drawingContext.DrawText(pillText, new Point(rect.Left + padding.Width, rect.Top + padding.Height - 1));
+
+        return rect;
+    }
+
+    private void StartEntranceAnimation()
+    {
+        BeginAnimation(AnimationProgressProperty, null);
+        var animation = new DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(560))
+        {
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut }
+        };
+        BeginAnimation(AnimationProgressProperty, animation);
+    }
+
+    private void OnMouseMove(object? sender, System.Windows.Input.MouseEventArgs e)
+    {
+        if (_hitTest.Count == 0)
+        {
+            HideTooltip();
+            return;
+        }
+
+        var position = e.GetPosition(this);
+        var hit = _hitTest.FirstOrDefault(info => info.Bounds.Contains(position));
+        if (hit.Entry is null)
+        {
+            HideTooltip();
+            return;
+        }
+
+        _tooltipText.Text = hit.Entry.HasDetail
+            ? $"{hit.Entry.Label}\n{hit.Entry.Detail}"
+            : hit.Entry.Label;
+
+        if (hit.Entry.HasPill)
+        {
+            _tooltipText.Text += $"\n{hit.Entry.Pill}";
+        }
+
+        _tooltip.HorizontalOffset = position.X + 12;
+        _tooltip.VerticalOffset = position.Y - 28;
+        if (!_tooltip.IsOpen)
+        {
+            _tooltip.IsOpen = true;
+        }
+    }
+
+    private void HideTooltip()
+    {
+        if (_tooltip.IsOpen)
+        {
+            _tooltip.IsOpen = false;
+        }
+    }
+
+    private static TextBlock CreateTooltipText()
+    {
+        return new TextBlock
+        {
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = 12,
+            Foreground = Brushes.White,
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(12, 8, 12, 8)
+        };
+    }
+
+    private Popup CreateTooltipPopup(UIElement content)
+    {
+        var border = new Border
+        {
+            Background = BrushUtilities.CreateFrozenBrush("#1B2734"),
+            BorderBrush = BrushUtilities.CreateFrozenBrush("#2EC4B6"),
+            BorderThickness = new Thickness(1),
+            CornerRadius = new CornerRadius(6),
+            Child = content,
+            Effect = new System.Windows.Media.Effects.DropShadowEffect
+            {
+                BlurRadius = 8,
+                ShadowDepth = 0,
+                Opacity = 0.6,
+                Color = Colors.Black
+            }
+        };
+
+        return new Popup
+        {
+            Placement = PlacementMode.Relative,
+            PlacementTarget = this,
+            AllowsTransparency = true,
+            StaysOpen = false,
+            Child = border
+        };
+    }
+
+    private readonly struct TimelineHitTestInfo
+    {
+        public TimelineHitTestInfo(Rect bounds, TimelineEntryViewModel entry)
+        {
+            Bounds = bounds;
+            Entry = entry;
+        }
+
+        public Rect Bounds { get; }
+
+        public TimelineEntryViewModel Entry { get; }
+    }
+}

--- a/WPF/FMUI.Wpf/Controls/VirtualizingCardPanel.cs
+++ b/WPF/FMUI.Wpf/Controls/VirtualizingCardPanel.cs
@@ -1,0 +1,383 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Controls;
+
+public sealed class VirtualizingCardPanel : VirtualizingPanel, IScrollInfo
+{
+    private const double ScrollLineDelta = 38d;
+    private const double VisibilityPadding = 160d;
+
+    public static readonly DependencyProperty SurfaceWidthProperty =
+        DependencyProperty.Register(
+            nameof(SurfaceWidth),
+            typeof(double),
+            typeof(VirtualizingCardPanel),
+            new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.AffectsMeasure, OnSurfaceSizeChanged));
+
+    public static readonly DependencyProperty SurfaceHeightProperty =
+        DependencyProperty.Register(
+            nameof(SurfaceHeight),
+            typeof(double),
+            typeof(VirtualizingCardPanel),
+            new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.AffectsMeasure, OnSurfaceSizeChanged));
+
+    private readonly Dictionary<int, UIElement> _realized = new();
+    private Size _extent;
+    private Size _viewport;
+    private Point _offset;
+
+    public VirtualizingCardPanel()
+    {
+        ClipToBounds = true;
+    }
+
+    public double SurfaceWidth
+    {
+        get => (double)GetValue(SurfaceWidthProperty);
+        set => SetValue(SurfaceWidthProperty, value);
+    }
+
+    public double SurfaceHeight
+    {
+        get => (double)GetValue(SurfaceHeightProperty);
+        set => SetValue(SurfaceHeightProperty, value);
+    }
+
+    public bool CanHorizontallyScroll { get; set; } = true;
+
+    public bool CanVerticallyScroll { get; set; } = true;
+
+    public double ExtentWidth => _extent.Width;
+
+    public double ExtentHeight => _extent.Height;
+
+    public double ViewportWidth => _viewport.Width;
+
+    public double ViewportHeight => _viewport.Height;
+
+    public double HorizontalOffset => _offset.X;
+
+    public double VerticalOffset => _offset.Y;
+
+    public ScrollViewer? ScrollOwner { get; set; }
+
+    public void LineDown() => SetVerticalOffset(VerticalOffset + ScrollLineDelta);
+
+    public void LineLeft() => SetHorizontalOffset(HorizontalOffset - ScrollLineDelta);
+
+    public void LineRight() => SetHorizontalOffset(HorizontalOffset + ScrollLineDelta);
+
+    public void LineUp() => SetVerticalOffset(VerticalOffset - ScrollLineDelta);
+
+    public Rect MakeVisible(Visual visual, Rect rectangle)
+    {
+        if (visual is UIElement element && InternalChildren.Contains(element))
+        {
+            if (ItemContainerGenerator.ItemFromContainer(element) is CardViewModel card)
+            {
+                var bounds = new Rect(new Point(card.Left, card.Top), new Size(card.Width, card.Height));
+                EnsureVisible(bounds);
+                return bounds;
+            }
+        }
+
+        return rectangle;
+    }
+
+    public void MouseWheelDown() => SetVerticalOffset(VerticalOffset + ScrollLineDelta * 3);
+
+    public void MouseWheelLeft() => SetHorizontalOffset(HorizontalOffset - ScrollLineDelta * 3);
+
+    public void MouseWheelRight() => SetHorizontalOffset(HorizontalOffset + ScrollLineDelta * 3);
+
+    public void MouseWheelUp() => SetVerticalOffset(VerticalOffset - ScrollLineDelta * 3);
+
+    public void PageDown() => SetVerticalOffset(VerticalOffset + ViewportHeight);
+
+    public void PageLeft() => SetHorizontalOffset(HorizontalOffset - ViewportWidth);
+
+    public void PageRight() => SetHorizontalOffset(HorizontalOffset + ViewportWidth);
+
+    public void PageUp() => SetVerticalOffset(VerticalOffset - ViewportHeight);
+
+    public void SetHorizontalOffset(double offset)
+    {
+        var newOffset = Clamp(offset, 0, Math.Max(0, ExtentWidth - ViewportWidth));
+        if (!DoubleUtil.AreClose(newOffset, _offset.X))
+        {
+            _offset.X = newOffset;
+            InvalidateMeasure();
+            ScrollOwner?.InvalidateScrollInfo();
+        }
+    }
+
+    public void SetVerticalOffset(double offset)
+    {
+        var newOffset = Clamp(offset, 0, Math.Max(0, ExtentHeight - ViewportHeight));
+        if (!DoubleUtil.AreClose(newOffset, _offset.Y))
+        {
+            _offset.Y = newOffset;
+            InvalidateMeasure();
+            ScrollOwner?.InvalidateScrollInfo();
+        }
+    }
+
+    protected override void OnItemsChanged(object sender, ItemsChangedEventArgs args)
+    {
+        base.OnItemsChanged(sender, args);
+
+        switch (args.Action)
+        {
+            case NotifyCollectionChangedAction.Reset:
+                ClearRealized();
+                break;
+            case NotifyCollectionChangedAction.Remove:
+            case NotifyCollectionChangedAction.Replace:
+            case NotifyCollectionChangedAction.Move:
+                ClearRealized();
+                break;
+        }
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        UpdateScrollData(availableSize);
+
+        if (ItemsControl.GetItemsOwner(this) is not ItemsControl owner)
+        {
+            return availableSize;
+        }
+
+        var viewportRect = new Rect(_offset, _viewport);
+        viewportRect.Inflate(VisibilityPadding, VisibilityPadding);
+
+        var generator = ItemContainerGenerator;
+        var required = new HashSet<int>();
+
+        for (var index = 0; index < owner.Items.Count; index++)
+        {
+            if (owner.Items[index] is not CardViewModel card)
+            {
+                continue;
+            }
+
+            if (!viewportRect.IntersectsWith(card.GetBounds()))
+            {
+                continue;
+            }
+
+            required.Add(index);
+            EnsureChild(generator, index);
+        }
+
+        CleanupChildren(generator, required);
+
+        foreach (var index in required)
+        {
+            if (_realized.TryGetValue(index, out var child) && owner.Items[index] is CardViewModel card)
+            {
+                child.Measure(new Size(card.Width, card.Height));
+            }
+        }
+
+        return availableSize;
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        foreach (var (index, child) in _realized.ToList())
+        {
+            if (ItemContainerGenerator.ItemFromContainer(child) is not CardViewModel card)
+            {
+                continue;
+            }
+
+            var rect = new Rect(card.Left, card.Top, card.Width, card.Height);
+            child.Arrange(rect);
+        }
+
+        return finalSize;
+    }
+
+    private void EnsureChild(IItemContainerGenerator generator, int itemIndex)
+    {
+        if (_realized.ContainsKey(itemIndex))
+        {
+            return;
+        }
+
+        var position = generator.GeneratorPositionFromIndex(itemIndex);
+        var direction = GeneratorDirection.Forward;
+
+        using (generator.StartAt(position, direction, true))
+        {
+            var child = (UIElement)generator.GenerateNext(out var newlyRealized);
+            if (newlyRealized)
+            {
+                var insertIndex = position.Index;
+                if (insertIndex < 0 || insertIndex > InternalChildren.Count)
+                {
+                    insertIndex = InternalChildren.Count;
+                }
+
+                InsertInternalChild(insertIndex, child);
+            }
+            else if (!InternalChildren.Contains(child))
+            {
+                InsertInternalChild(InternalChildren.Count, child);
+            }
+
+            generator.PrepareItemContainer(child);
+            _realized[itemIndex] = child;
+        }
+    }
+
+    private void CleanupChildren(IItemContainerGenerator generator, HashSet<int> keep)
+    {
+        foreach (var index in _realized.Keys.Except(keep).ToList())
+        {
+            var position = generator.GeneratorPositionFromIndex(index);
+            if (position.Index >= 0)
+            {
+                generator.Remove(position, 1);
+                RemoveInternalChildRange(position.Index, 1);
+            }
+            else if (_realized.TryGetValue(index, out var child))
+            {
+                var childIndex = InternalChildren.IndexOf(child);
+                if (childIndex >= 0)
+                {
+                    RemoveInternalChildRange(childIndex, 1);
+                }
+            }
+
+            _realized.Remove(index);
+        }
+    }
+
+    private void ClearRealized()
+    {
+        if (InternalChildren.Count > 0)
+        {
+            RemoveInternalChildRange(0, InternalChildren.Count);
+        }
+
+        _realized.Clear();
+        InvalidateMeasure();
+    }
+
+    private void UpdateScrollData(Size availableSize)
+    {
+        var viewportWidth = double.IsInfinity(availableSize.Width) || double.IsNaN(availableSize.Width)
+            ? SurfaceWidth
+            : availableSize.Width;
+        var viewportHeight = double.IsInfinity(availableSize.Height) || double.IsNaN(availableSize.Height)
+            ? SurfaceHeight
+            : availableSize.Height;
+
+        if (DoubleUtil.LessThanOrClose(viewportWidth, 0))
+        {
+            viewportWidth = SurfaceWidth;
+        }
+
+        if (DoubleUtil.LessThanOrClose(viewportHeight, 0))
+        {
+            viewportHeight = SurfaceHeight;
+        }
+
+        var extentWidth = Math.Max(SurfaceWidth, viewportWidth);
+        var extentHeight = Math.Max(SurfaceHeight, viewportHeight);
+
+        if (!DoubleUtil.AreClose(_viewport.Width, viewportWidth) || !DoubleUtil.AreClose(_viewport.Height, viewportHeight))
+        {
+            _viewport = new Size(viewportWidth, viewportHeight);
+            ScrollOwner?.InvalidateScrollInfo();
+        }
+
+        if (!DoubleUtil.AreClose(_extent.Width, extentWidth) || !DoubleUtil.AreClose(_extent.Height, extentHeight))
+        {
+            _extent = new Size(extentWidth, extentHeight);
+            ScrollOwner?.InvalidateScrollInfo();
+        }
+
+        CoerceOffsets();
+    }
+
+    private void EnsureVisible(Rect bounds)
+    {
+        var horizontal = HorizontalOffset;
+        var vertical = VerticalOffset;
+
+        if (bounds.Left < horizontal)
+        {
+            horizontal = bounds.Left;
+        }
+        else if (bounds.Right > horizontal + ViewportWidth)
+        {
+            horizontal = bounds.Right - ViewportWidth;
+        }
+
+        if (bounds.Top < vertical)
+        {
+            vertical = bounds.Top;
+        }
+        else if (bounds.Bottom > vertical + ViewportHeight)
+        {
+            vertical = bounds.Bottom - ViewportHeight;
+        }
+
+        SetHorizontalOffset(horizontal);
+        SetVerticalOffset(vertical);
+    }
+
+    private void CoerceOffsets()
+    {
+        SetHorizontalOffset(HorizontalOffset);
+        SetVerticalOffset(VerticalOffset);
+    }
+
+    private static void OnSurfaceSizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is VirtualizingCardPanel panel)
+        {
+            panel.InvalidateMeasure();
+        }
+    }
+
+    private static double Clamp(double value, double min, double max)
+    {
+        if (double.IsNaN(value))
+        {
+            return min;
+        }
+
+        if (value < min)
+        {
+            return min;
+        }
+
+        if (value > max)
+        {
+            return max;
+        }
+
+        return value;
+    }
+
+    private static class DoubleUtil
+    {
+        private const double Epsilon = 0.0001d;
+
+        public static bool AreClose(double x, double y) => Math.Abs(x - y) < Epsilon;
+
+        public static bool LessThanOrClose(double x, double y) => x < y || AreClose(x, y);
+    }
+}

--- a/WPF/FMUI.Wpf/Data/club-data.json
+++ b/WPF/FMUI.Wpf/Data/club-data.json
@@ -1,0 +1,4137 @@
+{
+  "navigationPermissions": {
+    "tabs": [
+      {
+        "tabId": "overview",
+        "isVisible": true,
+        "sections": [
+          {
+            "sectionId": "club-vision",
+            "isVisible": true
+          },
+          {
+            "sectionId": "dynamics",
+            "isVisible": true
+          },
+          {
+            "sectionId": "medical-centre",
+            "isVisible": true
+          },
+          {
+            "sectionId": "analytics",
+            "isVisible": true
+          }
+        ]
+      },
+      {
+        "tabId": "squad",
+        "isVisible": true,
+        "sections": [
+          {
+            "sectionId": "selection-info",
+            "isVisible": true
+          },
+          {
+            "sectionId": "players",
+            "isVisible": true
+          },
+          {
+            "sectionId": "international",
+            "isVisible": true
+          },
+          {
+            "sectionId": "squad-depth",
+            "isVisible": true
+          }
+        ]
+      },
+      {
+        "tabId": "tactics",
+        "isVisible": true,
+        "sections": [
+          {
+            "sectionId": "tactics-overview",
+            "isVisible": true
+          },
+          {
+            "sectionId": "set-pieces",
+            "isVisible": true
+          },
+          {
+            "sectionId": "tactics-analysis",
+            "isVisible": true
+          }
+        ]
+      },
+      {
+        "tabId": "training",
+        "isVisible": true,
+        "sections": [
+          {
+            "sectionId": "training-overview",
+            "isVisible": true
+          },
+          {
+            "sectionId": "training-calendar",
+            "isVisible": true
+          },
+          {
+            "sectionId": "training-units",
+            "isVisible": true
+          }
+        ]
+      },
+      {
+        "tabId": "transfers",
+        "isVisible": true,
+        "sections": [
+          {
+            "sectionId": "transfer-centre",
+            "isVisible": true
+          },
+          {
+            "sectionId": "scouting",
+            "isVisible": true
+          },
+          {
+            "sectionId": "shortlist",
+            "isVisible": false,
+            "requiredRole": "DirectorOfFootball"
+          }
+        ]
+      },
+      {
+        "tabId": "finances",
+        "isVisible": true,
+        "sections": [
+          {
+            "sectionId": "finances-summary",
+            "isVisible": true
+          },
+          {
+            "sectionId": "finances-income",
+            "isVisible": true
+          },
+          {
+            "sectionId": "finances-expenditure",
+            "isVisible": true
+          }
+        ]
+      },
+      {
+        "tabId": "fixtures",
+        "isVisible": true,
+        "sections": [
+          {
+            "sectionId": "fixtures-schedule",
+            "isVisible": true
+          },
+          {
+            "sectionId": "fixtures-results",
+            "isVisible": true
+          },
+          {
+            "sectionId": "fixtures-calendar",
+            "isVisible": true
+          }
+        ]
+      }
+    ]
+  },
+  "tactics": {
+    "formationName": "4-2-3-1 Wide",
+    "squadLabel": "Starting XI",
+    "description": "Balanced attacking structure with inverted wingers tucking inside to overload the half-spaces.",
+    "mentalityPill": "Positive",
+    "formationLines": [
+      {
+        "role": "Striker",
+        "players": [
+          {
+            "id": "st-ivan-toney",
+            "name": "Ivan Toney (AF)",
+            "x": 0.5,
+            "y": 0.08
+          }
+        ]
+      },
+      {
+        "role": "Attacking Midfield",
+        "players": [
+          {
+            "id": "am-phil-foden",
+            "name": "Phil Foden (IW)",
+            "x": 0.26,
+            "y": 0.28
+          },
+          {
+            "id": "am-martin-odegaard",
+            "name": "Martin \u00d8degaard (AP)",
+            "x": 0.5,
+            "y": 0.3
+          },
+          {
+            "id": "am-bukayo-saka",
+            "name": "Bukayo Saka (IW)",
+            "x": 0.74,
+            "y": 0.28
+          }
+        ]
+      },
+      {
+        "role": "Midfield Pivot",
+        "players": [
+          {
+            "id": "mid-declan-rice",
+            "name": "Declan Rice (HB)",
+            "x": 0.36,
+            "y": 0.48
+          },
+          {
+            "id": "mid-youri-tielemans",
+            "name": "Youri Tielemans (BBM)",
+            "x": 0.64,
+            "y": 0.48
+          }
+        ]
+      },
+      {
+        "role": "Defence",
+        "players": [
+          {
+            "id": "def-kieran-tierney",
+            "name": "Kieran Tierney (WB)",
+            "x": 0.18,
+            "y": 0.7
+          },
+          {
+            "id": "def-gabriel",
+            "name": "Gabriel (CD)",
+            "x": 0.38,
+            "y": 0.68
+          },
+          {
+            "id": "def-ben-white",
+            "name": "Ben White (BPD)",
+            "x": 0.62,
+            "y": 0.68
+          },
+          {
+            "id": "def-takehiro-tomiyasu",
+            "name": "Takehiro Tomiyasu (WB)",
+            "x": 0.82,
+            "y": 0.7
+          }
+        ]
+      },
+      {
+        "role": "Goalkeeper",
+        "players": [
+          {
+            "id": "gk-aaron-ramsdale",
+            "name": "Aaron Ramsdale (SK)",
+            "x": 0.5,
+            "y": 0.9
+          }
+        ]
+      }
+    ],
+    "playerPool": [
+      {
+        "id": "st-ivan-toney",
+        "name": "Ivan Toney",
+        "position": "ST",
+        "detail": "Advanced Forward"
+      },
+      {
+        "id": "st-gabriel-jesus",
+        "name": "Gabriel Jesus",
+        "position": "ST",
+        "detail": "Complete Forward"
+      },
+      {
+        "id": "am-martin-odegaard",
+        "name": "Martin \u00d8degaard",
+        "position": "AMC",
+        "detail": "Advanced Playmaker"
+      },
+      {
+        "id": "am-phil-foden",
+        "name": "Phil Foden",
+        "position": "AML",
+        "detail": "Inverted Winger"
+      },
+      {
+        "id": "am-bukayo-saka",
+        "name": "Bukayo Saka",
+        "position": "AMR",
+        "detail": "Inverted Winger"
+      },
+      {
+        "id": "am-gabriel-martinelli",
+        "name": "Gabriel Martinelli",
+        "position": "AML",
+        "detail": "Inside Forward"
+      },
+      {
+        "id": "am-leandro-trossard",
+        "name": "Leandro Trossard",
+        "position": "AML",
+        "detail": "Wide Playmaker"
+      },
+      {
+        "id": "mid-declan-rice",
+        "name": "Declan Rice",
+        "position": "DM",
+        "detail": "Half Back"
+      },
+      {
+        "id": "mid-thomas-partey",
+        "name": "Thomas Partey",
+        "position": "DM",
+        "detail": "Anchor Man"
+      },
+      {
+        "id": "mid-youri-tielemans",
+        "name": "Youri Tielemans",
+        "position": "MC",
+        "detail": "Box to Box"
+      },
+      {
+        "id": "mid-jorginho",
+        "name": "Jorginho",
+        "position": "DM",
+        "detail": "Deep Lying Playmaker"
+      },
+      {
+        "id": "def-ben-white",
+        "name": "Ben White",
+        "position": "DR",
+        "detail": "Ball Playing Defender"
+      },
+      {
+        "id": "def-gabriel",
+        "name": "Gabriel",
+        "position": "DC",
+        "detail": "Central Defender"
+      },
+      {
+        "id": "def-william-saliba",
+        "name": "William Saliba",
+        "position": "DC",
+        "detail": "Ball Playing Defender"
+      },
+      {
+        "id": "def-takehiro-tomiyasu",
+        "name": "Takehiro Tomiyasu",
+        "position": "DR",
+        "detail": "Wing Back"
+      },
+      {
+        "id": "def-kieran-tierney",
+        "name": "Kieran Tierney",
+        "position": "DL",
+        "detail": "Wing Back"
+      },
+      {
+        "id": "def-oleksandr-zinchenko",
+        "name": "Oleksandr Zinchenko",
+        "position": "DL",
+        "detail": "Inverted Wing Back"
+      },
+      {
+        "id": "def-jurrien-timber",
+        "name": "Jurrien Timber",
+        "position": "DC",
+        "detail": "Wide Centre-Back"
+      },
+      {
+        "id": "gk-aaron-ramsdale",
+        "name": "Aaron Ramsdale",
+        "position": "GK",
+        "detail": "Sweeper Keeper"
+      },
+      {
+        "id": "gk-david-raya",
+        "name": "David Raya",
+        "position": "GK",
+        "detail": "Sweeper Keeper"
+      }
+    ],
+    "fluidity": {
+      "value": "Highly Fluid",
+      "summary": "Players interchange positions freely, supporting overloads down both flanks.",
+      "pill": "Excellent"
+    },
+    "mentality": {
+      "value": "Positive",
+      "summary": "Balanced risk taking with emphasis on progressive runs and penetrative passing."
+    },
+    "inPossession": {
+      "description": "Encourage roaming play through the channels to destabilise compact blocks.",
+      "items": [
+        {
+          "label": "Width",
+          "value": "Fairly Wide"
+        },
+        {
+          "label": "Approach Play",
+          "value": "Play Out Of Defence"
+        },
+        {
+          "label": "Final Third",
+          "value": "Work Ball Into Box"
+        },
+        {
+          "label": "Tempo",
+          "value": "Higher"
+        },
+        {
+          "label": "Passing",
+          "value": "Shorter"
+        }
+      ]
+    },
+    "inTransition": {
+      "items": [
+        {
+          "label": "When Possession Has Been Lost",
+          "value": "Counter-Press"
+        },
+        {
+          "label": "When Possession Has Been Won",
+          "value": "Counter"
+        },
+        {
+          "label": "Goalkeeper In Possession",
+          "value": "Distribute Quickly",
+          "detail": "Full-Backs"
+        }
+      ]
+    },
+    "outOfPossession": {
+      "items": [
+        {
+          "label": "Defensive Line",
+          "value": "Higher"
+        },
+        {
+          "label": "Line of Engagement",
+          "value": "Higher"
+        },
+        {
+          "label": "Defensive Shape",
+          "value": "More Often Prevent Short GK Distribution"
+        },
+        {
+          "label": "Pressing Intensity",
+          "value": "Much More Often"
+        }
+      ]
+    },
+    "setPieces": {
+      "attackingCorners": [
+        {
+          "primary": "Near Post",
+          "secondary": "Gabriel",
+          "tertiary": "Saliba block"
+        },
+        {
+          "primary": "Far Post",
+          "secondary": "Toney",
+          "tertiary": "Tierney delivery"
+        }
+      ],
+      "defendingCorners": [
+        {
+          "primary": "Zonal Line",
+          "secondary": "Six-yard box"
+        },
+        {
+          "primary": "Marker",
+          "secondary": "Rice on aerial threat"
+        }
+      ],
+      "freeKicks": [
+        {
+          "primary": "Direct",
+          "secondary": "\u00d8degaard",
+          "tertiary": "Left foot"
+        },
+        {
+          "primary": "Indirect",
+          "secondary": "Saka",
+          "tertiary": "Inswingers"
+        }
+      ],
+      "throwIns": [
+        {
+          "primary": "Attacking",
+          "secondary": "Tomiyasu",
+          "tertiary": "Quick routine"
+        },
+        {
+          "primary": "Defensive",
+          "secondary": "White",
+          "tertiary": "Retain shape"
+        }
+      ],
+      "penaltyTakers": [
+        {
+          "primary": "1st",
+          "secondary": "Bukayo Saka"
+        },
+        {
+          "primary": "2nd",
+          "secondary": "Ivan Toney"
+        },
+        {
+          "primary": "3rd",
+          "secondary": "Martin \u00d8degaard"
+        }
+      ]
+    },
+    "analysis": {
+      "recentForm": {
+        "value": "WWWDL",
+        "summary": "10 goals scored, 4 conceded across last five competitive matches.",
+        "pill": "+6 GD"
+      },
+      "strengths": [
+        {
+          "primary": "Pressing Triggers",
+          "secondary": "Recover ball high",
+          "tertiary": "PPDA 8.9"
+        },
+        {
+          "primary": "Chance Creation",
+          "secondary": "Central overloads",
+          "tertiary": "xG +0.6"
+        }
+      ],
+      "weaknesses": [
+        {
+          "primary": "Transition Defence",
+          "secondary": "Vulnerable to long balls"
+        },
+        {
+          "primary": "Right Flank",
+          "secondary": "Space behind Saka"
+        }
+      ],
+      "statistics": [
+        {
+          "primary": "Shots For",
+          "secondary": "16.4 per game"
+        },
+        {
+          "primary": "Shots Against",
+          "secondary": "7.2 per game"
+        },
+        {
+          "primary": "Cross Completion",
+          "secondary": "23%"
+        }
+      ],
+      "recommendations": [
+        {
+          "primary": "Maintain high press",
+          "secondary": "City struggle under pressure"
+        },
+        {
+          "primary": "Rotate wide areas",
+          "secondary": "Protect Saka for Spurs"
+        }
+      ]
+    }
+  },
+  "overview": {
+    "clubVision": {
+      "boardConfidence": {
+        "value": "A",
+        "summary": "Board delighted with league position and financial prudence.",
+        "pill": "Secure"
+      },
+      "supporterConfidence": {
+        "value": "A-",
+        "summary": "Fans are thrilled by attacking football and marquee signings.",
+        "pill": "Vibrant"
+      },
+      "competitionExpectations": [
+        {
+          "primary": "Premier League",
+          "secondary": "Qualify for Champions League",
+          "tertiary": "Current: 1st"
+        },
+        {
+          "primary": "Champions League",
+          "secondary": "Reach Quarter Final",
+          "tertiary": "Current: Group B - 1st"
+        },
+        {
+          "primary": "FA Cup",
+          "secondary": "Reach Semi Final",
+          "tertiary": "Current: Starts Jan"
+        },
+        {
+          "primary": "Carabao Cup",
+          "secondary": "Reach Final",
+          "tertiary": "Current: Eliminated"
+        }
+      ],
+      "fiveYearPlan": [
+        {
+          "primary": "2023/24",
+          "secondary": "Maintain club stature",
+          "tertiary": "Premier League top four"
+        },
+        {
+          "primary": "2024/25",
+          "secondary": "Expand stadium capacity",
+          "tertiary": "Board planning"
+        },
+        {
+          "primary": "2025/26",
+          "secondary": "Win a major trophy",
+          "tertiary": "Minimum expectation"
+        }
+      ],
+      "financeSnapshot": [
+        {
+          "primary": "Overall Balance",
+          "secondary": "\u00a3182M"
+        },
+        {
+          "primary": "Transfer Budget",
+          "secondary": "\u00a348M"
+        },
+        {
+          "primary": "Wage Budget",
+          "secondary": "\u00a33.2M p/w",
+          "tertiary": "Committed: \u00a33.0M"
+        },
+        {
+          "primary": "Scouting Budget",
+          "secondary": "\u00a32.4M"
+        }
+      ],
+      "topPerformers": [
+        {
+          "primary": "Bukayo Saka",
+          "secondary": "3 goals",
+          "tertiary": "Average Rating 7.94"
+        },
+        {
+          "primary": "Martin \u00d8degaard",
+          "secondary": "4 assists",
+          "tertiary": "Average Rating 7.71"
+        },
+        {
+          "primary": "Declan Rice",
+          "secondary": "92% pass completion",
+          "tertiary": "Average Rating 7.48"
+        }
+      ],
+      "roadmap": {
+        "phases": [
+          {
+            "id": "roadmap-phase-1",
+            "title": "Re-establish Champions League football",
+            "timeline": "Season 2023/24",
+            "status": "On Track",
+            "description": "Maintain a top-four finish while embedding the aggressive press.",
+            "accent": "#2EC4B6",
+            "pill": "Immediate"
+          },
+          {
+            "id": "roadmap-phase-2",
+            "title": "Expand stadium capacity",
+            "timeline": "Season 2024/25",
+            "status": "At Risk",
+            "description": "Board feasibility study delayed by planning consultation.",
+            "accent": "#E05D5D",
+            "pill": "Mid-Term"
+          },
+          {
+            "id": "roadmap-phase-3",
+            "title": "Deliver sustained title challenge",
+            "timeline": "Season 2025/26",
+            "status": "Ahead",
+            "description": "Squad depth metrics exceed projection following academy integrations.",
+            "accent": "#3AA0FF",
+            "pill": "Long-Term"
+          }
+        ],
+        "statusOptions": [
+          "Ahead",
+          "On Track",
+          "At Risk",
+          "Behind",
+          "Complete"
+        ],
+        "pillOptions": [
+          "Immediate",
+          "Mid-Term",
+          "Long-Term"
+        ]
+      },
+      "expectationBoard": {
+        "objectives": [
+          {
+            "id": "objective-premier-league",
+            "objective": "Win the Premier League title",
+            "competition": "Premier League",
+            "priority": "Critical",
+            "status": "On Course",
+            "deadline": "May 2024",
+            "notes": "Seven-point lead maintained despite congested fixture run.",
+            "accent": "#E05D5D"
+          },
+          {
+            "id": "objective-champions-league",
+            "objective": "Reach the Champions League semi-finals",
+            "competition": "UEFA Champions League",
+            "priority": "High",
+            "status": "Needs Attention",
+            "deadline": "June 2024",
+            "notes": "Quarter-final draw vs Bayern Munich requires tactical adjustment.",
+            "accent": "#FFE4B123"
+          },
+          {
+            "id": "objective-youth-development",
+            "objective": "Promote two academy graduates",
+            "competition": "Youth Pathway",
+            "priority": "Medium",
+            "status": "Ahead",
+            "deadline": "May 2025",
+            "notes": "Lewis-Skelly and Walters have featured in cup competitions.",
+            "accent": "#2EC4B6"
+          }
+        ],
+        "statusOptions": [
+          "On Course",
+          "Ahead",
+          "Needs Attention",
+          "Critical",
+          "Complete"
+        ],
+        "priorityOptions": [
+          "Critical",
+          "High",
+          "Medium",
+          "Low"
+        ]
+      }
+    },
+    "dynamics": {
+      "teamCohesion": {
+        "value": "Excellent",
+        "summary": "Players have built strong partnerships across key units.",
+        "pill": "90%"
+      },
+      "dressingRoomAtmosphere": {
+        "value": "Very Good",
+        "summary": "Leaders set the tone and morale is trending upward.",
+        "pill": "+6"
+      },
+      "managerialSupport": {
+        "value": "Secure",
+        "summary": "Squad trusts the tactical plan and selection choices.",
+        "pill": "Backed"
+      },
+      "socialGroups": [
+        {
+          "primary": "Core Social",
+          "secondary": "12 players",
+          "accent": "Highly Influential"
+        },
+        {
+          "primary": "Secondary Unit",
+          "secondary": "7 players",
+          "accent": "Supportive"
+        },
+        {
+          "primary": "Newcomers",
+          "secondary": "4 players",
+          "accent": "Integrating"
+        }
+      ],
+      "influencers": [
+        {
+          "primary": "Martin \u00d8degaard",
+          "secondary": "Team Leader"
+        },
+        {
+          "primary": "Declan Rice",
+          "secondary": "Highly Influential"
+        },
+        {
+          "primary": "Aaron Ramsdale",
+          "secondary": "Influential"
+        }
+      ],
+      "moraleHeatmap": {
+        "columns": [
+          "Overall Mood",
+          "Support",
+          "Resilience"
+        ],
+        "rows": [
+          {
+            "label": "Leadership Group",
+            "cells": [
+              {
+                "column": "Overall Mood",
+                "intensityKey": "surging",
+                "label": "Confident",
+                "detail": "Leaders energised by recent performances."
+              },
+              {
+                "column": "Support",
+                "intensityKey": "surging",
+                "label": "Fully backing",
+                "detail": "Backing tactical tweaks without hesitation."
+              },
+              {
+                "column": "Resilience",
+                "intensityKey": "positive",
+                "label": "High focus",
+                "detail": "Driving standards in training."
+              }
+            ]
+          },
+          {
+            "label": "Core Squad",
+            "cells": [
+              {
+                "column": "Overall Mood",
+                "intensityKey": "positive",
+                "label": "Upbeat",
+                "detail": "Enjoying consistent selection."
+              },
+              {
+                "column": "Support",
+                "intensityKey": "positive",
+                "label": "Aligned",
+                "detail": "Support staff feedback implemented."
+              },
+              {
+                "column": "Resilience",
+                "intensityKey": "steady",
+                "label": "Managing load",
+                "detail": "Monitoring fatigue ahead of cup tie."
+              }
+            ]
+          },
+          {
+            "label": "Rotation Unit",
+            "cells": [
+              {
+                "column": "Overall Mood",
+                "intensityKey": "steady",
+                "label": "Balanced",
+                "detail": "Happy with communication on roles."
+              },
+              {
+                "column": "Support",
+                "intensityKey": "positive",
+                "label": "Engaged",
+                "detail": "Pushing for opportunities."
+              },
+              {
+                "column": "Resilience",
+                "intensityKey": "concern",
+                "label": "Anxious",
+                "detail": "Couple of players frustrated by minutes."
+              }
+            ]
+          },
+          {
+            "label": "Development Squad",
+            "cells": [
+              {
+                "column": "Overall Mood",
+                "intensityKey": "positive",
+                "label": "Motivated",
+                "detail": "Academy graduates relishing mentoring."
+              },
+              {
+                "column": "Support",
+                "intensityKey": "steady",
+                "label": "Listening",
+                "detail": "Focused on progression plans."
+              },
+              {
+                "column": "Resilience",
+                "intensityKey": "steady",
+                "label": "Learning",
+                "detail": "Adjusting to workload demands."
+              }
+            ]
+          }
+        ],
+        "intensities": [
+          {
+            "key": "surging",
+            "displayName": "Surging",
+            "color": "#FF4CE577",
+            "description": "Squad segment is thriving and lifting others."
+          },
+          {
+            "key": "positive",
+            "displayName": "Positive",
+            "color": "#FF2EC4B6",
+            "description": "Healthy morale with strong buy-in."
+          },
+          {
+            "key": "steady",
+            "displayName": "Steady",
+            "color": "#FF3AA0FF",
+            "description": "Content but monitoring for signs of fatigue."
+          },
+          {
+            "key": "concern",
+            "displayName": "Concern",
+            "color": "#FFE05D5D",
+            "description": "Requires attention from man-management team."
+          }
+        ],
+        "legendTitle": "Morale Levels",
+        "legendSubtitle": "Snapshot gathered from leadership meetings"
+      },
+      "playerIssues": [
+        {
+          "primary": "Gabriel Jesus",
+          "secondary": "Wants more playing time",
+          "accent": "High"
+        },
+        {
+          "primary": "Emile Smith Rowe",
+          "secondary": "Promised cup starts",
+          "accent": "Medium"
+        }
+      ],
+      "meetings": [
+        {
+          "primary": "Leadership Meeting",
+          "secondary": "Monday",
+          "tertiary": "Discuss training intensity"
+        },
+        {
+          "primary": "Squad Morale",
+          "secondary": "Thursday",
+          "tertiary": "Address rotation"
+        }
+      ],
+      "praiseMoments": [
+        {
+          "primary": "\u00d8degaard",
+          "secondary": "Commended for leadership"
+        },
+        {
+          "primary": "Saliba",
+          "secondary": "Praised for defensive form"
+        },
+        {
+          "primary": "Saka",
+          "secondary": "Recognised for training attitude"
+        }
+      ]
+    },
+    "medical": {
+      "injuryList": [
+        {
+          "primary": "Gabriel Jesus",
+          "secondary": "Sprained Knee Ligaments",
+          "tertiary": "2-3 weeks"
+        },
+        {
+          "primary": "Takehiro Tomiyasu",
+          "secondary": "Hamstring tightness",
+          "tertiary": "5 days"
+        },
+        {
+          "primary": "Thomas Partey",
+          "secondary": "Match fitness",
+          "tertiary": "Building",
+          "accent": "Monitoring"
+        }
+      ],
+      "riskAssessment": {
+        "value": "Medium",
+        "summary": "Two players flagged for overuse, overall load manageable.",
+        "pill": "Alert"
+      },
+      "riskBreakdown": [
+        {
+          "primary": "High",
+          "secondary": "\u00d8degaard",
+          "tertiary": "Tight calf"
+        },
+        {
+          "primary": "Medium",
+          "secondary": "Tierney",
+          "tertiary": "Match Sharpness 68%"
+        },
+        {
+          "primary": "Low",
+          "secondary": "Saliba",
+          "tertiary": "Fully fit"
+        }
+      ],
+      "rehabProgress": [
+        {
+          "primary": "Jesus",
+          "secondary": "Gym work",
+          "tertiary": "65% complete"
+        },
+        {
+          "primary": "Tomiyasu",
+          "secondary": "Light training",
+          "tertiary": "Expected return Sunday"
+        }
+      ],
+      "workloadMonitoring": {
+        "value": "Controlled",
+        "summary": "Load rotated effectively across congested schedule.",
+        "pill": "Green"
+      },
+      "staffNotes": [
+        {
+          "primary": "Head Physio",
+          "secondary": "Recovery plans on track"
+        },
+        {
+          "primary": "Sports Scientist",
+          "secondary": "Recommend additional rest after City"
+        }
+      ],
+      "timeline": {
+        "entries": [
+          {
+            "id": "injury-jesus",
+            "player": "Gabriel Jesus",
+            "diagnosis": "Sprained Knee Ligaments",
+            "status": "Rehab - Phase 2",
+            "expectedReturn": "Due in 2 weeks",
+            "accent": "#FFE05D5D",
+            "notes": "Integrating into ball work next week after strength benchmarks.",
+            "phases": [
+              {
+                "label": "Injury",
+                "detail": "Late vs Spurs",
+                "position": 0.05,
+                "pill": "Match"
+              },
+              {
+                "label": "Rehab",
+                "detail": "Gym + pool",
+                "position": 0.45
+              },
+              {
+                "label": "Return to Training",
+                "detail": "Projected",
+                "position": 0.78,
+                "pill": "Target"
+              },
+              {
+                "label": "Available",
+                "detail": "Medical clearance",
+                "position": 1.0
+              }
+            ]
+          },
+          {
+            "id": "injury-tomiyasu",
+            "player": "Takehiro Tomiyasu",
+            "diagnosis": "Hamstring tightness",
+            "status": "Modified training",
+            "expectedReturn": "Available this weekend",
+            "accent": "#FF3AA0FF",
+            "notes": "Cleared for 45 minutes if needed against Brentford.",
+            "phases": [
+              {
+                "label": "Flagged",
+                "detail": "High load alert",
+                "position": 0.1
+              },
+              {
+                "label": "Rest",
+                "detail": "Individual work",
+                "position": 0.32
+              },
+              {
+                "label": "Pitch Work",
+                "detail": "Light ball work",
+                "position": 0.6
+              },
+              {
+                "label": "Return",
+                "detail": "Full contact",
+                "position": 0.9,
+                "pill": "This week"
+              }
+            ]
+          },
+          {
+            "id": "injury-tierney",
+            "player": "Kieran Tierney",
+            "diagnosis": "Overuse monitoring",
+            "status": "Preventative programme",
+            "expectedReturn": "Fully fit",
+            "accent": "#FFE4B123",
+            "phases": [
+              {
+                "label": "Baseline",
+                "detail": "Screening",
+                "position": 0.0
+              },
+              {
+                "label": "Load Management",
+                "detail": "Reduced sprints",
+                "position": 0.4
+              },
+              {
+                "label": "Monitoring",
+                "detail": "GPS review",
+                "position": 0.7
+              },
+              {
+                "label": "Cleared",
+                "detail": "Full availability",
+                "position": 1.0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "analytics": {
+      "expectedGoalsTrend": {
+        "metric": {
+          "value": "+0.62",
+          "summary": "xG rolling average exceeds opponents over last five matches.",
+          "pill": "Upward"
+        },
+        "points": [
+          {
+            "label": "Aug",
+            "value": 1.68
+          },
+          {
+            "label": "Sep",
+            "value": 1.74
+          },
+          {
+            "label": "Oct",
+            "value": 1.81
+          },
+          {
+            "label": "Nov",
+            "value": 1.92
+          },
+          {
+            "label": "Dec",
+            "value": 2.04
+          }
+        ]
+      },
+      "shotLocations": [
+        {
+          "primary": "Central Box",
+          "secondary": "43%",
+          "tertiary": "High quality"
+        },
+        {
+          "primary": "Left Channel",
+          "secondary": "29%",
+          "tertiary": "Cut-backs"
+        },
+        {
+          "primary": "Right Channel",
+          "secondary": "18%",
+          "tertiary": "Low crosses"
+        }
+      ],
+      "possessionZones": [
+        {
+          "primary": "Defensive Third",
+          "secondary": "23%",
+          "accent": "Composed"
+        },
+        {
+          "primary": "Middle Third",
+          "secondary": "41%",
+          "accent": "Control"
+        },
+        {
+          "primary": "Attacking Third",
+          "secondary": "36%",
+          "accent": "Threat"
+        }
+      ],
+      "passingNetworks": [
+        {
+          "primary": "\u00d8degaard \u2192 Saka",
+          "secondary": "14 combinations"
+        },
+        {
+          "primary": "Rice \u2192 Zinchenko",
+          "secondary": "11 combinations"
+        },
+        {
+          "primary": "Saliba \u2192 White",
+          "secondary": "9 combinations"
+        }
+      ],
+      "teamComparison": [
+        {
+          "primary": "Goals Scored",
+          "secondary": "2.3 per game",
+          "tertiary": "League Rank 2"
+        },
+        {
+          "primary": "Goals Against",
+          "secondary": "0.8 per game",
+          "tertiary": "League Rank 1"
+        },
+        {
+          "primary": "xG Difference",
+          "secondary": "+1.1",
+          "tertiary": "League Rank 1"
+        }
+      ],
+      "keyStats": [
+        {
+          "primary": "PPDA",
+          "secondary": "8.9",
+          "tertiary": "Aggressive press"
+        },
+        {
+          "primary": "Pass Completion",
+          "secondary": "89%",
+          "tertiary": "Top 3 in league"
+        },
+        {
+          "primary": "Set-Piece Goals",
+          "secondary": "7",
+          "tertiary": "3rd best"
+        }
+      ],
+      "shotMap": {
+        "pitchWidth": 120,
+        "pitchHeight": 80,
+        "filters": [
+          {
+            "key": "goal",
+            "displayName": "Goals",
+            "color": "#FFE05D5D",
+            "isDefault": true
+          },
+          {
+            "key": "on-target",
+            "displayName": "On Target",
+            "color": "#FF3AA0FF",
+            "isDefault": true
+          },
+          {
+            "key": "off-target",
+            "displayName": "Off Target",
+            "color": "#FF2EC4B6",
+            "isDefault": true
+          },
+          {
+            "key": "blocked",
+            "displayName": "Blocked",
+            "color": "#FFE4B123",
+            "isDefault": false
+          }
+        ],
+        "events": [
+          {
+            "id": "shot-jesus-1",
+            "player": "Gabriel Jesus",
+            "minute": "12'",
+            "outcomeKey": "goal",
+            "x": 78,
+            "y": 36,
+            "expectedGoals": 0.34,
+            "assist": "Saka",
+            "detail": "Right-footed finish near post"
+          },
+          {
+            "id": "shot-martinelli-1",
+            "player": "Gabriel Martinelli",
+            "minute": "27'",
+            "outcomeKey": "on-target",
+            "x": 92,
+            "y": 18,
+            "expectedGoals": 0.21,
+            "assist": "\u00d8degaard",
+            "detail": "Curling effort saved"
+          },
+          {
+            "id": "shot-saka-1",
+            "player": "Bukayo Saka",
+            "minute": "41'",
+            "outcomeKey": "off-target",
+            "x": 88,
+            "y": 52,
+            "expectedGoals": 0.18,
+            "detail": "Dragged wide from tight angle"
+          },
+          {
+            "id": "shot-rice-1",
+            "player": "Declan Rice",
+            "minute": "54'",
+            "outcomeKey": "blocked",
+            "x": 70,
+            "y": 40,
+            "expectedGoals": 0.09,
+            "detail": "Drive blocked by centre-back"
+          },
+          {
+            "id": "shot-saka-2",
+            "player": "Bukayo Saka",
+            "minute": "63'",
+            "outcomeKey": "goal",
+            "x": 84,
+            "y": 28,
+            "expectedGoals": 0.31,
+            "assist": "Jesus",
+            "detail": "Cut inside and curled into far corner"
+          },
+          {
+            "id": "shot-havertz-1",
+            "player": "Kai Havertz",
+            "minute": "71'",
+            "outcomeKey": "on-target",
+            "x": 74,
+            "y": 24,
+            "expectedGoals": 0.27,
+            "detail": "Header saved on the line"
+          },
+          {
+            "id": "shot-trossard-1",
+            "player": "Leandro Trossard",
+            "minute": "82'",
+            "outcomeKey": "blocked",
+            "x": 66,
+            "y": 44,
+            "expectedGoals": 0.12,
+            "detail": "Low shot deflected behind"
+          },
+          {
+            "id": "shot-odegaard-1",
+            "player": "Martin \u00d8degaard",
+            "minute": "90+1'",
+            "outcomeKey": "off-target",
+            "x": 78,
+            "y": 30,
+            "expectedGoals": 0.15,
+            "detail": "Volley over from edge of box"
+          }
+        ]
+      }
+    }
+  },
+  "squad": {
+    "selectionInfo": {
+      "matchdayReadiness": [
+        {
+          "primary": "Starting XI",
+          "secondary": "Fully available"
+        },
+        {
+          "primary": "Bench",
+          "secondary": "Two U21 registrations required"
+        }
+      ],
+      "fitnessConcerns": [
+        {
+          "primary": "Bukayo Saka",
+          "secondary": "Fatigued",
+          "tertiary": "Needs 45 min cap",
+          "accent": "Manage"
+        },
+        {
+          "primary": "Ben White",
+          "secondary": "Tight hamstring",
+          "tertiary": "Late test"
+        }
+      ],
+      "suspensions": [
+        {
+          "primary": "Kai Havertz",
+          "secondary": "1 match ban",
+          "tertiary": "Yellow card accumulation"
+        }
+      ],
+      "recentForm": [
+        {
+          "primary": "Last 5",
+          "secondary": "WWWDL",
+          "tertiary": "9 scored / 4 conceded"
+        },
+        {
+          "primary": "Home",
+          "secondary": "W4 D1",
+          "tertiary": "Impenetrable"
+        },
+        {
+          "primary": "Away",
+          "secondary": "W3 L1",
+          "tertiary": "Improving"
+        }
+      ],
+      "trainingFocus": [
+        {
+          "primary": "Press Resistance",
+          "secondary": "Midfield unit"
+        },
+        {
+          "primary": "Crossing",
+          "secondary": "Wide players"
+        },
+        {
+          "primary": "Set Piece Delivery",
+          "secondary": "Rotation"
+        }
+      ]
+    },
+    "players": {
+      "keyPlayers": [
+        {
+          "primary": "\u00d8degaard",
+          "secondary": "Avg Rating 7.71",
+          "tertiary": "Chances created 35"
+        },
+        {
+          "primary": "Saka",
+          "secondary": "Goals 8",
+          "tertiary": "Assists 6"
+        },
+        {
+          "primary": "Rice",
+          "secondary": "Tackles / 90: 3.2",
+          "tertiary": "Interceptions / 90: 2.1"
+        }
+      ],
+      "emergingPlayers": [
+        {
+          "primary": "Ethan Nwaneri",
+          "secondary": "AMC",
+          "tertiary": "Training: Vision"
+        },
+        {
+          "primary": "Reuell Walters",
+          "secondary": "RB",
+          "tertiary": "Loan: Championship"
+        }
+      ],
+      "contractStatus": [
+        {
+          "primary": "Saliba",
+          "secondary": "2027",
+          "tertiary": "Key Player"
+        },
+        {
+          "primary": "Tierney",
+          "secondary": "2025",
+          "tertiary": "Rotation",
+          "accent": "Decision"
+        },
+        {
+          "primary": "Balogun",
+          "secondary": "2026",
+          "tertiary": "On loan"
+        }
+      ],
+      "statisticsLeaders": [
+        {
+          "primary": "Goals",
+          "secondary": "Saka - 8"
+        },
+        {
+          "primary": "Assists",
+          "secondary": "\u00d8degaard - 7"
+        },
+        {
+          "primary": "Average Rating",
+          "secondary": "Saliba - 7.62"
+        }
+      ],
+      "transferInterest": [
+        {
+          "primary": "Takehiro Tomiyasu",
+          "secondary": "AC Milan",
+          "tertiary": "Loan enquiry",
+          "accent": "Monitor"
+        },
+        {
+          "primary": "Emile Smith Rowe",
+          "secondary": "Newcastle",
+          "tertiary": "Permanent",
+          "accent": "Consider"
+        }
+      ],
+      "roster": [
+        {
+          "id": "player-raya",
+          "name": "David Raya",
+          "positionGroup": "Goalkeeper",
+          "position": "GK",
+          "role": "First Choice",
+          "morale": "Composed",
+          "condition": 0.97,
+          "matchSharpness": 0.94,
+          "averageRating": 7.18,
+          "appearances": 22,
+          "minutes": 1980,
+          "nationality": "ESP",
+          "status": "Clean sheet streak"
+        },
+        {
+          "id": "player-saliba",
+          "name": "William Saliba",
+          "positionGroup": "Defence",
+          "position": "RCB",
+          "role": "Key Player",
+          "morale": "Excellent",
+          "condition": 0.93,
+          "matchSharpness": 0.96,
+          "averageRating": 7.62,
+          "appearances": 26,
+          "minutes": 2280,
+          "nationality": "FRA",
+          "status": "Leadership core"
+        },
+        {
+          "id": "player-gabriel",
+          "name": "Gabriel",
+          "positionGroup": "Defence",
+          "position": "LCB",
+          "role": "Key Player",
+          "morale": "Very Good",
+          "condition": 0.91,
+          "matchSharpness": 0.92,
+          "averageRating": 7.24,
+          "appearances": 25,
+          "minutes": 2210,
+          "nationality": "BRA"
+        },
+        {
+          "id": "player-ben-white",
+          "name": "Ben White",
+          "positionGroup": "Defence",
+          "position": "RB",
+          "role": "Important",
+          "morale": "Good",
+          "condition": 0.88,
+          "matchSharpness": 0.9,
+          "averageRating": 7.08,
+          "appearances": 24,
+          "minutes": 2085,
+          "nationality": "ENG",
+          "status": "Rotation advised"
+        },
+        {
+          "id": "player-rice",
+          "name": "Declan Rice",
+          "positionGroup": "Midfield",
+          "position": "DM",
+          "role": "Key Player",
+          "morale": "Excellent",
+          "condition": 0.95,
+          "matchSharpness": 0.95,
+          "averageRating": 7.48,
+          "appearances": 27,
+          "minutes": 2340,
+          "nationality": "ENG",
+          "status": "Undroppable"
+        },
+        {
+          "id": "player-odegaard",
+          "name": "Martin \u00d8degaard",
+          "positionGroup": "Midfield",
+          "position": "AMC",
+          "role": "Captain",
+          "morale": "Inspired",
+          "condition": 0.9,
+          "matchSharpness": 0.93,
+          "averageRating": 7.71,
+          "appearances": 26,
+          "minutes": 2190,
+          "nationality": "NOR",
+          "status": "Chance creator"
+        },
+        {
+          "id": "player-saka",
+          "name": "Bukayo Saka",
+          "positionGroup": "Attack",
+          "position": "RW",
+          "role": "Key Player",
+          "morale": "Delighted",
+          "condition": 0.94,
+          "matchSharpness": 0.92,
+          "averageRating": 7.41,
+          "appearances": 25,
+          "minutes": 2125,
+          "nationality": "ENG",
+          "status": "Star performer"
+        },
+        {
+          "id": "player-martinelli",
+          "name": "Gabriel Martinelli",
+          "positionGroup": "Attack",
+          "position": "LW",
+          "role": "Important",
+          "morale": "Positive",
+          "condition": 0.89,
+          "matchSharpness": 0.9,
+          "averageRating": 7.02,
+          "appearances": 23,
+          "minutes": 1890,
+          "nationality": "BRA",
+          "status": "Rotation"
+        },
+        {
+          "id": "player-jesus",
+          "name": "Gabriel Jesus",
+          "positionGroup": "Attack",
+          "position": "ST",
+          "role": "Important",
+          "morale": "Determined",
+          "condition": 0.86,
+          "matchSharpness": 0.87,
+          "averageRating": 7.05,
+          "appearances": 21,
+          "minutes": 1610,
+          "nationality": "BRA",
+          "status": "Returning from injury"
+        },
+        {
+          "id": "player-trossard",
+          "name": "Leandro Trossard",
+          "positionGroup": "Attack",
+          "position": "LW/RW",
+          "role": "Rotation",
+          "morale": "Good",
+          "condition": 0.92,
+          "matchSharpness": 0.82,
+          "averageRating": 6.98,
+          "appearances": 19,
+          "minutes": 1280,
+          "nationality": "BEL"
+        },
+        {
+          "id": "player-smith-rowe",
+          "name": "Emile Smith Rowe",
+          "positionGroup": "Midfield",
+          "position": "AML",
+          "role": "Backup",
+          "morale": "Fair",
+          "condition": 0.9,
+          "matchSharpness": 0.78,
+          "averageRating": 6.84,
+          "appearances": 14,
+          "minutes": 780,
+          "nationality": "ENG",
+          "status": "Transfer interest"
+        },
+        {
+          "id": "player-timber",
+          "name": "Jurri\u00ebn Timber",
+          "positionGroup": "Defence",
+          "position": "RB/CB",
+          "role": "Backup",
+          "morale": "Ready",
+          "condition": 0.82,
+          "matchSharpness": 0.74,
+          "averageRating": 6.9,
+          "appearances": 9,
+          "minutes": 540,
+          "nationality": "NED",
+          "status": "Building fitness"
+        }
+      ]
+    },
+    "international": {
+      "callUps": [
+        {
+          "primary": "Saka",
+          "secondary": "England",
+          "tertiary": "UEFA Nations League"
+        },
+        {
+          "primary": "Saliba",
+          "secondary": "France",
+          "tertiary": "Friendlies"
+        },
+        {
+          "primary": "Martinelli",
+          "secondary": "Brazil",
+          "tertiary": "World Cup Qualifiers"
+        }
+      ],
+      "travelPlans": [
+        {
+          "primary": "England Camp",
+          "secondary": "St. George's Park",
+          "tertiary": "Return Fri"
+        },
+        {
+          "primary": "South America",
+          "secondary": "S\u00e3o Paulo",
+          "tertiary": "Return Mon",
+          "accent": "Long haul"
+        }
+      ],
+      "availability": [
+        {
+          "primary": "Saka",
+          "secondary": "Available 48h post return"
+        },
+        {
+          "primary": "Martinelli",
+          "secondary": "Rest required",
+          "accent": "Assess"
+        }
+      ],
+      "scoutingReports": [
+        {
+          "primary": "Brazil U23",
+          "secondary": "Endrick",
+          "tertiary": "Rated highly"
+        },
+        {
+          "primary": "France U21",
+          "secondary": "Cherki",
+          "tertiary": "Creative spark"
+        }
+      ]
+    },
+    "depth": {
+      "depthChart": [
+        {
+          "primary": "GK",
+          "secondary": "Ramsdale / Raya",
+          "tertiary": "Quality depth"
+        },
+        {
+          "primary": "CB",
+          "secondary": "Saliba / Gabriel",
+          "tertiary": "Holding cover"
+        },
+        {
+          "primary": "DM",
+          "secondary": "Rice / Partey",
+          "tertiary": "Solid"
+        }
+      ],
+      "roleBattles": [
+        {
+          "primary": "Left Wing",
+          "secondary": "Martinelli vs Trossard",
+          "tertiary": "Form vs Consistency"
+        },
+        {
+          "primary": "Striker",
+          "secondary": "Toney vs Jesus",
+          "tertiary": "Rotation"
+        }
+      ],
+      "youthDepth": [
+        {
+          "primary": "Full-back",
+          "secondary": "Lino Sousa",
+          "tertiary": "High potential"
+        },
+        {
+          "primary": "Midfield",
+          "secondary": "Charlie Patino",
+          "tertiary": "Loan recall option"
+        }
+      ],
+      "positionalRatings": [
+        {
+          "primary": "Defence",
+          "secondary": "4.5 stars"
+        },
+        {
+          "primary": "Midfield",
+          "secondary": "4 stars"
+        },
+        {
+          "primary": "Attack",
+          "secondary": "4 stars"
+        }
+      ]
+    }
+  },
+  "training": {
+    "overview": {
+      "upcomingSessions": [
+        {
+          "primary": "Mon",
+          "secondary": "Recovery",
+          "tertiary": "Unit split: Senior"
+        },
+        {
+          "primary": "Tue",
+          "secondary": "Tactical - Shape",
+          "tertiary": "Match Prep Focus"
+        },
+        {
+          "primary": "Wed",
+          "secondary": "Attacking - Wings",
+          "tertiary": "High Intensity"
+        },
+        {
+          "primary": "Thu",
+          "secondary": "Match Preview",
+          "tertiary": "Medium Intensity"
+        },
+        {
+          "primary": "Fri",
+          "secondary": "Match Practice",
+          "tertiary": "Set Pieces"
+        }
+      ],
+      "intensity": {
+        "metric": {
+          "value": "High",
+          "summary": "Condition monitored closely. Two players nearing risk threshold.",
+          "pill": "Alert"
+        },
+        "minimum": 0,
+        "maximum": 120,
+        "value": 86,
+        "target": 92,
+        "unit": "%",
+        "bands": [
+          {
+            "label": "Light",
+            "start": 0.0,
+            "end": 0.35,
+            "color": "#1B3A4B"
+          },
+          {
+            "label": "Balanced",
+            "start": 0.35,
+            "end": 0.7,
+            "color": "#24577A"
+          },
+          {
+            "label": "High",
+            "start": 0.7,
+            "end": 1.0,
+            "color": "#FF9F1C"
+          }
+        ],
+        "supportingItems": [
+          {
+            "primary": "Session Load",
+            "secondary": "86%",
+            "tertiary": "Target 92%"
+          },
+          {
+            "primary": "Condition Risk",
+            "secondary": "2 flagged players",
+            "accent": "Monitor"
+          }
+        ]
+      },
+      "workloadHeatmap": {
+        "columns": [
+          "Mon AM",
+          "Mon PM",
+          "Tue AM",
+          "Tue PM",
+          "Wed AM",
+          "Wed PM",
+          "Thu AM",
+          "Thu PM",
+          "Fri AM",
+          "Fri PM"
+        ],
+        "intensities": [
+          {
+            "key": "rest",
+            "displayName": "Recovery",
+            "color": "#1B3A4B",
+            "loadValue": 15
+          },
+          {
+            "key": "light",
+            "displayName": "Light",
+            "color": "#24577A",
+            "loadValue": 40
+          },
+          {
+            "key": "balanced",
+            "displayName": "Balanced",
+            "color": "#2EC4B6",
+            "loadValue": 70
+          },
+          {
+            "key": "high",
+            "displayName": "High",
+            "color": "#FF9F1C",
+            "loadValue": 95
+          }
+        ],
+        "legendTitle": "Weekly workload",
+        "legendSubtitle": "Intensity scale applied across all units",
+        "units": [
+          {
+            "label": "Goalkeeping",
+            "cells": [
+              {
+                "column": "Mon AM",
+                "intensityKey": "rest",
+                "load": 20,
+                "detail": "Recovery & analysis"
+              },
+              {
+                "column": "Mon PM",
+                "intensityKey": "light",
+                "load": 45
+              },
+              {
+                "column": "Tue AM",
+                "intensityKey": "balanced",
+                "load": 68
+              },
+              {
+                "column": "Tue PM",
+                "intensityKey": "balanced",
+                "load": 70
+              },
+              {
+                "column": "Wed AM",
+                "intensityKey": "high",
+                "load": 94,
+                "detail": "Aerial command"
+              },
+              {
+                "column": "Wed PM",
+                "intensityKey": "balanced",
+                "load": 72
+              },
+              {
+                "column": "Thu AM",
+                "intensityKey": "balanced",
+                "load": 74
+              },
+              {
+                "column": "Thu PM",
+                "intensityKey": "light",
+                "load": 48
+              },
+              {
+                "column": "Fri AM",
+                "intensityKey": "light",
+                "load": 42
+              },
+              {
+                "column": "Fri PM",
+                "intensityKey": "rest",
+                "load": 18
+              }
+            ]
+          },
+          {
+            "label": "Defence",
+            "cells": [
+              {
+                "column": "Mon AM",
+                "intensityKey": "rest",
+                "load": 22
+              },
+              {
+                "column": "Mon PM",
+                "intensityKey": "light",
+                "load": 44
+              },
+              {
+                "column": "Tue AM",
+                "intensityKey": "high",
+                "load": 98,
+                "detail": "Build-up structures"
+              },
+              {
+                "column": "Tue PM",
+                "intensityKey": "balanced",
+                "load": 76
+              },
+              {
+                "column": "Wed AM",
+                "intensityKey": "high",
+                "load": 96
+              },
+              {
+                "column": "Wed PM",
+                "intensityKey": "balanced",
+                "load": 78
+              },
+              {
+                "column": "Thu AM",
+                "intensityKey": "balanced",
+                "load": 72
+              },
+              {
+                "column": "Thu PM",
+                "intensityKey": "balanced",
+                "load": 70
+              },
+              {
+                "column": "Fri AM",
+                "intensityKey": "light",
+                "load": 46
+              },
+              {
+                "column": "Fri PM",
+                "intensityKey": "rest",
+                "load": 20
+              }
+            ]
+          },
+          {
+            "label": "Midfield",
+            "cells": [
+              {
+                "column": "Mon AM",
+                "intensityKey": "rest",
+                "load": 20
+              },
+              {
+                "column": "Mon PM",
+                "intensityKey": "light",
+                "load": 42
+              },
+              {
+                "column": "Tue AM",
+                "intensityKey": "balanced",
+                "load": 74
+              },
+              {
+                "column": "Tue PM",
+                "intensityKey": "balanced",
+                "load": 72
+              },
+              {
+                "column": "Wed AM",
+                "intensityKey": "high",
+                "load": 92,
+                "detail": "Wide overloads"
+              },
+              {
+                "column": "Wed PM",
+                "intensityKey": "balanced",
+                "load": 74
+              },
+              {
+                "column": "Thu AM",
+                "intensityKey": "balanced",
+                "load": 70
+              },
+              {
+                "column": "Thu PM",
+                "intensityKey": "balanced",
+                "load": 68
+              },
+              {
+                "column": "Fri AM",
+                "intensityKey": "light",
+                "load": 44
+              },
+              {
+                "column": "Fri PM",
+                "intensityKey": "rest",
+                "load": 18
+              }
+            ]
+          },
+          {
+            "label": "Attack",
+            "cells": [
+              {
+                "column": "Mon AM",
+                "intensityKey": "rest",
+                "load": 22
+              },
+              {
+                "column": "Mon PM",
+                "intensityKey": "light",
+                "load": 46
+              },
+              {
+                "column": "Tue AM",
+                "intensityKey": "balanced",
+                "load": 72
+              },
+              {
+                "column": "Tue PM",
+                "intensityKey": "balanced",
+                "load": 70
+              },
+              {
+                "column": "Wed AM",
+                "intensityKey": "high",
+                "load": 95
+              },
+              {
+                "column": "Wed PM",
+                "intensityKey": "high",
+                "load": 97,
+                "detail": "Final-third finishing"
+              },
+              {
+                "column": "Thu AM",
+                "intensityKey": "balanced",
+                "load": 74
+              },
+              {
+                "column": "Thu PM",
+                "intensityKey": "balanced",
+                "load": 72
+              },
+              {
+                "column": "Fri AM",
+                "intensityKey": "light",
+                "load": 48
+              },
+              {
+                "column": "Fri PM",
+                "intensityKey": "rest",
+                "load": 20
+              }
+            ]
+          }
+        ]
+      },
+      "focusAreas": [
+        {
+          "primary": "Team Focus",
+          "secondary": "Attacking Movement"
+        },
+        {
+          "primary": "Match Focus",
+          "secondary": "Counter-Press"
+        },
+        {
+          "primary": "Individual",
+          "secondary": "Finishing",
+          "tertiary": "6 players"
+        }
+      ],
+      "unitCoaches": [
+        {
+          "primary": "Goalkeeping",
+          "secondary": "Javi Garc\u00eda",
+          "tertiary": "Shot Stopping"
+        },
+        {
+          "primary": "Defence",
+          "secondary": "Stefan Schwarz",
+          "tertiary": "Positioning"
+        },
+        {
+          "primary": "Midfield",
+          "secondary": "Carles Cuadrat",
+          "tertiary": "Ball Retention"
+        },
+        {
+          "primary": "Attack",
+          "secondary": "Dennis Bergkamp",
+          "tertiary": "Off The Ball"
+        }
+      ],
+      "medicalWorkload": [
+        {
+          "primary": "High",
+          "secondary": "\u00d8degaard",
+          "tertiary": "Tight calf"
+        },
+        {
+          "primary": "Medium",
+          "secondary": "Tierney",
+          "tertiary": "Match Sharpness 68%"
+        },
+        {
+          "primary": "Medium",
+          "secondary": "Toney",
+          "tertiary": "Match Sharpness 71%"
+        }
+      ],
+      "matchPreparation": [
+        {
+          "primary": "Opponent",
+          "secondary": "Manchester City"
+        },
+        {
+          "primary": "Scout Summary",
+          "secondary": "Threat: Haaland aerially"
+        },
+        {
+          "primary": "Key Focus",
+          "secondary": "Limit crosses",
+          "tertiary": "Double up on wings"
+        }
+      ],
+      "individualFocus": [
+        {
+          "primary": "Bukayo Saka",
+          "secondary": "Final Third Runs",
+          "tertiary": "Progress: 73%"
+        },
+        {
+          "primary": "William Saliba",
+          "secondary": "Marking",
+          "tertiary": "Progress: 61%"
+        },
+        {
+          "primary": "Emile Smith Rowe",
+          "secondary": "Agility",
+          "tertiary": "Progress: 42%"
+        }
+      ],
+      "youthDevelopment": [
+        {
+          "primary": "U21",
+          "secondary": "Pressing Triggers",
+          "tertiary": "Lead: Per Mertesacker"
+        },
+        {
+          "primary": "U18",
+          "secondary": "Technical Passing",
+          "tertiary": "Lead: Jack Wilshere"
+        },
+        {
+          "primary": "U18",
+          "secondary": "Shape",
+          "tertiary": "5-2-3"
+        }
+      ],
+      "progression": {
+        "metricValue": "+12",
+        "metricLabel": "Progress vs last month",
+        "summary": "Senior units have outperformed targets with attacking improvements driving the uplift.",
+        "periods": [
+          "Week 1",
+          "Week 2",
+          "Week 3",
+          "Week 4",
+          "Week 5"
+        ],
+        "minimum": 0,
+        "maximum": 100,
+        "series": [
+          {
+            "id": "attacking-unit",
+            "name": "Attacking Unit",
+            "color": "#3E8EF7",
+            "accent": "Senior",
+            "isHighlighted": true,
+            "points": [
+              {
+                "period": "Week 1",
+                "value": 62.0,
+                "detail": "+2 chance creation"
+              },
+              {
+                "period": "Week 2",
+                "value": 68.5,
+                "detail": "+1 finishing"
+              },
+              {
+                "period": "Week 3",
+                "value": 72.0,
+                "detail": "+2 chance creation"
+              },
+              {
+                "period": "Week 4",
+                "value": 77.5,
+                "detail": "High-intensity pressing"
+              },
+              {
+                "period": "Week 5",
+                "value": 81.0,
+                "detail": "+3 team cohesion"
+              }
+            ]
+          },
+          {
+            "id": "defensive-unit",
+            "name": "Defensive Unit",
+            "color": "#48CFAE",
+            "accent": "Senior",
+            "isHighlighted": false,
+            "points": [
+              {
+                "period": "Week 1",
+                "value": 58.0,
+                "detail": "+1 aerial duels"
+              },
+              {
+                "period": "Week 2",
+                "value": 60.5,
+                "detail": "Shape work"
+              },
+              {
+                "period": "Week 3",
+                "value": 65.0,
+                "detail": "Clean sheet focus"
+              },
+              {
+                "period": "Week 4",
+                "value": 66.5,
+                "detail": "+1 positioning"
+              },
+              {
+                "period": "Week 5",
+                "value": 69.0,
+                "detail": "+2 interceptions"
+              }
+            ]
+          },
+          {
+            "id": "development-squad",
+            "name": "Development Squad",
+            "color": "#F6C560",
+            "accent": "U21",
+            "isHighlighted": false,
+            "points": [
+              {
+                "period": "Week 1",
+                "value": 48.0,
+                "detail": "Settling in"
+              },
+              {
+                "period": "Week 2",
+                "value": 52.0,
+                "detail": "+1 physical"
+              },
+              {
+                "period": "Week 3",
+                "value": 55.0,
+                "detail": "+1 tactical"
+              },
+              {
+                "period": "Week 4",
+                "value": 57.5,
+                "detail": "+1 technical"
+              },
+              {
+                "period": "Week 5",
+                "value": 60.0,
+                "detail": "+2 mentoring"
+              }
+            ]
+          }
+        ],
+        "highlights": [
+          {
+            "primary": "Gabriel Martinelli sharpness +3",
+            "secondary": "Attacking Unit",
+            "tertiary": "End product improving weekly",
+            "accent": "#3E8EF7"
+          },
+          {
+            "primary": "William Saliba defensive awareness +2",
+            "secondary": "Defensive Unit",
+            "tertiary": "Leading clean sheet metrics",
+            "accent": "#48CFAE"
+          },
+          {
+            "primary": "Ethan Nwaneri development +4",
+            "secondary": "Development Squad",
+            "tertiary": "Fast-tracked for senior training",
+            "accent": "#F6C560"
+          }
+        ]
+      }
+    },
+    "calendar": {
+      "weekOverview": [
+        {
+          "primary": "Monday",
+          "secondary": "Recovery",
+          "tertiary": "Morning \u2013 Recovery \u2013 Senior split \u2022 Afternoon \u2013 Gym Work \u2013 Conditioning"
+        },
+        {
+          "primary": "Tuesday",
+          "secondary": "Tactical Periodisation",
+          "tertiary": "Morning \u2013 Tactical Periodisation \u2013 Build-up play \u2022 Afternoon \u2013 Unit Work \u2013 Defensive shape"
+        },
+        {
+          "primary": "Wednesday",
+          "secondary": "Attacking Patterns",
+          "tertiary": "Morning \u2013 Attacking Patterns \u2013 Wide overloads \u2022 Afternoon \u2013 Finishing Drills \u2013 Final third"
+        },
+        {
+          "primary": "Thursday",
+          "secondary": "Set Pieces",
+          "tertiary": "Morning \u2013 Set Pieces \u2013 Offensive routines \u2022 Afternoon \u2013 Transition Play \u2013 Counter-press"
+        },
+        {
+          "primary": "Friday",
+          "secondary": "Match Prep",
+          "tertiary": "Morning \u2013 Match Prep \u2013 Opponent review \u2022 Afternoon \u2013 Recovery Briefing \u2013 Travel"
+        }
+      ],
+      "sessionDetails": [
+        {
+          "id": "session-mon-am",
+          "day": "Monday",
+          "slot": "Morning",
+          "activity": "Recovery",
+          "focus": "Senior split",
+          "intensity": "Light"
+        },
+        {
+          "id": "session-mon-pm",
+          "day": "Monday",
+          "slot": "Afternoon",
+          "activity": "Gym Work",
+          "focus": "Conditioning",
+          "intensity": "Medium"
+        },
+        {
+          "id": "session-tue-am",
+          "day": "Tuesday",
+          "slot": "Morning",
+          "activity": "Tactical Periodisation",
+          "focus": "Build-up play",
+          "intensity": "High"
+        },
+        {
+          "id": "session-tue-pm",
+          "day": "Tuesday",
+          "slot": "Afternoon",
+          "activity": "Unit Work",
+          "focus": "Defensive shape",
+          "intensity": "Medium"
+        },
+        {
+          "id": "session-wed-am",
+          "day": "Wednesday",
+          "slot": "Morning",
+          "activity": "Attacking Patterns",
+          "focus": "Wide overloads",
+          "intensity": "High"
+        },
+        {
+          "id": "session-wed-pm",
+          "day": "Wednesday",
+          "slot": "Afternoon",
+          "activity": "Finishing Drills",
+          "focus": "Final third",
+          "intensity": "Medium"
+        },
+        {
+          "id": "session-thu-am",
+          "day": "Thursday",
+          "slot": "Morning",
+          "activity": "Set Pieces",
+          "focus": "Offensive routines",
+          "intensity": "Medium"
+        },
+        {
+          "id": "session-thu-pm",
+          "day": "Thursday",
+          "slot": "Afternoon",
+          "activity": "Transition Play",
+          "focus": "Counter-press",
+          "intensity": "Medium"
+        },
+        {
+          "id": "session-fri-am",
+          "day": "Friday",
+          "slot": "Morning",
+          "activity": "Match Prep",
+          "focus": "Opponent review",
+          "intensity": "Low"
+        },
+        {
+          "id": "session-fri-pm",
+          "day": "Friday",
+          "slot": "Afternoon",
+          "activity": "Recovery Briefing",
+          "focus": "Travel",
+          "intensity": "Low"
+        }
+      ],
+      "restDays": [
+        {
+          "primary": "Saturday",
+          "secondary": "Optional recovery"
+        },
+        {
+          "primary": "Sunday",
+          "secondary": "Mandatory rest"
+        }
+      ],
+      "matchPrepFocus": [
+        {
+          "primary": "Opposition",
+          "secondary": "Manchester City",
+          "tertiary": "High press"
+        },
+        {
+          "primary": "Key Drill",
+          "secondary": "Compact mid-block"
+        }
+      ],
+      "upcomingMilestones": [
+        {
+          "primary": "Youth Intake Preview",
+          "secondary": "10 Oct"
+        },
+        {
+          "primary": "Set Piece Review",
+          "secondary": "12 Oct"
+        },
+        {
+          "primary": "Team Bonding",
+          "secondary": "13 Oct"
+        }
+      ]
+    },
+    "units": {
+      "seniorUnit": [
+        {
+          "primary": "Defensive Core",
+          "secondary": "Saliba, Gabriel, White"
+        },
+        {
+          "primary": "Midfield",
+          "secondary": "Rice, \u00d8degaard"
+        },
+        {
+          "primary": "Attack",
+          "secondary": "Saka, Toney"
+        }
+      ],
+      "youthUnit": [
+        {
+          "primary": "U21",
+          "secondary": "Walters, Azeez"
+        },
+        {
+          "primary": "U18",
+          "secondary": "Nwaneri, Sousa"
+        }
+      ],
+      "goalkeepingUnit": [
+        {
+          "primary": "Senior",
+          "secondary": "Ramsdale"
+        },
+        {
+          "primary": "Support",
+          "secondary": "Raya"
+        },
+        {
+          "primary": "Academy",
+          "secondary": "Karl Hein"
+        }
+      ],
+      "coachAssignments": [
+        {
+          "primary": "Senior Unit",
+          "secondary": "Mikel Arteta",
+          "accent": "#2EC4B6"
+        },
+        {
+          "primary": "Youth Unit",
+          "secondary": "Dennis Bergkamp",
+          "accent": "#5A8DEE"
+        },
+        {
+          "primary": "Goalkeeping",
+          "secondary": "Javi Garc\u00eda",
+          "accent": "#FF9F1C"
+        }
+      ],
+      "board": {
+        "units": [
+          {
+            "id": "senior",
+            "name": "Senior Unit",
+            "coachId": "coach-arteta",
+            "coachOptions": [
+              {
+                "id": "coach-arteta",
+                "name": "Mikel Arteta",
+                "accent": "#2EC4B6"
+              },
+              {
+                "id": "coach-cuadrat",
+                "name": "Carlos Cuadrat",
+                "accent": "#FF9F1C"
+              },
+              {
+                "id": "coach-bergkamp",
+                "name": "Dennis Bergkamp",
+                "accent": "#5A8DEE"
+              }
+            ],
+            "members": [
+              {
+                "id": "player-ramsdale",
+                "name": "Aaron Ramsdale",
+                "position": "GK",
+                "role": "Sweeper Keeper",
+                "status": "Starting XI",
+                "accent": "#2EC4B6",
+                "detail": "Clean sheets: 8"
+              },
+              {
+                "id": "player-saliba",
+                "name": "William Saliba",
+                "position": "CB",
+                "role": "Ball Playing Defender",
+                "status": "Key Player",
+                "accent": "#2EC4B6",
+                "detail": "Form: 7.26"
+              },
+              {
+                "id": "player-white",
+                "name": "Ben White",
+                "position": "RB",
+                "role": "Inverted Full-Back",
+                "status": "Trusted",
+                "accent": "#2EC4B6"
+              },
+              {
+                "id": "player-rice",
+                "name": "Declan Rice",
+                "position": "DM",
+                "role": "Half Back",
+                "status": "Key Player",
+                "accent": "#2EC4B6",
+                "detail": "Match Sharpness 92%"
+              },
+              {
+                "id": "player-odegaard",
+                "name": "Martin \u00d8degaard",
+                "position": "AM",
+                "role": "Advanced Playmaker",
+                "status": "Creative Hub",
+                "accent": "#2EC4B6",
+                "detail": "Chances created: 52"
+              },
+              {
+                "id": "player-saka",
+                "name": "Bukayo Saka",
+                "position": "RW",
+                "role": "Inverted Winger",
+                "status": "Key Player",
+                "accent": "#2EC4B6",
+                "detail": "Goals: 12"
+              },
+              {
+                "id": "player-toney",
+                "name": "Ivan Toney",
+                "position": "ST",
+                "role": "Advanced Forward",
+                "status": "Match Fit",
+                "accent": "#2EC4B6",
+                "detail": "Expected return in 2 days"
+              }
+            ]
+          },
+          {
+            "id": "youth",
+            "name": "Youth Unit",
+            "coachId": "coach-bergkamp",
+            "coachOptions": [
+              {
+                "id": "coach-bergkamp",
+                "name": "Dennis Bergkamp",
+                "accent": "#5A8DEE"
+              },
+              {
+                "id": "coach-wilshere",
+                "name": "Jack Wilshere",
+                "accent": "#5A8DEE"
+              },
+              {
+                "id": "coach-cuadrat",
+                "name": "Carlos Cuadrat",
+                "accent": "#FF9F1C"
+              }
+            ],
+            "members": [
+              {
+                "id": "player-nwaneri",
+                "name": "Ethan Nwaneri",
+                "position": "AM",
+                "role": "Shadow Striker",
+                "status": "Development",
+                "accent": "#5A8DEE",
+                "detail": "U21 starts: 14"
+              },
+              {
+                "id": "player-sousa",
+                "name": "Lino Sousa",
+                "position": "LB",
+                "role": "Attacking Wing-Back",
+                "status": "Development",
+                "accent": "#5A8DEE",
+                "detail": "Mentor: Zinchenko"
+              },
+              {
+                "id": "player-walters",
+                "name": "Reuell Walters",
+                "position": "CB",
+                "role": "Ball Playing Defender",
+                "status": "Ready Soon",
+                "accent": "#2EC4B6",
+                "detail": "Training load 78%"
+              }
+            ]
+          },
+          {
+            "id": "goalkeeping",
+            "name": "Goalkeeping",
+            "coachId": "coach-garcia",
+            "coachOptions": [
+              {
+                "id": "coach-garcia",
+                "name": "Javi Garc\u00eda",
+                "accent": "#FF9F1C"
+              },
+              {
+                "id": "coach-arteta",
+                "name": "Mikel Arteta",
+                "accent": "#2EC4B6"
+              },
+              {
+                "id": "coach-cuadrat",
+                "name": "Carlos Cuadrat",
+                "accent": "#FF9F1C"
+              }
+            ],
+            "members": [
+              {
+                "id": "player-raya",
+                "name": "David Raya",
+                "position": "GK",
+                "role": "Sweeper Keeper",
+                "status": "Rotation",
+                "accent": "#2EC4B6",
+                "detail": "Command of area 15"
+              },
+              {
+                "id": "player-hein",
+                "name": "Karl Hein",
+                "position": "GK",
+                "role": "Shot Stopper",
+                "status": "Prospect",
+                "accent": "#5A8DEE",
+                "detail": "Loan interest: 3 clubs"
+              }
+            ]
+          }
+        ],
+        "availablePlayers": [
+          {
+            "id": "player-smith-rowe",
+            "name": "Emile Smith Rowe",
+            "position": "AM",
+            "role": "Advanced Playmaker",
+            "status": "Return to training",
+            "accent": "#FF9F1C",
+            "detail": "Recovery: 85%"
+          },
+          {
+            "id": "player-nelson",
+            "name": "Reiss Nelson",
+            "position": "RW",
+            "role": "Inside Forward",
+            "status": "Rotation",
+            "accent": "#2EC4B6",
+            "detail": "Minutes: 612"
+          }
+        ]
+      }
+    }
+  },
+  "transfers": {
+    "centre": {
+      "budgetUsage": {
+        "metric": {
+          "value": "65%",
+          "summary": "Transfer budget committed after Toney deal.",
+          "pill": "Caution"
+        },
+        "minimum": 0,
+        "maximum": 100,
+        "value": 65,
+        "target": 72,
+        "unit": "%",
+        "bands": [
+          {
+            "label": "Comfort",
+            "start": 0.0,
+            "end": 0.5,
+            "color": "#1B3A4B"
+          },
+          {
+            "label": "Managed",
+            "start": 0.5,
+            "end": 0.8,
+            "color": "#2EC4B6"
+          },
+          {
+            "label": "Critical",
+            "start": 0.8,
+            "end": 1.0,
+            "color": "#FF6F59"
+          }
+        ],
+        "supportingItems": [
+          {
+            "primary": "Remaining Budget",
+            "secondary": "\u00a317.5M"
+          },
+          {
+            "primary": "Wage Flex",
+            "secondary": "\u00a3180K p/w",
+            "tertiary": "Available"
+          }
+        ]
+      },
+      "activeDeals": [
+        {
+          "primary": "Ivan Toney",
+          "secondary": "\u00a355M",
+          "tertiary": "Negotiating",
+          "accent": "In Progress"
+        },
+        {
+          "primary": "Miguel Almir\u00f3n",
+          "secondary": "\u00a322M",
+          "tertiary": "Counter Offer",
+          "accent": "Hot"
+        }
+      ],
+      "negotiations": [
+        {
+          "id": "ivan-toney",
+          "player": "Ivan Toney",
+          "position": "ST (C)",
+          "club": "Brentford",
+          "stage": "Finalising Terms",
+          "status": "Negotiating",
+          "deadline": "5 days",
+          "summary": "Brentford want higher guaranteed fee and structured bonuses.",
+          "agent": "CAA Stellar",
+          "response": "Club wants \u00a360M upfront plus goal bonus.",
+          "accent": "In Progress",
+          "stageOptions": [
+            "Initial Talks",
+            "Negotiating",
+            "Finalising Terms",
+            "Waiting on Player"
+          ],
+          "statusOptions": [
+            "Monitoring",
+            "Negotiating",
+            "Accepted",
+            "Rejected"
+          ],
+          "terms": [
+            {
+              "id": "fee",
+              "label": "Transfer Fee",
+              "format": "\u00a3{0:0.0}M",
+              "minimum": 45.0,
+              "maximum": 70.0,
+              "step": 0.5,
+              "value": 55.0,
+              "target": 60.0,
+              "tooltip": "Guaranteed fee offered to Brentford."
+            },
+            {
+              "id": "wage",
+              "label": "Weekly Wages",
+              "format": "\u00a3{0:0}K p/w",
+              "minimum": 120.0,
+              "maximum": 250.0,
+              "step": 5.0,
+              "value": 180.0,
+              "target": 200.0,
+              "tooltip": "Weekly salary for the player."
+            },
+            {
+              "id": "bonus",
+              "label": "Signing Bonus",
+              "format": "\u00a3{0:0.0}M",
+              "minimum": 2.0,
+              "maximum": 8.0,
+              "step": 0.25,
+              "value": 3.5,
+              "target": 4.5,
+              "tooltip": "Upfront bonus requested by the agent."
+            }
+          ]
+        },
+        {
+          "id": "miguel-almiron",
+          "player": "Miguel Almir\u00f3n",
+          "position": "AM (R)",
+          "club": "Newcastle",
+          "stage": "Negotiating",
+          "status": "Counter Offer",
+          "deadline": "3 days",
+          "summary": "Newcastle expect structured add-ons linked to appearances.",
+          "agent": "ICM Stellar",
+          "response": "Player wants regular starts and appearance bonuses.",
+          "accent": "Hot",
+          "stageOptions": [
+            "Initial Talks",
+            "Negotiating",
+            "Club Review",
+            "Accepted"
+          ],
+          "statusOptions": [
+            "Monitoring",
+            "Counter Offer",
+            "Awaiting Response",
+            "Accepted"
+          ],
+          "terms": [
+            {
+              "id": "fee",
+              "label": "Transfer Fee",
+              "format": "\u00a3{0:0.0}M",
+              "minimum": 18.0,
+              "maximum": 30.0,
+              "step": 0.25,
+              "value": 22.0,
+              "target": 24.0,
+              "tooltip": "Guaranteed amount for Newcastle."
+            },
+            {
+              "id": "addon",
+              "label": "Add-Ons",
+              "format": "\u00a3{0:0.0}M",
+              "minimum": 0.0,
+              "maximum": 8.0,
+              "step": 0.25,
+              "value": 3.0,
+              "target": 5.0,
+              "tooltip": "Performance-based add-ons requested."
+            },
+            {
+              "id": "wage",
+              "label": "Weekly Wages",
+              "format": "\u00a3{0:0}K p/w",
+              "minimum": 80.0,
+              "maximum": 180.0,
+              "step": 5.0,
+              "value": 130.0,
+              "target": 140.0,
+              "tooltip": "Weekly salary proposal for the player."
+            }
+          ]
+        }
+      ],
+      "recentActivity": [
+        {
+          "primary": "Out",
+          "secondary": "Balogun to Monaco",
+          "tertiary": "\u00a335M"
+        },
+        {
+          "primary": "Loan",
+          "secondary": "Patino to Swansea",
+          "tertiary": "Season"
+        }
+      ],
+      "loanWatch": [
+        {
+          "primary": "Balogun",
+          "secondary": "Monaco",
+          "tertiary": "Goals: 4"
+        },
+        {
+          "primary": "Lokonga",
+          "secondary": "Burnley",
+          "tertiary": "Apps: 6"
+        }
+      ],
+      "clauses": [
+        {
+          "primary": "Saliba",
+          "secondary": "Lyon solidarity",
+          "tertiary": "\u00a32.1M"
+        },
+        {
+          "primary": "Toney",
+          "secondary": "Add-ons",
+          "tertiary": "\u00a35M goals bonus"
+        }
+      ]
+    },
+    "scouting": {
+      "assignments": [
+        {
+          "primary": "Iberia",
+          "secondary": "Advanced Playmaker",
+          "tertiary": "3 weeks"
+        },
+        {
+          "primary": "South America",
+          "secondary": "Pressing Forward",
+          "tertiary": "4 weeks"
+        }
+      ],
+      "focusRegions": [
+        {
+          "primary": "Spain",
+          "secondary": "High knowledge",
+          "accent": "95%"
+        },
+        {
+          "primary": "Brazil",
+          "secondary": "Growing",
+          "accent": "72%"
+        }
+      ],
+      "knowledgeLevels": [
+        {
+          "primary": "Europe",
+          "secondary": "Extensive"
+        },
+        {
+          "primary": "South America",
+          "secondary": "Comprehensive"
+        },
+        {
+          "primary": "Africa",
+          "secondary": "Average"
+        }
+      ],
+      "recommendedPlayers": [
+        {
+          "primary": "Pedro Neto",
+          "secondary": "Wolves",
+          "tertiary": "Transfer value \u00a345M",
+          "accent": "A"
+        },
+        {
+          "primary": "Jo\u00e3o Neves",
+          "secondary": "Benfica",
+          "tertiary": "Release clause \u00a395M",
+          "accent": "B"
+        }
+      ],
+      "shortTermFocus": [
+        {
+          "primary": "January Window",
+          "secondary": "Left-sided defender"
+        },
+        {
+          "primary": "Summer",
+          "secondary": "Elite striker"
+        }
+      ],
+      "assignmentBoard": [
+        {
+          "id": "assign-001",
+          "focus": "Iberia",
+          "role": "Advanced Playmaker",
+          "region": "Spain & Portugal",
+          "priority": "High",
+          "stage": "In Progress",
+          "deadline": "Due in 3 weeks",
+          "scout": "Helena Ruiz",
+          "notes": "Track Braga's midfield trio"
+        },
+        {
+          "id": "assign-002",
+          "focus": "South America",
+          "role": "Pressing Forward",
+          "region": "Brazil & Argentina",
+          "priority": "Medium",
+          "stage": "Awaiting Report",
+          "deadline": "Due in 4 weeks",
+          "scout": "Miguel Duarte",
+          "notes": "Follow Copa Libertadores knockout matches"
+        },
+        {
+          "id": "assign-003",
+          "focus": "Scandinavia",
+          "role": "Ball Playing Defender",
+          "region": "Norway & Sweden",
+          "priority": "Medium",
+          "stage": "New",
+          "deadline": "Due in 6 weeks",
+          "scout": "Liv Andersson",
+          "notes": "Identify U23 prospects"
+        }
+      ],
+      "scoutPool": [
+        {
+          "id": "scout-helena",
+          "name": "Helena Ruiz",
+          "region": "Iberia",
+          "availability": "1 assignment"
+        },
+        {
+          "id": "scout-miguel",
+          "name": "Miguel Duarte",
+          "region": "South America",
+          "availability": "2 assignments"
+        },
+        {
+          "id": "scout-liv",
+          "name": "Liv Andersson",
+          "region": "Scandinavia",
+          "availability": "Available"
+        },
+        {
+          "id": "scout-owen",
+          "name": "Owen Harris",
+          "region": "UK & Ireland",
+          "availability": "Available"
+        }
+      ],
+      "assignmentStages": [
+        "New",
+        "In Progress",
+        "Awaiting Report",
+        "Complete"
+      ],
+      "assignmentPriorities": [
+        "High",
+        "Medium",
+        "Low"
+      ]
+    },
+    "shortlist": {
+      "priorityTargets": [
+        {
+          "primary": "Pedro Neto",
+          "secondary": "Inside Forward",
+          "tertiary": "Expected cost \u00a345M",
+          "accent": "Priority"
+        },
+        {
+          "primary": "Jo\u0161ko Gvardiol",
+          "secondary": "Ball Playing CB",
+          "tertiary": "Expected cost \u00a375M"
+        }
+      ],
+      "contractStatus": [
+        {
+          "primary": "Neto",
+          "secondary": "2027",
+          "tertiary": "Wolves"
+        },
+        {
+          "primary": "Gvardiol",
+          "secondary": "2028",
+          "tertiary": "Man City"
+        }
+      ],
+      "competition": [
+        {
+          "primary": "Liverpool",
+          "secondary": "Monitoring Neto"
+        },
+        {
+          "primary": "Real Madrid",
+          "secondary": "Tracking Gvardiol"
+        }
+      ],
+      "notes": [
+        {
+          "primary": "Medical",
+          "secondary": "Monitor Neto hamstring history"
+        },
+        {
+          "primary": "Scouting",
+          "secondary": "Gvardiol excels in back three"
+        }
+      ],
+      "board": [
+        {
+          "id": "shortlist-001",
+          "name": "Pedro Neto",
+          "position": "Inside Forward",
+          "status": "Make Offer",
+          "action": "Advance",
+          "priority": "Priority",
+          "notes": "Squad agrees he is primary January target"
+        },
+        {
+          "id": "shortlist-002",
+          "name": "Jo\u0161ko Gvardiol",
+          "position": "Ball Playing Defender",
+          "status": "Monitor",
+          "action": "Scout",
+          "priority": "Watch",
+          "notes": "Wait for budget clarity before bidding"
+        },
+        {
+          "id": "shortlist-003",
+          "name": "Arthur Vermeeren",
+          "position": "Deep Lying Playmaker",
+          "status": "Scout",
+          "action": "Assign Scout",
+          "priority": "Development",
+          "notes": "Ideal for long-term midfield succession"
+        }
+      ],
+      "statusOptions": [
+        "Make Offer",
+        "Monitor",
+        "Scout",
+        "No Action"
+      ],
+      "actionOptions": [
+        "Advance",
+        "Assign Scout",
+        "Hold",
+        "Remove"
+      ]
+    }
+  },
+  "finance": {
+    "summary": {
+      "overallBalance": {
+        "metric": {
+          "value": "\u00a3182M",
+          "summary": "Balance boosted by Champions League revenue.",
+          "pill": "Healthy"
+        },
+        "minimum": 0,
+        "maximum": 250,
+        "value": 182,
+        "target": 200,
+        "unit": "\u00a3M",
+        "bands": [
+          {
+            "label": "Critical",
+            "start": 0.0,
+            "end": 0.3,
+            "color": "#FF6F59"
+          },
+          {
+            "label": "Stable",
+            "start": 0.3,
+            "end": 0.65,
+            "color": "#24577A"
+          },
+          {
+            "label": "Healthy",
+            "start": 0.65,
+            "end": 1.0,
+            "color": "#2EC4B6"
+          }
+        ],
+        "supportingItems": [
+          {
+            "primary": "Operating Cash",
+            "secondary": "\u00a394M"
+          },
+          {
+            "primary": "Transfer Reserve",
+            "secondary": "\u00a328M"
+          }
+        ]
+      },
+      "profitThisMonth": {
+        "metric": {
+          "value": "\u00a36.2M",
+          "summary": "Matchday receipts and merchandise strong.",
+          "pill": "+12%"
+        },
+        "points": [
+          {
+            "label": "Aug",
+            "value": 4.1
+          },
+          {
+            "label": "Sep",
+            "value": 4.8
+          },
+          {
+            "label": "Oct",
+            "value": 5.6
+          },
+          {
+            "label": "Nov",
+            "value": 6.0
+          },
+          {
+            "label": "Dec",
+            "value": 6.2
+          }
+        ]
+      },
+      "budgetAllocator": {
+        "commitLabel": "Save allocation",
+        "resetLabel": "Reset",
+        "summaryFormat": "{0:+\u00a3#,##0;-\u00a3#,##0;\u00a30} remaining \u2022 Total \u00a3{1:#,##0}",
+        "lines": [
+          {
+            "id": "transfer",
+            "label": "Transfer Budget",
+            "description": "Funds available for immediate transfers.",
+            "minimum": 30,
+            "maximum": 80,
+            "step": 1,
+            "value": 48,
+            "baseline": 48,
+            "format": "\u00a3{0:0}M",
+            "accent": "#2EC4B6"
+          },
+          {
+            "id": "wage",
+            "label": "Wage Budget",
+            "description": "Weekly salary allowance for the senior squad.",
+            "minimum": 2.5,
+            "maximum": 4.0,
+            "step": 0.1,
+            "value": 3.2,
+            "baseline": 3.2,
+            "format": "\u00a3{0:0.0}M p/w",
+            "accent": "#FF9F1C"
+          },
+          {
+            "id": "scouting",
+            "label": "Scouting Budget",
+            "description": "Global scouting initiatives and assignments.",
+            "minimum": 4,
+            "maximum": 10,
+            "step": 0.5,
+            "value": 6.5,
+            "baseline": 6.5,
+            "format": "\u00a3{0:0.0}M",
+            "accent": "#E71D36"
+          }
+        ]
+      },
+      "cashflow": {
+        "summaryLabel": "Net movement",
+        "summaryFormat": "\u00a3{0:0.0}M selected \u2022 \u00a3{1:0.0}M total",
+        "categories": [
+          {
+            "id": "matchday",
+            "name": "Matchday Income",
+            "description": "Gate receipts, hospitality, and concessions.",
+            "amount": 16.4,
+            "format": "\u00a3{0:0.0}M",
+            "accent": "#2EC4B6",
+            "items": [
+              {
+                "id": "ticketing",
+                "name": "Ticketing",
+                "amount": 10.2,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Season tickets and single match sales."
+              },
+              {
+                "id": "hospitality",
+                "name": "Hospitality",
+                "amount": 4.6,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Premium seating and lounge revenue."
+              },
+              {
+                "id": "concessions",
+                "name": "Concessions",
+                "amount": 1.6,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Retail, food, and beverage sales."
+              }
+            ]
+          },
+          {
+            "id": "commercial",
+            "name": "Commercial",
+            "description": "Broadcast and sponsorship receipts.",
+            "amount": 12.8,
+            "format": "\u00a3{0:0.0}M",
+            "accent": "#2EC4B6",
+            "items": [
+              {
+                "id": "broadcast",
+                "name": "Broadcast",
+                "amount": 7.5,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "League and continental distributions."
+              },
+              {
+                "id": "sponsorship",
+                "name": "Sponsorship",
+                "amount": 3.6,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Principal and secondary partners."
+              },
+              {
+                "id": "merchandise",
+                "name": "Merchandise",
+                "amount": 1.7,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Kits, retail, and licensing."
+              }
+            ]
+          },
+          {
+            "id": "operating",
+            "name": "Operating Costs",
+            "description": "Stadium, staffing, and club operations.",
+            "amount": -9.4,
+            "format": "\u00a3{0:0.0}M",
+            "accent": "#E71D36",
+            "items": [
+              {
+                "id": "facilities",
+                "name": "Facilities",
+                "amount": -3.2,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Maintenance and matchday operations."
+              },
+              {
+                "id": "staff",
+                "name": "Staffing",
+                "amount": -2.9,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Support staff and academy wages."
+              },
+              {
+                "id": "travel",
+                "name": "Travel & Logistics",
+                "amount": -3.3,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Domestic and continental travel programmes."
+              }
+            ]
+          },
+          {
+            "id": "transfers",
+            "name": "Transfer Activity",
+            "description": "Fees paid and received this window.",
+            "amount": -6.5,
+            "format": "\u00a3{0:0.0}M",
+            "accent": "#E71D36",
+            "items": [
+              {
+                "id": "incoming",
+                "name": "Incoming Fees",
+                "amount": -8.1,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Guaranteed fees for new signings."
+              },
+              {
+                "id": "outgoing",
+                "name": "Outgoing Receipts",
+                "amount": 1.6,
+                "format": "\u00a3{0:0.0}M",
+                "detail": "Sales and loan contributions."
+              }
+            ]
+          }
+        ]
+      },
+      "projections": [
+        {
+          "primary": "End of Season",
+          "secondary": "\u00a3210M",
+          "tertiary": "+\u00a328M"
+        },
+        {
+          "primary": "Two Year",
+          "secondary": "\u00a3238M",
+          "tertiary": "Stable"
+        }
+      ],
+      "debts": [
+        {
+          "primary": "Stadium Loan",
+          "secondary": "\u00a3145M",
+          "tertiary": "\u00a37M yearly"
+        }
+      ],
+      "sponsorDeals": [
+        {
+          "primary": "Emirates",
+          "secondary": "\u00a360M p/a",
+          "tertiary": "Expires 2028"
+        },
+        {
+          "primary": "Adidas",
+          "secondary": "\u00a355M p/a",
+          "tertiary": "Expires 2030"
+        }
+      ],
+      "scenarioBoard": {
+        "summaryLabel": "Scenario impact",
+        "summaryFormat": "\u00a3{0:+0.0;-0.0;0.0}M impact \u2022 {1} initiatives active",
+        "commitLabel": "Save scenarios",
+        "resetLabel": "Reset",
+        "options": [
+          {
+            "id": "stadium-expansion",
+            "title": "Stadium Expansion",
+            "detail": "Phase two capacity project with premium seating.",
+            "impact": -12.5,
+            "format": "\u00a3{0:+0.0;-0.0;0.0}M",
+            "isSelected": true,
+            "accent": "#FF9F1C"
+          },
+          {
+            "id": "academy-upgrade",
+            "title": "Academy Upgrade",
+            "detail": "Improve youth facilities and staffing.",
+            "impact": -3.8,
+            "format": "\u00a3{0:+0.0;-0.0;0.0}M",
+            "isSelected": false,
+            "accent": "#E71D36"
+          },
+          {
+            "id": "new-partner",
+            "title": "New Commercial Partner",
+            "detail": "Regional sponsorship opportunity awaiting approval.",
+            "impact": 5.2,
+            "format": "\u00a3{0:+0.0;-0.0;0.0}M",
+            "isSelected": true,
+            "accent": "#2EC4B6"
+          }
+        ]
+      },
+      "forecast": {
+        "sliderLabel": "Budget allocation",
+        "valueDisplayFormat": "{0:0}% allocation",
+        "commitLabel": "Save scenario",
+        "summaryLabel": "Projected balance",
+        "minimum": 70,
+        "maximum": 130,
+        "step": 1,
+        "currentPercentage": 100,
+        "impacts": [
+          {
+            "label": "Projected Balance",
+            "format": "\u00a3{0:0.0}M",
+            "baseValue": 182.0,
+            "sensitivity": 0.42
+          },
+          {
+            "label": "Transfer Budget",
+            "format": "\u00a3{0:0.0}M",
+            "baseValue": 48.0,
+            "sensitivity": 0.28
+          },
+          {
+            "label": "Wage Budget",
+            "format": "\u00a3{0:0.00}M p/w",
+            "baseValue": 3.2,
+            "sensitivity": 0.015
+          }
+        ]
+      }
+    },
+    "income": {
+      "revenueStreams": [
+        {
+          "primary": "Matchday",
+          "secondary": "\u00a33.8M"
+        },
+        {
+          "primary": "Broadcast",
+          "secondary": "\u00a34.6M"
+        },
+        {
+          "primary": "Commercial",
+          "secondary": "\u00a32.4M"
+        }
+      ],
+      "matchdayIncome": [
+        {
+          "primary": "Ticket Sales",
+          "secondary": "\u00a32.1M"
+        },
+        {
+          "primary": "Hospitality",
+          "secondary": "\u00a31.2M"
+        },
+        {
+          "primary": "Retail",
+          "secondary": "\u00a30.5M"
+        }
+      ],
+      "commercialIncome": [
+        {
+          "primary": "Merchandise",
+          "secondary": "+18% YoY"
+        },
+        {
+          "primary": "Sponsorship",
+          "secondary": "+6% YoY"
+        }
+      ],
+      "competitionPrizes": [
+        {
+          "primary": "Champions League",
+          "secondary": "\u00a37.4M",
+          "tertiary": "Group bonus"
+        },
+        {
+          "primary": "Premier League",
+          "secondary": "\u00a32.6M",
+          "tertiary": "Television"
+        }
+      ]
+    },
+    "expenditure": {
+      "majorCosts": [
+        {
+          "primary": "Wages",
+          "secondary": "\u00a32.9M p/w"
+        },
+        {
+          "primary": "Bonuses",
+          "secondary": "\u00a30.6M"
+        }
+      ],
+      "wageBreakdown": [
+        {
+          "primary": "First Team",
+          "secondary": "\u00a32.1M"
+        },
+        {
+          "primary": "U21",
+          "secondary": "\u00a30.4M"
+        },
+        {
+          "primary": "U18",
+          "secondary": "\u00a30.2M"
+        }
+      ],
+      "transferSpending": [
+        {
+          "primary": "Incoming",
+          "secondary": "\u00a377M"
+        },
+        {
+          "primary": "Outgoing",
+          "secondary": "\u00a344M"
+        }
+      ],
+      "operationalCosts": [
+        {
+          "primary": "Facilities",
+          "secondary": "\u00a31.1M"
+        },
+        {
+          "primary": "Travel",
+          "secondary": "\u00a30.4M"
+        },
+        {
+          "primary": "Academy",
+          "secondary": "\u00a30.7M"
+        }
+      ]
+    }
+  },
+  "fixtures": {
+    "schedule": {
+      "upcomingFixtures": [
+        {
+          "primary": "vs Man City",
+          "secondary": "Sat 17:30",
+          "tertiary": "Premier League"
+        },
+        {
+          "primary": "@ Sevilla",
+          "secondary": "Tue 20:00",
+          "tertiary": "Champions League"
+        },
+        {
+          "primary": "vs Spurs",
+          "secondary": "Sun 16:30",
+          "tertiary": "Premier League"
+        }
+      ],
+      "fixtureTimeline": {
+        "events": [
+          {
+            "label": "Man City",
+            "detail": "Premier League",
+            "position": 0.05,
+            "pill": "Home",
+            "accent": "#2EC4B6"
+          },
+          {
+            "label": "Sevilla",
+            "detail": "Champions League",
+            "position": 0.25,
+            "pill": "Away",
+            "accent": "#FF9F1C"
+          },
+          {
+            "label": "Spurs",
+            "detail": "Premier League",
+            "position": 0.45,
+            "pill": "Home",
+            "accent": "#2EC4B6"
+          },
+          {
+            "label": "Wolves",
+            "detail": "Premier League",
+            "position": 0.68,
+            "pill": "Away",
+            "accent": "#FF9F1C"
+          },
+          {
+            "label": "PSG",
+            "detail": "Champions League",
+            "position": 0.9,
+            "pill": "Home",
+            "accent": "#7A5CFF"
+          }
+        ]
+      },
+      "travelPlans": [
+        {
+          "primary": "Manchester",
+          "secondary": "Train",
+          "tertiary": "Same day"
+        },
+        {
+          "primary": "Seville",
+          "secondary": "Flight",
+          "tertiary": "Depart Mon"
+        }
+      ],
+      "broadcasts": [
+        {
+          "primary": "Sky Sports",
+          "secondary": "vs Man City"
+        },
+        {
+          "primary": "BT Sport",
+          "secondary": "@ Sevilla"
+        }
+      ],
+      "preparationFocus": [
+        {
+          "primary": "Rest Windows",
+          "secondary": "Regenerate after European trip"
+        },
+        {
+          "primary": "Rotation",
+          "secondary": "Use Hale End graduates vs Spurs"
+        }
+      ]
+    },
+    "results": {
+      "recentResults": [
+        {
+          "primary": "vs Chelsea",
+          "secondary": "W 2-0",
+          "tertiary": "Saka (2)"
+        },
+        {
+          "primary": "@ Brentford",
+          "secondary": "D 1-1",
+          "tertiary": "Toney"
+        },
+        {
+          "primary": "vs Brighton",
+          "secondary": "W 3-1",
+          "tertiary": "Martinelli, Rice, Saka"
+        }
+      ],
+      "playerRatings": [
+        {
+          "primary": "Saliba",
+          "secondary": "8.2",
+          "tertiary": "MOTM vs Chelsea"
+        },
+        {
+          "primary": "Ramsdale",
+          "secondary": "7.9",
+          "tertiary": "Clean sheet"
+        }
+      ],
+      "trends": [
+        {
+          "primary": "Clean Sheets",
+          "secondary": "3 in last 5"
+        },
+        {
+          "primary": "Goals Scored",
+          "secondary": "10 in last 5"
+        }
+      ],
+      "keyMoments": [
+        {
+          "primary": "\u00d8degaard FK",
+          "secondary": "vs Brighton"
+        },
+        {
+          "primary": "Rice winner",
+          "secondary": "vs Chelsea"
+        }
+      ]
+    },
+    "calendar": {
+      "monthOverview": [
+        {
+          "primary": "October Week 1",
+          "secondary": "3 fixtures"
+        },
+        {
+          "primary": "October Week 2",
+          "secondary": "International break"
+        },
+        {
+          "primary": "October Week 3",
+          "secondary": "Two home matches"
+        }
+      ],
+      "cupDraws": [
+        {
+          "primary": "FA Cup 4th Round",
+          "secondary": "Draw on 15 Oct"
+        }
+      ],
+      "internationalBreaks": [
+        {
+          "primary": "9 Oct - 17 Oct",
+          "secondary": "Most squad away"
+        }
+      ],
+      "reminders": [
+        {
+          "primary": "Register U21 players",
+          "secondary": "Before 20 Oct"
+        },
+        {
+          "primary": "Submit Champions League squad",
+          "secondary": "1 Feb"
+        }
+      ],
+      "filters": [
+        {
+          "id": "all",
+          "displayName": "All Competitions",
+          "isDefault": true,
+          "competitions": []
+        },
+        {
+          "id": "premier-league",
+          "displayName": "Premier League",
+          "isDefault": false,
+          "competitions": [
+            "Premier League"
+          ]
+        },
+        {
+          "id": "champions-league",
+          "displayName": "Champions League",
+          "isDefault": false,
+          "competitions": [
+            "Champions League"
+          ]
+        },
+        {
+          "id": "fa-cup",
+          "displayName": "FA Cup",
+          "isDefault": false,
+          "competitions": [
+            "FA Cup"
+          ]
+        }
+      ],
+      "weeks": [
+        {
+          "label": "Week Commencing 7 Oct",
+          "days": [
+            {
+              "label": "Mon",
+              "date": "7 Oct",
+              "matches": []
+            },
+            {
+              "label": "Tue",
+              "date": "8 Oct",
+              "matches": [
+                {
+                  "id": "fixture-sevilla-away",
+                  "day": "Tue",
+                  "kickOff": "20:00",
+                  "competition": "Champions League",
+                  "opponent": "Sevilla",
+                  "venue": "Ramon S\u00e1nchez-Pizju\u00e1n",
+                  "isHome": false,
+                  "importance": "High",
+                  "broadcast": "BT Sport",
+                  "travelNote": "Flight departs Mon 10:00",
+                  "preparationNote": "Focus on pressing triggers",
+                  "status": "Scouting underway",
+                  "competitionAccent": "#7A5CFF",
+                  "keyPeople": [
+                    {
+                      "primary": "Lead Analyst",
+                      "secondary": "Luis Garc\u00eda"
+                    },
+                    {
+                      "primary": "Travel",
+                      "secondary": "Maria Spencer"
+                    }
+                  ],
+                  "preparation": [
+                    {
+                      "primary": "Opposition Report",
+                      "secondary": "Due Fri"
+                    },
+                    {
+                      "primary": "Recovery",
+                      "secondary": "Schedule lighter session Thu"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "Wed",
+              "date": "9 Oct",
+              "matches": []
+            },
+            {
+              "label": "Thu",
+              "date": "10 Oct",
+              "matches": []
+            },
+            {
+              "label": "Fri",
+              "date": "11 Oct",
+              "matches": []
+            },
+            {
+              "label": "Sat",
+              "date": "12 Oct",
+              "matches": [
+                {
+                  "id": "fixture-spurs-home",
+                  "day": "Sat",
+                  "kickOff": "16:30",
+                  "competition": "Premier League",
+                  "opponent": "Tottenham Hotspur",
+                  "venue": "Emirates Stadium",
+                  "isHome": true,
+                  "importance": "Derby",
+                  "broadcast": "Sky Sports",
+                  "travelNote": "Team hotel Friday night",
+                  "preparationNote": "Set-piece focus vs man marking",
+                  "status": "Ticket allocation confirmed",
+                  "competitionAccent": "#2EC4B6",
+                  "keyPeople": [
+                    {
+                      "primary": "Match Delegate",
+                      "secondary": "Sarah Powell"
+                    },
+                    {
+                      "primary": "Security",
+                      "secondary": "Derby day operations"
+                    }
+                  ],
+                  "preparation": [
+                    {
+                      "primary": "Derby Briefing",
+                      "secondary": "Leadership group Thu"
+                    },
+                    {
+                      "primary": "Officials",
+                      "secondary": "Tierney assigned"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "Sun",
+              "date": "13 Oct",
+              "matches": []
+            }
+          ]
+        },
+        {
+          "label": "Week Commencing 14 Oct",
+          "days": [
+            {
+              "label": "Mon",
+              "date": "14 Oct",
+              "matches": []
+            },
+            {
+              "label": "Tue",
+              "date": "15 Oct",
+              "matches": []
+            },
+            {
+              "label": "Wed",
+              "date": "16 Oct",
+              "matches": []
+            },
+            {
+              "label": "Thu",
+              "date": "17 Oct",
+              "matches": []
+            },
+            {
+              "label": "Fri",
+              "date": "18 Oct",
+              "matches": []
+            },
+            {
+              "label": "Sat",
+              "date": "19 Oct",
+              "matches": [
+                {
+                  "id": "fixture-leeds-fa",
+                  "day": "Sat",
+                  "kickOff": "12:30",
+                  "competition": "FA Cup",
+                  "opponent": "Leeds United",
+                  "venue": "Elland Road",
+                  "isHome": false,
+                  "importance": "Cup",
+                  "broadcast": "BBC One",
+                  "travelNote": "Coach departs Fri 14:00",
+                  "preparationNote": "Rotate squad, monitor minutes",
+                  "status": "Rotation planned",
+                  "competitionAccent": "#FF9F1C",
+                  "keyPeople": [
+                    {
+                      "primary": "Squad Rotation",
+                      "secondary": "Give minutes to Hale End"
+                    }
+                  ],
+                  "preparation": [
+                    {
+                      "primary": "Pitch Inspection",
+                      "secondary": "Fri evening"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "Sun",
+              "date": "20 Oct",
+              "matches": []
+            }
+          ]
+        },
+        {
+          "label": "Week Commencing 21 Oct",
+          "days": [
+            {
+              "label": "Mon",
+              "date": "21 Oct",
+              "matches": []
+            },
+            {
+              "label": "Tue",
+              "date": "22 Oct",
+              "matches": [
+                {
+                  "id": "fixture-psg-home",
+                  "day": "Tue",
+                  "kickOff": "20:00",
+                  "competition": "Champions League",
+                  "opponent": "Paris Saint-Germain",
+                  "venue": "Emirates Stadium",
+                  "isHome": true,
+                  "importance": "High",
+                  "broadcast": "BT Sport",
+                  "travelNote": "VIP hospitality extended",
+                  "preparationNote": "Manage Mbapp\u00e9 threat",
+                  "status": "Sold out",
+                  "competitionAccent": "#7A5CFF",
+                  "keyPeople": [
+                    {
+                      "primary": "Hospitality",
+                      "secondary": "Legends lounge upgrade"
+                    }
+                  ],
+                  "preparation": [
+                    {
+                      "primary": "Opponent Analysis",
+                      "secondary": "Mbapp\u00e9 & Demb\u00e9l\u00e9 patterns"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "Wed",
+              "date": "23 Oct",
+              "matches": []
+            },
+            {
+              "label": "Thu",
+              "date": "24 Oct",
+              "matches": []
+            },
+            {
+              "label": "Fri",
+              "date": "25 Oct",
+              "matches": []
+            },
+            {
+              "label": "Sat",
+              "date": "26 Oct",
+              "matches": [
+                {
+                  "id": "fixture-wolves-home",
+                  "day": "Sat",
+                  "kickOff": "17:30",
+                  "competition": "Premier League",
+                  "opponent": "Wolverhampton",
+                  "venue": "Emirates Stadium",
+                  "isHome": true,
+                  "importance": "Medium",
+                  "result": "-",
+                  "broadcast": "Sky Sports",
+                  "travelNote": "Home fixture",
+                  "preparationNote": "Emphasise transitions",
+                  "status": "Media duties assigned",
+                  "competitionAccent": "#2EC4B6",
+                  "keyPeople": [
+                    {
+                      "primary": "Media",
+                      "secondary": "Arteta + new signing"
+                    }
+                  ],
+                  "preparation": [
+                    {
+                      "primary": "Scouting Update",
+                      "secondary": "Pedro Neto fitness check"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "label": "Sun",
+              "date": "27 Oct",
+              "matches": []
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/WPF/FMUI.Wpf/FMUI.Wpf.csproj
+++ b/WPF/FMUI.Wpf/FMUI.Wpf.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="app.manifest" />
+    <None Update="Data\club-data.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="Views\MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\CardSurfaceView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\TrainingCalendarView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\TrainingProgressionView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Resources\Theme.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+</Project>

--- a/WPF/FMUI.Wpf/Infrastructure/AsyncRelayCommand.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/AsyncRelayCommand.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public sealed class AsyncRelayCommand : ICommand
+{
+    private readonly Func<object?, Task> _execute;
+    private readonly Func<object?, bool>? _canExecute;
+    private bool _isExecuting;
+
+    public AsyncRelayCommand(Func<Task> execute)
+        : this(_ => execute(), _ => true)
+    {
+    }
+
+    public AsyncRelayCommand(Func<Task> execute, Func<bool> canExecute)
+        : this(_ => execute(), _ => canExecute())
+    {
+    }
+
+    public AsyncRelayCommand(Func<object?, Task> execute)
+        : this(execute, _ => true)
+    {
+    }
+
+    public AsyncRelayCommand(Func<object?, Task> execute, Func<object?, bool>? canExecute)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter)
+    {
+        if (_isExecuting)
+        {
+            return false;
+        }
+
+        return _canExecute?.Invoke(parameter) ?? true;
+    }
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute(parameter);
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/WPF/FMUI.Wpf/Infrastructure/Behaviors/ListBoxDragReorderBehavior.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/Behaviors/ListBoxDragReorderBehavior.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace FMUI.Wpf.Infrastructure.Behaviors;
+
+public static class ListBoxDragReorderBehavior
+{
+    private const string DragDataFormat = "FMUI.Wpf.ListBoxDragReorderBehavior.Item";
+
+    public static readonly DependencyProperty EnableReorderProperty = DependencyProperty.RegisterAttached(
+        "EnableReorder",
+        typeof(bool),
+        typeof(ListBoxDragReorderBehavior),
+        new PropertyMetadata(false, OnEnableReorderChanged));
+
+    private static readonly Dictionary<ListBox, Point> DragStartPoints = new();
+
+    public static bool GetEnableReorder(DependencyObject obj) => (bool)obj.GetValue(EnableReorderProperty);
+
+    public static void SetEnableReorder(DependencyObject obj, bool value) => obj.SetValue(EnableReorderProperty, value);
+
+    private static void OnEnableReorderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ListBox listBox)
+        {
+            return;
+        }
+
+        var enable = (bool)e.NewValue;
+        if (enable)
+        {
+            listBox.AllowDrop = true;
+            listBox.PreviewMouseLeftButtonDown += OnPreviewMouseLeftButtonDown;
+            listBox.PreviewMouseMove += OnPreviewMouseMove;
+            listBox.Drop += OnDrop;
+            listBox.DragOver += OnDragOver;
+        }
+        else
+        {
+            listBox.AllowDrop = false;
+            listBox.PreviewMouseLeftButtonDown -= OnPreviewMouseLeftButtonDown;
+            listBox.PreviewMouseMove -= OnPreviewMouseMove;
+            listBox.Drop -= OnDrop;
+            listBox.DragOver -= OnDragOver;
+            DragStartPoints.Remove(listBox);
+        }
+    }
+
+    private static void OnPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not ListBox listBox)
+        {
+            return;
+        }
+
+        var item = GetItemContainer(listBox, e.OriginalSource as DependencyObject);
+        if (item is null || IsTextBoxDescendant(e.OriginalSource as DependencyObject))
+        {
+            return;
+        }
+
+        DragStartPoints[listBox] = e.GetPosition(listBox);
+    }
+
+    private static void OnPreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (sender is not ListBox listBox)
+        {
+            return;
+        }
+
+        if (e.LeftButton != MouseButtonState.Pressed)
+        {
+            DragStartPoints.Remove(listBox);
+            return;
+        }
+
+        if (!DragStartPoints.TryGetValue(listBox, out var startPoint))
+        {
+            return;
+        }
+
+        var currentPoint = e.GetPosition(listBox);
+        if (Math.Abs(currentPoint.X - startPoint.X) < SystemParameters.MinimumHorizontalDragDistance &&
+            Math.Abs(currentPoint.Y - startPoint.Y) < SystemParameters.MinimumVerticalDragDistance)
+        {
+            return;
+        }
+
+        var item = GetItemContainer(listBox, e.OriginalSource as DependencyObject);
+        if (item is null)
+        {
+            return;
+        }
+
+        var data = listBox.ItemContainerGenerator.ItemFromContainer(item);
+        if (data is null)
+        {
+            return;
+        }
+
+        listBox.SelectedItem = data;
+        DragStartPoints.Remove(listBox);
+        var dragData = new DataObject(DragDataFormat, data);
+        DragDrop.DoDragDrop(listBox, dragData, DragDropEffects.Move);
+    }
+
+    private static void OnDragOver(object sender, DragEventArgs e)
+    {
+        if (sender is not ListBox listBox)
+        {
+            return;
+        }
+
+        if (!e.Data.GetDataPresent(DragDataFormat) || listBox.ItemsSource is not IList)
+        {
+            e.Effects = DragDropEffects.None;
+            e.Handled = true;
+            return;
+        }
+
+        e.Effects = DragDropEffects.Move;
+        e.Handled = true;
+    }
+
+    private static void OnDrop(object sender, DragEventArgs e)
+    {
+        if (sender is not ListBox listBox || listBox.ItemsSource is not IList items)
+        {
+            return;
+        }
+
+        if (!e.Data.GetDataPresent(DragDataFormat))
+        {
+            e.Handled = true;
+            return;
+        }
+
+        var data = e.Data.GetData(DragDataFormat);
+        if (data is null)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        var oldIndex = items.IndexOf(data);
+        if (oldIndex < 0)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        var targetContainer = GetItemContainer(listBox, e.OriginalSource as DependencyObject);
+        var newIndex = items.Count;
+        if (targetContainer is not null)
+        {
+            newIndex = listBox.ItemContainerGenerator.IndexFromContainer(targetContainer);
+            if (newIndex < 0)
+            {
+                newIndex = items.Count;
+            }
+            else
+            {
+                var position = e.GetPosition(targetContainer);
+                if (position.Y > targetContainer.ActualHeight / 2)
+                {
+                    newIndex++;
+                }
+            }
+        }
+
+        if (newIndex == oldIndex)
+        {
+            e.Handled = true;
+            return;
+        }
+
+        Move(items, oldIndex, newIndex);
+        listBox.SelectedItem = data;
+        e.Handled = true;
+    }
+
+    private static void Move(IList items, int oldIndex, int newIndex)
+    {
+        if (newIndex >= items.Count)
+        {
+            newIndex = items.Count - 1;
+        }
+
+        if (newIndex < 0)
+        {
+            newIndex = 0;
+        }
+
+        if (oldIndex == newIndex)
+        {
+            return;
+        }
+
+        // Try to use ObservableCollection<T>.Move via reflection when available.
+        var moveMethod = items.GetType().GetMethod(
+            "Move",
+            BindingFlags.Public | BindingFlags.Instance,
+            null,
+            new[] { typeof(int), typeof(int) },
+            null);
+        if (moveMethod is not null)
+        {
+            moveMethod.Invoke(items, new object[] { oldIndex, newIndex });
+            return;
+        }
+
+        var item = items[oldIndex];
+        items.RemoveAt(oldIndex);
+        if (oldIndex < newIndex)
+        {
+            newIndex--;
+        }
+
+        if (newIndex > items.Count)
+        {
+            newIndex = items.Count;
+        }
+
+        items.Insert(newIndex, item);
+    }
+
+    private static ListBoxItem? GetItemContainer(ItemsControl listBox, DependencyObject? originalSource)
+    {
+        return originalSource is null ? null : FindVisualParent<ListBoxItem>(originalSource);
+    }
+
+    private static bool IsTextBoxDescendant(DependencyObject? source)
+    {
+        return source is not null && FindVisualParent<TextBoxBase>(source) is not null;
+    }
+
+    private static T? FindVisualParent<T>(DependencyObject? child) where T : DependencyObject
+    {
+        while (child is not null)
+        {
+            if (child is T typed)
+            {
+                return typed;
+            }
+
+            child = VisualTreeHelper.GetParent(child);
+        }
+
+        return null;
+    }
+}

--- a/WPF/FMUI.Wpf/Infrastructure/EventAggregator.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/EventAggregator.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public interface IEventAggregator
+{
+    void Publish<TEvent>(TEvent eventData);
+    IDisposable Subscribe<TEvent>(Action<TEvent> handler);
+}
+
+public sealed class EventAggregator : IEventAggregator
+{
+    private readonly ConcurrentDictionary<Type, List<ISubscription>> _subscriptions = new();
+
+    public void Publish<TEvent>(TEvent eventData)
+    {
+        if (eventData is null)
+        {
+            throw new ArgumentNullException(nameof(eventData));
+        }
+
+        if (_subscriptions.TryGetValue(typeof(TEvent), out var handlers))
+        {
+            ISubscription[] snapshot;
+            lock (handlers)
+            {
+                snapshot = handlers.ToArray();
+            }
+
+            foreach (var subscription in snapshot)
+            {
+                subscription.Invoke(eventData);
+            }
+        }
+    }
+
+    public IDisposable Subscribe<TEvent>(Action<TEvent> handler)
+    {
+        if (handler is null)
+        {
+            throw new ArgumentNullException(nameof(handler));
+        }
+
+        var subscription = new Subscription<TEvent>(this, handler);
+        var handlers = _subscriptions.GetOrAdd(typeof(TEvent), _ => new List<ISubscription>());
+
+        lock (handlers)
+        {
+            handlers.Add(subscription);
+        }
+
+        return subscription;
+    }
+
+    private void Unsubscribe(Type eventType, ISubscription subscription)
+    {
+        if (_subscriptions.TryGetValue(eventType, out var handlers))
+        {
+            lock (handlers)
+            {
+                handlers.Remove(subscription);
+            }
+        }
+    }
+
+    private interface ISubscription : IDisposable
+    {
+        void Invoke(object eventData);
+    }
+
+    private sealed class Subscription<TEvent> : ISubscription
+    {
+        private readonly EventAggregator _owner;
+        private readonly Action<TEvent> _handler;
+        private bool _isDisposed;
+
+        public Subscription(EventAggregator owner, Action<TEvent> handler)
+        {
+            _owner = owner;
+            _handler = handler;
+        }
+
+        public void Invoke(object eventData)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (eventData is TEvent typed)
+            {
+                _handler(typed);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            _owner.Unsubscribe(typeof(TEvent), this);
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/Infrastructure/NavigationSectionChangedEvent.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/NavigationSectionChangedEvent.cs
@@ -1,0 +1,3 @@
+namespace FMUI.Wpf.Infrastructure;
+
+public sealed record NavigationSectionChangedEvent(string TabIdentifier, string? SectionIdentifier);

--- a/WPF/FMUI.Wpf/Infrastructure/ObservableObject.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/ObservableObject.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public abstract class ObservableObject : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(storage, value))
+        {
+            return false;
+        }
+
+        storage = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/WPF/FMUI.Wpf/Infrastructure/RelayCommand.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/RelayCommand.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Windows.Input;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public sealed class RelayCommand : ICommand
+{
+    private readonly Action<object?> _execute;
+    private readonly Func<object?, bool>? _canExecute;
+
+    public RelayCommand(Action execute)
+        : this(_ => execute(), _ => true)
+    {
+    }
+
+    public RelayCommand(Action execute, Func<bool> canExecute)
+        : this(_ => execute(), _ => canExecute())
+    {
+    }
+
+    public RelayCommand(Action<object?> execute)
+        : this(execute, _ => true)
+    {
+    }
+
+    public RelayCommand(Action<object?> execute, Func<object?, bool>? canExecute)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
+
+    public void Execute(object? parameter) => _execute(parameter);
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/WPF/FMUI.Wpf/Models/CardInteractionModels.cs
+++ b/WPF/FMUI.Wpf/Models/CardInteractionModels.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace FMUI.Wpf.Models;
+
+public readonly record struct CardDragDelta(double HorizontalChange, double VerticalChange);
+
+public readonly record struct CardDragCompleted(bool Canceled);
+
+public enum ResizeHandle
+{
+    East,
+    South,
+    SouthEast
+}
+
+public readonly record struct CardResizeDelta(ResizeHandle Handle, double HorizontalChange, double VerticalChange);
+
+public readonly record struct CardResizeCompleted(ResizeHandle Handle, bool Canceled);
+
+public readonly record struct CardGeometry(int Column, int Row, int ColumnSpan, int RowSpan);
+
+public readonly record struct CardGeometrySnapshot(string CardId, CardGeometry Geometry);
+
+public readonly record struct CardPreviewSnapshot(string CardId, CardGeometry Geometry, bool IsValid);
+
+public readonly record struct FormationPlayerDragDelta(double HorizontalChange, double VerticalChange, double PitchWidth, double PitchHeight, double TokenSize);
+
+public readonly record struct FormationPlayerDragCompleted(bool Canceled);
+
+public readonly record struct FormationPlayerPositionSnapshot(string CardId, string PlayerId, double X, double Y);
+
+public enum SelectionModifier
+{
+    Replace,
+    Add,
+    Toggle
+}
+
+public readonly record struct CardHistoryEntry(
+    IReadOnlyList<CardGeometrySnapshot> GeometryBefore,
+    IReadOnlyList<CardGeometrySnapshot> GeometryAfter,
+    IReadOnlyList<FormationPlayerPositionSnapshot> PlayersBefore,
+    IReadOnlyList<FormationPlayerPositionSnapshot> PlayersAfter);

--- a/WPF/FMUI.Wpf/Models/CardLayoutStateSnapshot.cs
+++ b/WPF/FMUI.Wpf/Models/CardLayoutStateSnapshot.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace FMUI.Wpf.Models;
+
+public sealed class CardLayoutStateSnapshot
+{
+    public CardLayoutStateSnapshot()
+        : this(
+            new Dictionary<string, Dictionary<string, Dictionary<string, CardGeometry>>>(),
+            new Dictionary<string, Dictionary<string, Dictionary<string, Dictionary<string, FormationPlayerState>>>>>())
+    {
+    }
+
+    [JsonConstructor]
+    public CardLayoutStateSnapshot(
+        Dictionary<string, Dictionary<string, Dictionary<string, CardGeometry>>> layouts,
+        Dictionary<string, Dictionary<string, Dictionary<string, Dictionary<string, FormationPlayerState>>>>> formations)
+    {
+        Layouts = layouts ?? new Dictionary<string, Dictionary<string, Dictionary<string, CardGeometry>>>();
+        Formations = formations ?? new Dictionary<string, Dictionary<string, Dictionary<string, Dictionary<string, FormationPlayerState>>>>>();
+    }
+
+    public Dictionary<string, Dictionary<string, Dictionary<string, CardGeometry>>> Layouts { get; }
+
+    public Dictionary<string, Dictionary<string, Dictionary<string, Dictionary<string, FormationPlayerState>>>>> Formations { get; }
+
+    public static CardLayoutStateSnapshot Empty { get; } = new();
+}
+
+public sealed record FormationPlayerState(string PlayerId, double X, double Y);

--- a/WPF/FMUI.Wpf/Models/CardModels.cs
+++ b/WPF/FMUI.Wpf/Models/CardModels.cs
@@ -1,0 +1,440 @@
+using System.Collections.Generic;
+
+namespace FMUI.Wpf.Models;
+
+public enum CardKind
+{
+    Metric,
+    List,
+    Formation,
+    Fixture,
+    Status,
+    LineChart,
+    Gauge,
+    Timeline,
+    TrainingCalendar,
+    Forecast,
+    WorkloadHeatmap,
+    MoraleHeatmap,
+    SquadTable,
+    FixtureCalendar,
+    TransferNegotiation,
+    ScoutAssignments,
+    ShortlistBoard,
+    TrainingUnitBoard,
+    TrainingProgression,
+    ShotMap,
+    MedicalTimeline,
+    ClubVisionRoadmap,
+    ClubVisionExpectations,
+    FinanceCashflow,
+    FinanceBudgetAllocator,
+    FinanceScenarioBoard
+}
+
+public sealed record ChartDataPointDefinition(string Label, double Value);
+
+public sealed record ChartSeriesDefinition(string Name, string Color, IReadOnlyList<ChartDataPointDefinition> Points);
+
+public sealed record GaugeBandDefinition(string Label, double Start, double End, string Color);
+
+public sealed record GaugeDefinition(
+    double Minimum,
+    double Maximum,
+    double Value,
+    double Target,
+    string Unit,
+    IReadOnlyList<GaugeBandDefinition> Bands,
+    string? DisplayValue = null,
+    string? DisplaySummary = null,
+    string? DisplayPill = null);
+
+public sealed record TimelineEntryDefinition(string Label, string? Detail, double Position, string? Pill = null, string? Accent = null);
+
+public sealed record CardListItem(string Primary, string? Secondary = null, string? Tertiary = null, string? Accent = null);
+
+public sealed record ScoutOptionDefinition(string Id, string Name, string Region, string Availability);
+
+public sealed record ScoutAssignmentDefinition(
+    string Id,
+    string Focus,
+    string Role,
+    string Region,
+    string Priority,
+    string Stage,
+    string Deadline,
+    string Scout,
+    string? Notes = null);
+
+public sealed record ScoutAssignmentBoardDefinition(
+    IReadOnlyList<ScoutAssignmentDefinition> Assignments,
+    IReadOnlyList<string> StageOptions,
+    IReadOnlyList<string> PriorityOptions,
+    IReadOnlyList<ScoutOptionDefinition> ScoutOptions);
+
+public sealed record ShortlistPlayerDefinition(
+    string Id,
+    string Name,
+    string Position,
+    string Status,
+    string Action,
+    string? Priority = null,
+    string? Notes = null);
+
+public sealed record ShortlistBoardDefinition(
+    IReadOnlyList<ShortlistPlayerDefinition> Players,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<string> ActionOptions);
+
+public sealed record TrainingUnitCoachOptionDefinition(string Id, string Name, string? Accent = null);
+
+public sealed record TrainingUnitMemberDefinition(
+    string Id,
+    string Name,
+    string Position,
+    string Role,
+    string Status,
+    string? Accent = null,
+    string? Detail = null);
+
+public sealed record TrainingUnitGroupDefinition(
+    string Id,
+    string Name,
+    string? CoachId,
+    string? CoachName,
+    string? CoachAccent,
+    IReadOnlyList<TrainingUnitCoachOptionDefinition> CoachOptions,
+    IReadOnlyList<TrainingUnitMemberDefinition> Members);
+
+public sealed record TrainingUnitBoardDefinition(
+    IReadOnlyList<TrainingUnitGroupDefinition> Units,
+    IReadOnlyList<TrainingUnitMemberDefinition> AvailablePlayers);
+
+public sealed record TrainingProgressionPointDefinition(string Period, double Value, string? Detail = null);
+
+public sealed record TrainingProgressionSeriesDefinition(
+    string Id,
+    string Name,
+    string Color,
+    string? Accent,
+    bool IsHighlighted,
+    IReadOnlyList<TrainingProgressionPointDefinition> Points);
+
+public sealed record TrainingProgressionDefinition(
+    IReadOnlyList<string> Periods,
+    double Minimum,
+    double Maximum,
+    string? Summary,
+    IReadOnlyList<TrainingProgressionSeriesDefinition> Series);
+
+public sealed record FormationPlayerDefinition(string Id, string Name, double X, double Y);
+
+public sealed record FormationLineDefinition(string Role, IReadOnlyList<FormationPlayerDefinition> Players);
+
+public sealed record ShotMapFilterDefinition(string Key, string DisplayName, string Color, bool IsDefault);
+
+public sealed record ShotMapEventDefinition(
+    string Id,
+    string Player,
+    string Minute,
+    string OutcomeKey,
+    double X,
+    double Y,
+    double? ExpectedGoals = null,
+    string? Assist = null,
+    string? BodyPart = null,
+    string? Detail = null,
+    string? Accent = null);
+
+public sealed record ShotMapDefinition(
+    double PitchWidth,
+    double PitchHeight,
+    IReadOnlyList<ShotMapFilterDefinition> Filters,
+    IReadOnlyList<ShotMapEventDefinition> Events);
+
+public sealed record MedicalTimelineEntryDefinition(
+    string Id,
+    string Player,
+    string Diagnosis,
+    string Status,
+    string ExpectedReturn,
+    IReadOnlyList<TimelineEntryDefinition> Phases,
+    string? Notes = null,
+    string? Accent = null);
+
+public sealed record MedicalTimelineDefinition(IReadOnlyList<MedicalTimelineEntryDefinition> Entries);
+
+public sealed record FinanceForecastImpactDefinition(string Label, string Format, double BaseValue, double Sensitivity);
+
+public sealed record FinanceForecastDefinition(
+    string SliderLabel,
+    string ValueDisplayFormat,
+    string CommitLabel,
+    string SummaryLabel,
+    double Minimum,
+    double Maximum,
+    double Step,
+    double Value,
+    IReadOnlyList<FinanceForecastImpactDefinition> Impacts);
+
+public sealed record TrainingIntensityLevelDefinition(string Key, string DisplayName, string Color, double LoadValue);
+
+public sealed record TrainingWorkloadCellDefinition(string Column, string IntensityKey, double Load, string? Detail = null);
+
+public sealed record TrainingWorkloadRowDefinition(string Label, IReadOnlyList<TrainingWorkloadCellDefinition> Cells);
+
+public sealed record TrainingWorkloadHeatmapDefinition(
+    IReadOnlyList<string> Columns,
+    IReadOnlyList<TrainingWorkloadRowDefinition> Rows,
+    IReadOnlyList<TrainingIntensityLevelDefinition> Intensities,
+    string? LegendTitle = null,
+    string? LegendSubtitle = null);
+
+public sealed record MoraleIntensityDefinition(string Key, string DisplayName, string Color, string? Description = null);
+
+public sealed record MoraleHeatmapCellDefinition(string Column, string IntensityKey, string Label, string? Detail = null);
+
+public sealed record MoraleHeatmapRowDefinition(string Label, IReadOnlyList<MoraleHeatmapCellDefinition> Cells);
+
+public sealed record MoraleHeatmapDefinition(
+    IReadOnlyList<string> Columns,
+    IReadOnlyList<MoraleHeatmapRowDefinition> Rows,
+    IReadOnlyList<MoraleIntensityDefinition> Intensities,
+    string? LegendTitle = null,
+    string? LegendSubtitle = null);
+
+public sealed record ClubVisionRoadmapPhaseDefinition(
+    string Id,
+    string Title,
+    string Timeline,
+    string Status,
+    string? Description = null,
+    string? Accent = null,
+    string? Pill = null);
+
+public sealed record ClubVisionRoadmapDefinition(
+    IReadOnlyList<ClubVisionRoadmapPhaseDefinition> Phases,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<string> PillOptions);
+
+public sealed record ClubVisionExpectationDefinition(
+    string Id,
+    string Objective,
+    string Competition,
+    string Priority,
+    string Status,
+    string Deadline,
+    string? Notes = null,
+    string? Accent = null);
+
+public sealed record ClubVisionExpectationBoardDefinition(
+    IReadOnlyList<ClubVisionExpectationDefinition> Objectives,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<string> PriorityOptions);
+
+public sealed record FixtureCalendarFilterDefinition(
+    string Id,
+    string DisplayName,
+    bool IsDefault,
+    IReadOnlyList<string> Competitions);
+
+public sealed record FixtureCalendarMatchDefinition(
+    string Id,
+    string Day,
+    string KickOff,
+    string Competition,
+    string Opponent,
+    string Venue,
+    bool IsHome,
+    string Importance,
+    string? Result = null,
+    string? Broadcast = null,
+    string? TravelNote = null,
+    string? PreparationNote = null,
+    string? Status = null,
+    string? CompetitionAccent = null,
+    IReadOnlyList<CardListItem>? KeyPeople = null,
+    IReadOnlyList<CardListItem>? Preparation = null);
+
+public sealed record FixtureCalendarDayDefinition(
+    string Label,
+    string Date,
+    IReadOnlyList<FixtureCalendarMatchDefinition> Matches);
+
+public sealed record FixtureCalendarWeekDefinition(
+    string Label,
+    IReadOnlyList<FixtureCalendarDayDefinition> Days);
+
+public sealed record FixtureCalendarDefinition(
+    IReadOnlyList<FixtureCalendarFilterDefinition> Filters,
+    IReadOnlyList<FixtureCalendarWeekDefinition> Weeks,
+    string? LegendTitle = null,
+    string? LegendSubtitle = null);
+
+public sealed record TransferNegotiationTermDefinition(
+    string Id,
+    string Label,
+    string Format,
+    double Minimum,
+    double Maximum,
+    double Step,
+    double Value,
+    double Target,
+    string? Tooltip = null);
+
+public sealed record TransferNegotiationDealDefinition(
+    string Id,
+    string Player,
+    string Position,
+    string Club,
+    string Stage,
+    string Status,
+    string Deadline,
+    string Summary,
+    string Agent,
+    string Response,
+    string? Accent,
+    IReadOnlyList<string> StageOptions,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<TransferNegotiationTermDefinition> Terms);
+
+public sealed record TransferNegotiationDefinition(
+    IReadOnlyList<TransferNegotiationDealDefinition> Deals);
+
+public sealed record TrainingCalendarSessionDefinition(
+    string Id,
+    string Day,
+    string Slot,
+    string Activity,
+    string? Focus = null,
+    string? Intensity = null);
+
+public sealed record TrainingCalendarDefinition(
+    IReadOnlyList<string> Days,
+    IReadOnlyList<string> Slots,
+    IReadOnlyList<TrainingCalendarSessionDefinition> Sessions);
+
+public sealed record SquadPlayerDefinition(
+    string Id,
+    string Name,
+    string PositionGroup,
+    string Position,
+    string Role,
+    string Morale,
+    double Condition,
+    double MatchSharpness,
+    double AverageRating,
+    int Appearances,
+    int Minutes,
+    string? Nationality = null,
+    string? Status = null);
+
+public sealed record SquadTableDefinition(IReadOnlyList<SquadPlayerDefinition> Players);
+
+public sealed record FinanceCashflowItemDefinition(
+    string Id,
+    string Name,
+    double Amount,
+    string Format,
+    string? Accent = null,
+    string? Detail = null);
+
+public sealed record FinanceCashflowCategoryDefinition(
+    string Id,
+    string Name,
+    string? Description,
+    double Amount,
+    string Format,
+    string? Accent,
+    IReadOnlyList<FinanceCashflowItemDefinition> Items);
+
+public sealed record FinanceCashflowDefinition(
+    string SummaryLabel,
+    string SummaryFormat,
+    IReadOnlyList<FinanceCashflowCategoryDefinition> Categories);
+
+public sealed record FinanceBudgetAllocationLineDefinition(
+    string Id,
+    string Label,
+    string? Description,
+    double Minimum,
+    double Maximum,
+    double Step,
+    double Value,
+    double Baseline,
+    string Format,
+    string? Accent = null);
+
+public sealed record FinanceBudgetAllocatorDefinition(
+    string CommitLabel,
+    string ResetLabel,
+    string SummaryFormat,
+    IReadOnlyList<FinanceBudgetAllocationLineDefinition> Lines);
+
+public sealed record FinanceScenarioOptionDefinition(
+    string Id,
+    string Title,
+    string Detail,
+    double Impact,
+    string Format,
+    bool IsSelected,
+    string? Accent = null);
+
+public sealed record FinanceScenarioDefinition(
+    string SummaryLabel,
+    string SummaryFormat,
+    string CommitLabel,
+    string ResetLabel,
+    IReadOnlyList<FinanceScenarioOptionDefinition> Options);
+
+public sealed record CardDefinition(
+    string Id,
+    string Title,
+    string? Subtitle,
+    CardKind Kind,
+    int Column,
+    int Row,
+    int ColumnSpan,
+    int RowSpan,
+    string? MetricValue = null,
+    string? MetricLabel = null,
+    string? Description = null,
+    string? PillText = null,
+    IReadOnlyList<CardListItem>? ListItems = null,
+    IReadOnlyList<FormationLineDefinition>? FormationLines = null,
+    IReadOnlyList<ChartSeriesDefinition>? ChartSeries = null,
+    GaugeDefinition? Gauge = null,
+    IReadOnlyList<TimelineEntryDefinition>? Timeline = null,
+    SquadTableDefinition? SquadTable = null,
+    TrainingCalendarDefinition? TrainingCalendar = null,
+    FinanceForecastDefinition? Forecast = null,
+    TrainingWorkloadHeatmapDefinition? WorkloadHeatmap = null,
+    MoraleHeatmapDefinition? MoraleHeatmap = null,
+    FixtureCalendarDefinition? FixtureCalendar = null,
+    TransferNegotiationDefinition? Negotiations = null,
+    ScoutAssignmentBoardDefinition? ScoutAssignments = null,
+    ShortlistBoardDefinition? ShortlistBoard = null,
+    TrainingUnitBoardDefinition? TrainingUnitBoard = null,
+    TrainingProgressionDefinition? TrainingProgression = null,
+    ShotMapDefinition? ShotMap = null,
+    MedicalTimelineDefinition? MedicalTimeline = null,
+    ClubVisionRoadmapDefinition? ClubVisionRoadmap = null,
+    ClubVisionExpectationBoardDefinition? ClubVisionExpectations = null,
+    FinanceCashflowDefinition? FinanceCashflow = null,
+    FinanceBudgetAllocatorDefinition? FinanceBudgetAllocator = null,
+    FinanceScenarioDefinition? FinanceScenario = null);
+
+public sealed record CardPresetDefinition(string Id, string DisplayName, string? Description, CardDefinition Template);
+
+public sealed record CardLayout(
+    string TabIdentifier,
+    string SectionIdentifier,
+    IReadOnlyList<CardDefinition> Cards,
+    IReadOnlyList<CardPresetDefinition> Palette)
+{
+    public static CardLayout Empty { get; } = new(
+        string.Empty,
+        string.Empty,
+        System.Array.Empty<CardDefinition>(),
+        System.Array.Empty<CardPresetDefinition>());
+}

--- a/WPF/FMUI.Wpf/Models/ClubDataSnapshot.cs
+++ b/WPF/FMUI.Wpf/Models/ClubDataSnapshot.cs
@@ -1,0 +1,613 @@
+using System.Collections.Generic;
+
+namespace FMUI.Wpf.Models;
+
+public sealed record ClubDataSnapshot(
+    TacticalSnapshot Tactics,
+    OverviewSnapshot Overview,
+    SquadSnapshot Squad,
+    TrainingSnapshot Training,
+    TransfersSnapshot Transfers,
+    FinanceSnapshot Finance,
+    FixturesSnapshot Fixtures,
+    NavigationPermissionsSnapshot? NavigationPermissions = null);
+
+public sealed record NavigationPermissionsSnapshot(
+    IReadOnlyList<NavigationTabPermissionSnapshot> Tabs);
+
+public sealed record NavigationTabPermissionSnapshot(
+    string TabId,
+    bool IsVisible,
+    IReadOnlyList<NavigationSectionPermissionSnapshot> Sections);
+
+public sealed record NavigationSectionPermissionSnapshot(
+    string SectionId,
+    bool IsVisible,
+    string? RequiredRole = null);
+
+public sealed record TrendDataPointSnapshot(string Label, double Value);
+
+public sealed record TrendSnapshot(MetricSnapshot Metric, IReadOnlyList<TrendDataPointSnapshot> Points);
+
+public sealed record GaugeBandSnapshot(string Label, double Start, double End, string Color);
+
+public sealed record GaugeSnapshot(
+    MetricSnapshot Metric,
+    double Minimum,
+    double Maximum,
+    double Value,
+    double Target,
+    string Unit,
+    IReadOnlyList<GaugeBandSnapshot> Bands,
+    IReadOnlyList<ListEntrySnapshot>? SupportingItems = null);
+
+public sealed record TimelineEntrySnapshot(string Label, string? Detail, double Position, string? Pill = null, string? Accent = null);
+
+public sealed record TimelineSnapshot(IReadOnlyList<TimelineEntrySnapshot> Events);
+
+public sealed record MoraleIntensitySnapshot(string Key, string DisplayName, string Color, string? Description = null);
+
+public sealed record MoraleHeatmapCellSnapshot(string Column, string IntensityKey, string Label, string? Detail = null);
+
+public sealed record MoraleHeatmapRowSnapshot(string Label, IReadOnlyList<MoraleHeatmapCellSnapshot> Cells);
+
+public sealed record MoraleHeatmapSnapshot(
+    IReadOnlyList<string> Columns,
+    IReadOnlyList<MoraleHeatmapRowSnapshot> Rows,
+    IReadOnlyList<MoraleIntensitySnapshot> Intensities,
+    string? LegendTitle = null,
+    string? LegendSubtitle = null);
+
+public sealed record TacticalSnapshot(
+    string FormationName,
+    string SquadLabel,
+    string Description,
+    string? MentalityPill,
+    IReadOnlyList<FormationLineSnapshot> FormationLines,
+    IReadOnlyList<FormationPlayerOptionSnapshot> PlayerPool,
+    MetricSnapshot Fluidity,
+    MetricSnapshot Mentality,
+    InstructionSnapshot InPossession,
+    InstructionSnapshot InTransition,
+    InstructionSnapshot OutOfPossession,
+    SetPieceSnapshot SetPieces,
+    TacticalAnalysisSnapshot Analysis);
+
+public sealed record FormationPlayerSnapshot(string Id, string Name, double X, double Y);
+
+public sealed record FormationLineSnapshot(string Role, IReadOnlyList<FormationPlayerSnapshot> Players);
+
+public sealed record FormationPlayerOptionSnapshot(string Id, string Name, string? Position = null, string? Detail = null);
+
+public sealed record MetricSnapshot(string Value, string Summary, string? Pill = null);
+
+public sealed record InstructionSnapshot(
+    string? Description,
+    IReadOnlyList<InstructionItemSnapshot> Items);
+
+public sealed record InstructionItemSnapshot(string Label, string Value, string? Detail = null);
+
+public sealed record SetPieceSnapshot(
+    IReadOnlyList<ListEntrySnapshot> AttackingCorners,
+    IReadOnlyList<ListEntrySnapshot> DefendingCorners,
+    IReadOnlyList<ListEntrySnapshot> FreeKicks,
+    IReadOnlyList<ListEntrySnapshot> ThrowIns,
+    IReadOnlyList<ListEntrySnapshot> PenaltyTakers);
+
+public sealed record TacticalAnalysisSnapshot(
+    MetricSnapshot RecentForm,
+    IReadOnlyList<ListEntrySnapshot> Strengths,
+    IReadOnlyList<ListEntrySnapshot> Weaknesses,
+    IReadOnlyList<ListEntrySnapshot> Statistics,
+    IReadOnlyList<ListEntrySnapshot> Recommendations);
+
+public sealed record OverviewSnapshot(
+    ClubVisionSnapshot ClubVision,
+    DynamicsSnapshot Dynamics,
+    MedicalSnapshot Medical,
+    AnalyticsSnapshot Analytics);
+
+public sealed record ClubVisionSnapshot(
+    MetricSnapshot BoardConfidence,
+    MetricSnapshot SupporterConfidence,
+    IReadOnlyList<ListEntrySnapshot> CompetitionExpectations,
+    IReadOnlyList<ListEntrySnapshot> FiveYearPlan,
+    IReadOnlyList<ListEntrySnapshot> FinanceSnapshot,
+    IReadOnlyList<ListEntrySnapshot> TopPerformers,
+    ClubVisionRoadmapSnapshot Roadmap,
+    ClubVisionExpectationBoardSnapshot ExpectationBoard);
+
+public sealed record ClubVisionRoadmapSnapshot(
+    IReadOnlyList<ClubVisionRoadmapPhaseSnapshot> Phases,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<string> PillOptions);
+
+public sealed record ClubVisionRoadmapPhaseSnapshot(
+    string Id,
+    string Title,
+    string Timeline,
+    string Status,
+    string? Description = null,
+    string? Accent = null,
+    string? Pill = null);
+
+public sealed record ClubVisionExpectationBoardSnapshot(
+    IReadOnlyList<ClubVisionExpectationSnapshot> Objectives,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<string> PriorityOptions);
+
+public sealed record ClubVisionExpectationSnapshot(
+    string Id,
+    string Objective,
+    string Competition,
+    string Priority,
+    string Status,
+    string Deadline,
+    string? Notes = null,
+    string? Accent = null);
+
+public sealed record DynamicsSnapshot(
+    MetricSnapshot TeamCohesion,
+    MetricSnapshot DressingRoomAtmosphere,
+    MetricSnapshot ManagerialSupport,
+    IReadOnlyList<ListEntrySnapshot> SocialGroups,
+    IReadOnlyList<ListEntrySnapshot> Influencers,
+    MoraleHeatmapSnapshot MoraleHeatmap,
+    IReadOnlyList<ListEntrySnapshot> PlayerIssues,
+    IReadOnlyList<ListEntrySnapshot> Meetings,
+    IReadOnlyList<ListEntrySnapshot> PraiseMoments);
+
+public sealed record MedicalSnapshot(
+    IReadOnlyList<ListEntrySnapshot> InjuryList,
+    MetricSnapshot RiskAssessment,
+    IReadOnlyList<ListEntrySnapshot> RiskBreakdown,
+    IReadOnlyList<ListEntrySnapshot> RehabProgress,
+    MetricSnapshot WorkloadMonitoring,
+    IReadOnlyList<ListEntrySnapshot> StaffNotes,
+    MedicalTimelineSnapshot Timeline);
+
+public sealed record MedicalTimelineSnapshot(IReadOnlyList<MedicalTimelineEntrySnapshot> Entries);
+
+public sealed record MedicalTimelineEntrySnapshot(
+    string Id,
+    string Player,
+    string Diagnosis,
+    string Status,
+    string ExpectedReturn,
+    IReadOnlyList<TimelineEntrySnapshot> Phases,
+    string? Notes = null,
+    string? Accent = null);
+
+public sealed record AnalyticsSnapshot(
+    TrendSnapshot ExpectedGoalsTrend,
+    IReadOnlyList<ListEntrySnapshot> ShotLocations,
+    IReadOnlyList<ListEntrySnapshot> PossessionZones,
+    IReadOnlyList<ListEntrySnapshot> PassingNetworks,
+    IReadOnlyList<ListEntrySnapshot> TeamComparison,
+    IReadOnlyList<ListEntrySnapshot> KeyStats,
+    ShotMapSnapshot ShotMap);
+
+public sealed record ShotMapSnapshot(
+    double PitchWidth,
+    double PitchHeight,
+    IReadOnlyList<ShotMapFilterSnapshot> Filters,
+    IReadOnlyList<ShotMapEventSnapshot> Events);
+
+public sealed record ShotMapFilterSnapshot(string Key, string DisplayName, string Color, bool IsDefault);
+
+public sealed record ShotMapEventSnapshot(
+    string Id,
+    string Player,
+    string Minute,
+    string OutcomeKey,
+    double X,
+    double Y,
+    double? ExpectedGoals = null,
+    string? Assist = null,
+    string? BodyPart = null,
+    string? Detail = null,
+    string? Accent = null);
+
+public sealed record SquadSnapshot(
+    SelectionInfoSnapshot SelectionInfo,
+    PlayersSnapshot Players,
+    InternationalSnapshot International,
+    SquadDepthSnapshot Depth);
+
+public sealed record SelectionInfoSnapshot(
+    IReadOnlyList<ListEntrySnapshot> MatchdayReadiness,
+    IReadOnlyList<ListEntrySnapshot> FitnessConcerns,
+    IReadOnlyList<ListEntrySnapshot> Suspensions,
+    IReadOnlyList<ListEntrySnapshot> RecentForm,
+    IReadOnlyList<ListEntrySnapshot> TrainingFocus);
+
+public sealed record PlayersSnapshot(
+    IReadOnlyList<ListEntrySnapshot> KeyPlayers,
+    IReadOnlyList<ListEntrySnapshot> EmergingPlayers,
+    IReadOnlyList<ListEntrySnapshot> ContractStatus,
+    IReadOnlyList<ListEntrySnapshot> StatisticsLeaders,
+    IReadOnlyList<ListEntrySnapshot> TransferInterest,
+    IReadOnlyList<SquadPlayerSnapshot> Roster);
+
+public sealed record InternationalSnapshot(
+    IReadOnlyList<ListEntrySnapshot> CallUps,
+    IReadOnlyList<ListEntrySnapshot> TravelPlans,
+    IReadOnlyList<ListEntrySnapshot> Availability,
+    IReadOnlyList<ListEntrySnapshot> ScoutingReports);
+
+public sealed record SquadDepthSnapshot(
+    IReadOnlyList<ListEntrySnapshot> DepthChart,
+    IReadOnlyList<ListEntrySnapshot> RoleBattles,
+    IReadOnlyList<ListEntrySnapshot> YouthDepth,
+    IReadOnlyList<ListEntrySnapshot> PositionalRatings);
+
+public sealed record SquadPlayerSnapshot(
+    string Id,
+    string Name,
+    string PositionGroup,
+    string Position,
+    string Role,
+    string Morale,
+    double Condition,
+    double MatchSharpness,
+    double AverageRating,
+    int Appearances,
+    int Minutes,
+    string? Nationality = null,
+    string? Status = null);
+
+public sealed record TrainingSnapshot(
+    TrainingOverviewSnapshot Overview,
+    TrainingCalendarSnapshot Calendar,
+    TrainingUnitsSnapshot Units);
+
+public sealed record TrainingOverviewSnapshot(
+    IReadOnlyList<ListEntrySnapshot> UpcomingSessions,
+    GaugeSnapshot Intensity,
+    TrainingWorkloadHeatmapSnapshot WorkloadHeatmap,
+    TrainingProgressionSnapshot Progression,
+    IReadOnlyList<ListEntrySnapshot> FocusAreas,
+    IReadOnlyList<ListEntrySnapshot> UnitCoaches,
+    IReadOnlyList<ListEntrySnapshot> MedicalWorkload,
+    IReadOnlyList<ListEntrySnapshot> MatchPreparation,
+    IReadOnlyList<ListEntrySnapshot> IndividualFocus,
+    IReadOnlyList<ListEntrySnapshot> YouthDevelopment);
+
+public sealed record TrainingProgressionSnapshot(
+    string MetricValue,
+    string MetricLabel,
+    string Summary,
+    IReadOnlyList<string> Periods,
+    double Minimum,
+    double Maximum,
+    IReadOnlyList<TrainingProgressionSeriesSnapshot> Series,
+    IReadOnlyList<ListEntrySnapshot> Highlights);
+
+public sealed record TrainingProgressionSeriesSnapshot(
+    string Id,
+    string Name,
+    string Color,
+    string? Accent,
+    bool IsHighlighted,
+    IReadOnlyList<TrainingProgressionPointSnapshot> Points);
+
+public sealed record TrainingProgressionPointSnapshot(string Period, double Value, string? Detail = null);
+
+public sealed record TrainingWorkloadHeatmapSnapshot(
+    IReadOnlyList<string> Columns,
+    IReadOnlyList<TrainingWorkloadUnitSnapshot> Units,
+    IReadOnlyList<TrainingIntensityLevelSnapshot> Intensities,
+    string? LegendTitle = null,
+    string? LegendSubtitle = null);
+
+public sealed record TrainingWorkloadUnitSnapshot(
+    string Label,
+    IReadOnlyList<TrainingWorkloadCellSnapshot> Cells);
+
+public sealed record TrainingWorkloadCellSnapshot(
+    string Column,
+    string IntensityKey,
+    double Load,
+    string? Detail = null);
+
+public sealed record TrainingIntensityLevelSnapshot(
+    string Key,
+    string DisplayName,
+    string Color,
+    double LoadValue);
+
+public sealed record TrainingCalendarSnapshot(
+    IReadOnlyList<ListEntrySnapshot> WeekOverview,
+    IReadOnlyList<TrainingSessionDetailSnapshot> SessionDetails,
+    IReadOnlyList<ListEntrySnapshot> RestDays,
+    IReadOnlyList<ListEntrySnapshot> MatchPrepFocus,
+    IReadOnlyList<ListEntrySnapshot> UpcomingMilestones);
+
+public sealed record TrainingSessionDetailSnapshot(
+    string Id,
+    string Day,
+    string Slot,
+    string Activity,
+    string? Focus = null,
+    string? Intensity = null);
+
+public sealed record TrainingUnitCoachSnapshot(string Id, string Name, string? Accent = null);
+
+public sealed record TrainingUnitMemberSnapshot(
+    string Id,
+    string Name,
+    string Position,
+    string Role,
+    string Status,
+    string? Accent = null,
+    string? Detail = null);
+
+public sealed record TrainingUnitGroupSnapshot(
+    string Id,
+    string Name,
+    string? CoachId,
+    IReadOnlyList<TrainingUnitCoachSnapshot> CoachOptions,
+    IReadOnlyList<TrainingUnitMemberSnapshot> Members);
+
+public sealed record TrainingUnitsBoardSnapshot(
+    IReadOnlyList<TrainingUnitGroupSnapshot> Units,
+    IReadOnlyList<TrainingUnitMemberSnapshot> AvailablePlayers);
+
+public sealed record TrainingUnitsSnapshot(
+    IReadOnlyList<ListEntrySnapshot> SeniorUnit,
+    IReadOnlyList<ListEntrySnapshot> YouthUnit,
+    IReadOnlyList<ListEntrySnapshot> GoalkeepingUnit,
+    IReadOnlyList<ListEntrySnapshot> CoachAssignments,
+    TrainingUnitsBoardSnapshot? Board = null);
+
+public sealed record TransfersSnapshot(
+    TransferCentreSnapshot Centre,
+    ScoutingSnapshot Scouting,
+    ShortlistSnapshot Shortlist);
+
+public sealed record TransferCentreSnapshot(
+    GaugeSnapshot BudgetUsage,
+    IReadOnlyList<ListEntrySnapshot> ActiveDeals,
+    IReadOnlyList<ListEntrySnapshot> RecentActivity,
+    IReadOnlyList<ListEntrySnapshot> LoanWatch,
+    IReadOnlyList<ListEntrySnapshot> Clauses,
+    IReadOnlyList<TransferNegotiationDealSnapshot>? Negotiations = null);
+
+public sealed record TransferNegotiationTermSnapshot(
+    string Id,
+    string Label,
+    string Format,
+    double Minimum,
+    double Maximum,
+    double Step,
+    double Value,
+    double Target,
+    string? Tooltip = null);
+
+public sealed record TransferNegotiationDealSnapshot(
+    string Id,
+    string Player,
+    string Position,
+    string Club,
+    string Stage,
+    string Status,
+    string Deadline,
+    string Summary,
+    string Agent,
+    string Response,
+    string? Accent,
+    IReadOnlyList<string> StageOptions,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<TransferNegotiationTermSnapshot> Terms);
+
+public sealed record ScoutOptionSnapshot(
+    string Id,
+    string Name,
+    string Region,
+    string Availability);
+
+public sealed record ScoutAssignmentSnapshot(
+    string Id,
+    string Focus,
+    string Role,
+    string Region,
+    string Priority,
+    string Stage,
+    string Deadline,
+    string Scout,
+    string? Notes = null);
+
+public sealed record ScoutingSnapshot(
+    IReadOnlyList<ListEntrySnapshot> Assignments,
+    IReadOnlyList<ListEntrySnapshot> FocusRegions,
+    IReadOnlyList<ListEntrySnapshot> KnowledgeLevels,
+    IReadOnlyList<ListEntrySnapshot> RecommendedPlayers,
+    IReadOnlyList<ListEntrySnapshot> ShortTermFocus,
+    IReadOnlyList<ScoutAssignmentSnapshot> AssignmentBoard,
+    IReadOnlyList<ScoutOptionSnapshot> ScoutPool,
+    IReadOnlyList<string> AssignmentStages,
+    IReadOnlyList<string> AssignmentPriorities);
+
+public sealed record ShortlistPlayerSnapshot(
+    string Id,
+    string Name,
+    string Position,
+    string Status,
+    string Action,
+    string? Priority = null,
+    string? Notes = null);
+
+public sealed record ShortlistSnapshot(
+    IReadOnlyList<ListEntrySnapshot> PriorityTargets,
+    IReadOnlyList<ListEntrySnapshot> ContractStatus,
+    IReadOnlyList<ListEntrySnapshot> Competition,
+    IReadOnlyList<ListEntrySnapshot> Notes,
+    IReadOnlyList<ShortlistPlayerSnapshot> Board,
+    IReadOnlyList<string> StatusOptions,
+    IReadOnlyList<string> ActionOptions);
+
+public sealed record FinanceSnapshot(
+    FinanceSummarySnapshot Summary,
+    FinanceIncomeSnapshot Income,
+    FinanceExpenditureSnapshot Expenditure);
+
+public sealed record FinanceSummarySnapshot(
+    GaugeSnapshot OverallBalance,
+    TrendSnapshot ProfitThisMonth,
+    FinanceBudgetAllocationSnapshot BudgetAllocator,
+    FinanceCashflowSnapshot Cashflow,
+    IReadOnlyList<ListEntrySnapshot> Projections,
+    IReadOnlyList<ListEntrySnapshot> Debts,
+    IReadOnlyList<ListEntrySnapshot> SponsorDeals,
+    FinanceForecastSnapshot Forecast,
+    FinanceScenarioBoardSnapshot ScenarioBoard);
+
+public sealed record FinanceIncomeSnapshot(
+    IReadOnlyList<ListEntrySnapshot> RevenueStreams,
+    IReadOnlyList<ListEntrySnapshot> MatchdayIncome,
+    IReadOnlyList<ListEntrySnapshot> CommercialIncome,
+    IReadOnlyList<ListEntrySnapshot> CompetitionPrizes);
+
+public sealed record FinanceExpenditureSnapshot(
+    IReadOnlyList<ListEntrySnapshot> MajorCosts,
+    IReadOnlyList<ListEntrySnapshot> WageBreakdown,
+    IReadOnlyList<ListEntrySnapshot> TransferSpending,
+    IReadOnlyList<ListEntrySnapshot> OperationalCosts);
+
+public sealed record FinanceBudgetAllocationSnapshot(
+    string CommitLabel,
+    string ResetLabel,
+    string SummaryFormat,
+    IReadOnlyList<FinanceBudgetAllocationLineSnapshot> Lines);
+
+public sealed record FinanceBudgetAllocationLineSnapshot(
+    string Id,
+    string Label,
+    string? Description,
+    double Minimum,
+    double Maximum,
+    double Step,
+    double Value,
+    double Baseline,
+    string Format,
+    string? Accent);
+
+public sealed record FinanceCashflowSnapshot(
+    string SummaryLabel,
+    string SummaryFormat,
+    IReadOnlyList<FinanceCashflowCategorySnapshot> Categories);
+
+public sealed record FinanceCashflowCategorySnapshot(
+    string Id,
+    string Name,
+    string? Description,
+    double Amount,
+    string Format,
+    string? Accent,
+    IReadOnlyList<FinanceCashflowItemSnapshot> Items);
+
+public sealed record FinanceCashflowItemSnapshot(
+    string Id,
+    string Name,
+    double Amount,
+    string Format,
+    string? Accent = null,
+    string? Detail = null);
+
+public sealed record FinanceForecastSnapshot(
+    string SliderLabel,
+    string ValueDisplayFormat,
+    string CommitLabel,
+    string SummaryLabel,
+    double Minimum,
+    double Maximum,
+    double Step,
+    double CurrentPercentage,
+    IReadOnlyList<FinanceForecastImpactSnapshot> Impacts);
+
+public sealed record FinanceForecastImpactSnapshot(
+    string Label,
+    string Format,
+    double BaseValue,
+    double Sensitivity);
+
+public sealed record FinanceScenarioBoardSnapshot(
+    string SummaryLabel,
+    string SummaryFormat,
+    string CommitLabel,
+    string ResetLabel,
+    IReadOnlyList<FinanceScenarioOptionSnapshot> Options);
+
+public sealed record FinanceScenarioOptionSnapshot(
+    string Id,
+    string Title,
+    string Detail,
+    double Impact,
+    string Format,
+    bool IsSelected,
+    string? Accent = null);
+
+public sealed record FixturesSnapshot(
+    FixturesScheduleSnapshot Schedule,
+    FixturesResultsSnapshot Results,
+    FixturesCalendarSnapshot Calendar);
+
+public sealed record FixturesScheduleSnapshot(
+    IReadOnlyList<ListEntrySnapshot> UpcomingFixtures,
+    TimelineSnapshot FixtureTimeline,
+    IReadOnlyList<ListEntrySnapshot> TravelPlans,
+    IReadOnlyList<ListEntrySnapshot> Broadcasts,
+    IReadOnlyList<ListEntrySnapshot> PreparationFocus);
+
+public sealed record FixturesResultsSnapshot(
+    IReadOnlyList<ListEntrySnapshot> RecentResults,
+    IReadOnlyList<ListEntrySnapshot> PlayerRatings,
+    IReadOnlyList<ListEntrySnapshot> Trends,
+    IReadOnlyList<ListEntrySnapshot> KeyMoments);
+
+public sealed record FixturesCalendarSnapshot(
+    IReadOnlyList<ListEntrySnapshot> MonthOverview,
+    IReadOnlyList<ListEntrySnapshot> CupDraws,
+    IReadOnlyList<ListEntrySnapshot> InternationalBreaks,
+    IReadOnlyList<ListEntrySnapshot> Reminders,
+    IReadOnlyList<FixtureCalendarFilterSnapshot> Filters,
+    IReadOnlyList<FixtureCalendarWeekSnapshot> Weeks);
+
+public sealed record FixtureCalendarFilterSnapshot(
+    string Id,
+    string DisplayName,
+    bool IsDefault,
+    IReadOnlyList<string> Competitions);
+
+public sealed record FixtureCalendarWeekSnapshot(
+    string Label,
+    IReadOnlyList<FixtureCalendarDaySnapshot> Days);
+
+public sealed record FixtureCalendarDaySnapshot(
+    string Label,
+    string Date,
+    IReadOnlyList<FixtureCalendarMatchSnapshot> Matches);
+
+public sealed record FixtureCalendarMatchSnapshot(
+    string Id,
+    string Day,
+    string KickOff,
+    string Competition,
+    string Opponent,
+    string Venue,
+    bool IsHome,
+    string Importance,
+    string? Result = null,
+    string? Broadcast = null,
+    string? TravelNote = null,
+    string? PreparationNote = null,
+    string? Status = null,
+    string? CompetitionAccent = null,
+    IReadOnlyList<ListEntrySnapshot>? KeyPeople = null,
+    IReadOnlyList<ListEntrySnapshot>? Preparation = null);
+
+public sealed record ListEntrySnapshot(
+    string Primary,
+    string? Secondary = null,
+    string? Tertiary = null,
+    string? Accent = null);

--- a/WPF/FMUI.Wpf/Models/NavigationModels.cs
+++ b/WPF/FMUI.Wpf/Models/NavigationModels.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace FMUI.Wpf.Models;
+
+public sealed record NavigationSubItem(string Title, string Identifier);
+
+public sealed record NavigationTab(string Title, string Identifier, IReadOnlyList<NavigationSubItem> SubItems);
+
+public enum NavigationIndicatorSeverity
+{
+    None = 0,
+    Info = 1,
+    Warning = 2,
+    Critical = 3
+}
+
+public sealed record NavigationIndicatorSnapshot(int Count, NavigationIndicatorSeverity Severity, string? Tooltip)
+{
+    public static NavigationIndicatorSnapshot None { get; } = new(0, NavigationIndicatorSeverity.None, null);
+
+    public bool HasAlert => Severity != NavigationIndicatorSeverity.None;
+}

--- a/WPF/FMUI.Wpf/Resources/Theme.xaml
+++ b/WPF/FMUI.Wpf/Resources/Theme.xaml
@@ -1,0 +1,269 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="SurfaceDarkColor">#0D1117</Color>
+    <Color x:Key="SurfaceMediumColor">#151B24</Color>
+    <Color x:Key="SurfaceLightColor">#1E2632</Color>
+    <Color x:Key="AccentPrimaryColor">#FF2EC4B6</Color>
+    <Color x:Key="AccentSecondaryColor">#FF3AA0FF</Color>
+    <Color x:Key="WarningColor">#FFE4B123</Color>
+    <Color x:Key="SuccessColor">#FF4CE577</Color>
+    <Color x:Key="NeutralTextColor">#FF8EA1B5</Color>
+    <Color x:Key="PrimaryTextColor">#FFF7FAFF</Color>
+
+    <SolidColorBrush x:Key="SurfaceDarkBrush" Color="{StaticResource SurfaceDarkColor}" />
+    <SolidColorBrush x:Key="SurfaceMediumBrush" Color="{StaticResource SurfaceMediumColor}" />
+    <SolidColorBrush x:Key="SurfaceLightBrush" Color="{StaticResource SurfaceLightColor}" />
+    <SolidColorBrush x:Key="AccentPrimaryBrush" Color="{StaticResource AccentPrimaryColor}" />
+    <SolidColorBrush x:Key="AccentSecondaryBrush" Color="{StaticResource AccentSecondaryColor}" />
+    <SolidColorBrush x:Key="NeutralTextBrush" Color="{StaticResource NeutralTextColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SurfaceToolbarBackgroundBrush" Color="#80202938" />
+    <SolidColorBrush x:Key="SurfaceToolbarBorderBrush" Color="#FF2A3443" />
+    <SolidColorBrush x:Key="OverlayBackdropBrush" Color="#B3101624" />
+    <SolidColorBrush x:Key="OverlaySurfaceBrush" Color="#F0161F2D" />
+    <SolidColorBrush x:Key="OverlayBorderBrush" Color="#FF2EC4B6" />
+    <SolidColorBrush x:Key="OverlayListBackgroundBrush" Color="#CC101623" />
+    <SolidColorBrush x:Key="OverlayListItemBrush" Color="#1F2A39" />
+    <SolidColorBrush x:Key="OverlayListItemBorderBrush" Color="#FF2B3444" />
+    <SolidColorBrush x:Key="OverlayListItemHoverBrush" Color="#273347" />
+    <SolidColorBrush x:Key="OverlayListItemSelectedBrush" Color="#442EC4B6" />
+    <SolidColorBrush x:Key="NavigationBadgeInfoBrush" Color="#FF2EC4B6" />
+    <SolidColorBrush x:Key="NavigationBadgeWarningBrush" Color="#FFE4B123" />
+    <SolidColorBrush x:Key="NavigationBadgeCriticalBrush" Color="#FF6F59" />
+    <SolidColorBrush x:Key="NavigationBadgeForegroundBrush" Color="#FFF7FAFF" />
+    <SolidColorBrush x:Key="TooltipBackgroundBrush" Color="#F0151E2B" />
+    <SolidColorBrush x:Key="TooltipBorderBrush" Color="#FF2EC4B6" />
+
+    <LinearGradientBrush x:Key="HeaderGradientBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#FF161A24" Offset="0" />
+        <GradientStop Color="#FF0D1117" Offset="1" />
+    </LinearGradientBrush>
+
+    <LinearGradientBrush x:Key="ContentGradientBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#FF080B11" Offset="0" />
+        <GradientStop Color="#FF0F1620" Offset="1" />
+    </LinearGradientBrush>
+
+    <Style x:Key="ContinueButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource AccentPrimaryBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Padding" Value="18,10" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border CornerRadius="6"
+                            Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{StaticResource AccentSecondaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="{StaticResource AccentPrimaryBrush}" />
+                            <Setter Property="Opacity" Value="0.85" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="NavigationTabContainerStyle" TargetType="Border">
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="Padding" Value="14,12" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+    <Style x:Key="NavigationTabTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
+        <Setter Property="TextOptions.TextRenderingMode" Value="Auto" />
+    </Style>
+
+    <Style x:Key="NavigationSubItemTextStyle" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        <Setter Property="FontWeight" Value="Medium" />
+    </Style>
+
+    <Style x:Key="SubNavigationButtonStyle" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        <Setter Property="Padding" Value="12,6" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border CornerRadius="6" Background="{TemplateBinding Background}">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#332EC4B6" />
+                            <Setter Property="Foreground" Value="White" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="#552EC4B6" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="#668EA1B5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="CardToolTipStyle" TargetType="ToolTip">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Placement" Value="Mouse" />
+        <Setter Property="Background" Value="{StaticResource TooltipBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource TooltipBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="12" />
+        <Setter Property="HorizontalOffset" Value="0" />
+        <Setter Property="VerticalOffset" Value="12" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToolTip">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="10"
+                            SnapsToDevicePixels="True"
+                            Opacity="0.95">
+                        <ContentPresenter Margin="{TemplateBinding Padding}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SurfaceToolbarButtonStyle" TargetType="Button">
+        <Setter Property="Padding" Value="16,8" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Background" Value="#1D2736" />
+        <Setter Property="BorderBrush" Value="#2A3342" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="16"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#253346" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="#1A2332" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PalettePrimaryButtonStyle" TargetType="Button">
+        <Setter Property="Padding" Value="18,10" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="Background" Value="{StaticResource AccentPrimaryBrush}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            CornerRadius="14"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{StaticResource AccentSecondaryBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Opacity" Value="0.85" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PaletteSecondaryButtonStyle" TargetType="Button">
+        <Setter Property="Padding" Value="18,10" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="14"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          RecognizesAccessKey="True" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#222F40" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="#1A2535" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="GridOverlayRectangleStyle" TargetType="Rectangle">
+        <Setter Property="Stroke" Value="#112EC4B6" />
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+    </Style>
+</ResourceDictionary>

--- a/WPF/FMUI.Wpf/Services/CardEditorCatalog.cs
+++ b/WPF/FMUI.Wpf/Services/CardEditorCatalog.cs
@@ -1,0 +1,541 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.ViewModels.Editors;
+
+namespace FMUI.Wpf.Services;
+
+public interface ICardEditorCatalog
+{
+    bool SupportsEditing(string tabIdentifier, string sectionIdentifier, CardDefinition definition);
+
+    CardEditorViewModel? CreateEditor(string tabIdentifier, string sectionIdentifier, CardDefinition definition);
+}
+
+public sealed class CardEditorCatalog : ICardEditorCatalog
+{
+    private readonly IClubDataService _clubDataService;
+
+    public CardEditorCatalog(IClubDataService clubDataService)
+    {
+        _clubDataService = clubDataService;
+    }
+
+    public bool SupportsEditing(string tabIdentifier, string sectionIdentifier, CardDefinition definition)
+    {
+        return GetFactory(tabIdentifier, sectionIdentifier, definition) is not null;
+    }
+
+    public CardEditorViewModel? CreateEditor(string tabIdentifier, string sectionIdentifier, CardDefinition definition)
+    {
+        var factory = GetFactory(tabIdentifier, sectionIdentifier, definition);
+        return factory?.Invoke();
+    }
+
+    private Func<CardEditorViewModel>? GetFactory(string tabIdentifier, string sectionIdentifier, CardDefinition definition)
+    {
+        if (definition is null)
+        {
+            return null;
+        }
+
+        return (tabIdentifier, sectionIdentifier, definition.Id) switch
+        {
+            ("tactics", "tactics-overview", "formation-overview") => CreateFormationEditorFactory(),
+            ("overview", "club-vision", "competition-objectives") => CreateClubVisionExpectationsBoardFactory(),
+            ("overview", "club-vision", "strategic-roadmap") => CreateClubVisionRoadmapFactory(),
+            ("overview", "dynamics", "player-issues") => CreateDynamicsPlayerIssuesFactory(),
+            ("overview", "dynamics", "morale-heatmap") => CreateDynamicsMoraleHeatmapFactory(),
+            ("squad", "players", "key-players") => CreateSquadKeyPlayersFactory(),
+            ("training", "training-overview", "training-intensity") => CreateTrainingIntensityFactory(),
+            ("training", "training-overview", "focus-areas") => CreateTrainingFocusAreasFactory(),
+            ("training", "training-overview", "training-workload-heatmap") => CreateTrainingWorkloadHeatmapFactory(),
+            ("training", "training-overview", "training-progression") => CreateTrainingProgressionFactory(),
+            ("training", "training-calendar", "weekly-calendar") => CreateTrainingSessionsFactory(),
+            ("training", "training-calendar", "week-overview") => CreateTrainingSessionsFactory(),
+            ("training", "training-units", "training-unit-board") => CreateTrainingUnitBoardFactory(),
+            ("transfers", "transfer-centre", "budget-usage") => CreateTransferBudgetUsageFactory(),
+            ("transfers", "transfer-centre", "active-deals") => CreateTransferActiveDealsFactory(),
+            ("transfers", "transfer-centre", "recent-activity") => CreateTransferRecentActivityFactory(),
+            ("transfers", "scouting", "scout-assignments-board") => CreateScoutAssignmentsFactory(),
+            ("transfers", "shortlist", "shortlist-board") => CreateShortlistBoardFactory(),
+            ("finances", "finances-summary", "overall-balance") => CreateOverallBalanceFactory(),
+            _ => null
+        };
+    }
+
+    private Func<CardEditorViewModel>? CreateFormationEditorFactory()
+    {
+        var snapshot = _clubDataService.Current.Tactics;
+        var lines = snapshot.FormationLines;
+        var playerPool = snapshot.PlayerPool;
+
+        if (playerPool is null || playerPool.Count == 0)
+        {
+            return null;
+        }
+
+        return () => new FormationEditorViewModel(
+            "Manage Starting XI",
+            "Swap players within the tactical shape.",
+            lines,
+            playerPool,
+            _clubDataService);
+    }
+
+    private Func<CardEditorViewModel>? CreateClubVisionExpectationsBoardFactory()
+    {
+        var board = _clubDataService.Current.Overview.ClubVision.ExpectationBoard;
+
+        return () => new ClubVisionExpectationBoardEditorViewModel(
+            "Adjust Competition Objectives",
+            "Update board-monitored targets and priorities.",
+            board,
+            PersistClubVisionExpectationsBoardAsync);
+    }
+
+    private async Task PersistClubVisionExpectationsBoardAsync(ClubVisionExpectationBoardSnapshot board)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var clubVision = snapshot.Overview.ClubVision with { ExpectationBoard = board };
+            var overview = snapshot.Overview with { ClubVision = clubVision };
+            return snapshot with { Overview = overview };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateClubVisionRoadmapFactory()
+    {
+        var roadmap = _clubDataService.Current.Overview.ClubVision.Roadmap;
+
+        return () => new ClubVisionRoadmapEditorViewModel(
+            "Edit Strategic Roadmap",
+            "Manage long-term milestones and board checkpoints.",
+            roadmap,
+            PersistClubVisionRoadmapAsync);
+    }
+
+    private async Task PersistClubVisionRoadmapAsync(ClubVisionRoadmapSnapshot roadmap)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var clubVision = snapshot.Overview.ClubVision with { Roadmap = roadmap };
+            var overview = snapshot.Overview with { ClubVision = clubVision };
+            return snapshot with { Overview = overview };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateDynamicsPlayerIssuesFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var items = snapshot.Overview.Dynamics.PlayerIssues;
+
+        return () => new ListCardEditorViewModel(
+            "Edit Player Issues",
+            "Capture concerns raised by the squad.",
+            items,
+            PersistDynamicsPlayerIssuesAsync);
+    }
+
+    private async Task PersistDynamicsPlayerIssuesAsync(IReadOnlyList<ListEntrySnapshot> items)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var dynamics = snapshot.Overview.Dynamics with { PlayerIssues = items };
+            var overview = snapshot.Overview with { Dynamics = dynamics };
+            return snapshot with { Overview = overview };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateDynamicsMoraleHeatmapFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var heatmap = snapshot.Overview.Dynamics.MoraleHeatmap;
+
+        return () => new MoraleHeatmapEditorViewModel(
+            "Adjust Dressing Room Morale",
+            "Update unit morale levels and supporting notes.",
+            heatmap,
+            PersistDynamicsMoraleHeatmapAsync);
+    }
+
+    private async Task PersistDynamicsMoraleHeatmapAsync(MoraleHeatmapSnapshot heatmap)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var dynamics = snapshot.Overview.Dynamics with { MoraleHeatmap = heatmap };
+            var overview = snapshot.Overview with { Dynamics = dynamics };
+            return snapshot with { Overview = overview };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateSquadKeyPlayersFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var items = snapshot.Squad.Players.KeyPlayers;
+
+        return () => new ListCardEditorViewModel(
+            "Edit Key Players",
+            "Update the squad leaders highlighted on the tactical board.",
+            items,
+            PersistSquadKeyPlayersAsync);
+    }
+
+    private async Task PersistSquadKeyPlayersAsync(IReadOnlyList<ListEntrySnapshot> items)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var players = snapshot.Squad.Players with { KeyPlayers = items };
+            var squad = snapshot.Squad with { Players = players };
+            return snapshot with { Squad = squad };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateTrainingIntensityFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var gauge = snapshot.Training.Overview.Intensity;
+
+        return () => new GaugeEditorViewModel(
+            "Tune Training Intensity",
+            "Adjust the workload to balance fitness and freshness.",
+            gauge,
+            PersistTrainingIntensityAsync);
+    }
+
+    private async Task PersistTrainingIntensityAsync(GaugeSnapshot gauge)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var overview = snapshot.Training.Overview with { Intensity = gauge };
+            var training = snapshot.Training with { Overview = overview };
+            return snapshot with { Training = training };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateTrainingFocusAreasFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var items = snapshot.Training.Overview.FocusAreas;
+
+        return () => new ListCardEditorViewModel(
+            "Edit Focus Areas",
+            "Direct what the squad concentrates on this week.",
+            items,
+            PersistTrainingFocusAreasAsync);
+    }
+
+    private async Task PersistTrainingFocusAreasAsync(IReadOnlyList<ListEntrySnapshot> items)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var overview = snapshot.Training.Overview with { FocusAreas = items };
+            var training = snapshot.Training with { Overview = overview };
+            return snapshot with { Training = training };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateTrainingProgressionFactory()
+    {
+        var progression = _clubDataService.Current.Training.Overview.Progression;
+
+        if (progression is null)
+        {
+            return null;
+        }
+
+        return () => new TrainingProgressionEditorViewModel(
+            progression,
+            _clubDataService);
+    }
+
+    private Func<CardEditorViewModel>? CreateTrainingWorkloadHeatmapFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var heatmap = snapshot.Training.Overview.WorkloadHeatmap;
+
+        if (heatmap is null)
+        {
+            return null;
+        }
+
+        return () => new TrainingWorkloadEditorViewModel(
+            "Adjust Workload Heatmap",
+            "Balance unit intensity across the weekly schedule.",
+            heatmap,
+            PersistTrainingWorkloadHeatmapAsync);
+    }
+
+    private async Task PersistTrainingWorkloadHeatmapAsync(TrainingWorkloadHeatmapSnapshot heatmap)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var overview = snapshot.Training.Overview with { WorkloadHeatmap = heatmap };
+            var training = snapshot.Training with { Overview = overview };
+            return snapshot with { Training = training };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateTrainingSessionsFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var sessions = snapshot.Training.Calendar.SessionDetails;
+
+        return () => new TrainingSessionEditorViewModel(
+            "Configure Training Sessions",
+            "Reschedule slots and adjust focus areas for the upcoming week.",
+            sessions,
+            PersistTrainingSessionsAsync);
+    }
+
+    private async Task PersistTrainingSessionsAsync(IReadOnlyList<TrainingSessionDetailSnapshot> sessions)
+    {
+        var orderedSessions = TrainingCalendarFormatter.OrderSessions(sessions).ToList();
+        var overview = TrainingCalendarFormatter.BuildWeekOverview(orderedSessions).ToList();
+
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var calendar = snapshot.Training.Calendar with
+            {
+                SessionDetails = orderedSessions,
+                WeekOverview = overview
+            };
+            var training = snapshot.Training with { Calendar = calendar };
+            return snapshot with { Training = training };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateTrainingUnitBoardFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var units = snapshot.Training.Units;
+        var board = units.Board;
+
+        if (board is null)
+        {
+            return null;
+        }
+
+        return () => new TrainingUnitBoardEditorViewModel(
+            "Manage Training Units",
+            "Assign players and coaches across the senior, youth, and goalkeeping groups.",
+            board,
+            PersistTrainingUnitBoardAsync);
+    }
+
+    private async Task PersistTrainingUnitBoardAsync(TrainingUnitsBoardSnapshot board)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var units = snapshot.Training.Units;
+
+            var updatedUnits = units with
+            {
+                Board = board,
+                SeniorUnit = CreateTrainingUnitListEntries(board, "senior"),
+                YouthUnit = CreateTrainingUnitListEntries(board, "youth"),
+                GoalkeepingUnit = CreateTrainingUnitListEntries(board, "goalkeeping"),
+                CoachAssignments = CreateTrainingCoachAssignments(board)
+            };
+
+            var training = snapshot.Training with { Units = updatedUnits };
+            return snapshot with { Training = training };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateTransferBudgetUsageFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var gauge = snapshot.Transfers.Centre.BudgetUsage;
+
+        return () => new GaugeEditorViewModel(
+            "Adjust Budget Usage",
+            "Reflect committed and available funds.",
+            gauge,
+            PersistTransferBudgetUsageAsync);
+    }
+
+    private async Task PersistTransferBudgetUsageAsync(GaugeSnapshot gauge)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var centre = snapshot.Transfers.Centre with { BudgetUsage = gauge };
+            var transfers = snapshot.Transfers with { Centre = centre };
+            return snapshot with { Transfers = transfers };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateTransferActiveDealsFactory()
+    {
+        var snapshot = _clubDataService.Current.Transfers.Centre;
+        var deals = snapshot.Negotiations ?? Array.Empty<TransferNegotiationDealSnapshot>();
+        var summaries = snapshot.ActiveDeals ?? Array.Empty<ListEntrySnapshot>();
+
+        return () => new TransferNegotiationEditorViewModel(
+            deals,
+            summaries,
+            _clubDataService);
+    }
+
+    private Func<CardEditorViewModel>? CreateTransferRecentActivityFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var items = snapshot.Transfers.Centre.RecentActivity;
+
+        return () => new ListCardEditorViewModel(
+            "Edit Recent Activity",
+            "Log the latest completed moves.",
+            items,
+            PersistTransferRecentActivityAsync);
+    }
+
+    private async Task PersistTransferRecentActivityAsync(IReadOnlyList<ListEntrySnapshot> items)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var centre = snapshot.Transfers.Centre with { RecentActivity = items };
+            var transfers = snapshot.Transfers with { Centre = centre };
+            return snapshot with { Transfers = transfers };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateScoutAssignmentsFactory()
+    {
+        var scouting = _clubDataService.Current.Transfers.Scouting;
+
+        return () => new ScoutAssignmentEditorViewModel(
+            scouting.AssignmentBoard,
+            scouting.ScoutPool,
+            scouting.AssignmentStages,
+            scouting.AssignmentPriorities,
+            PersistScoutAssignmentsAsync);
+    }
+
+    private async Task PersistScoutAssignmentsAsync(IReadOnlyList<ScoutAssignmentSnapshot> assignments)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var scouting = snapshot.Transfers.Scouting;
+            var assignmentList = assignments ?? Array.Empty<ScoutAssignmentSnapshot>();
+            var summaries = assignmentList
+                .Select(assignment => new ListEntrySnapshot(
+                    assignment.Focus,
+                    string.IsNullOrWhiteSpace(assignment.Role)
+                        ? assignment.Region
+                        : $"{assignment.Role} • {assignment.Region}",
+                    assignment.Deadline,
+                    string.IsNullOrWhiteSpace(assignment.Scout) ? null : assignment.Scout))
+                .ToList();
+
+            var updatedScouting = scouting with
+            {
+                AssignmentBoard = assignmentList,
+                Assignments = summaries
+            };
+
+            var transfers = snapshot.Transfers with { Scouting = updatedScouting };
+            return snapshot with { Transfers = transfers };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateShortlistBoardFactory()
+    {
+        var shortlist = _clubDataService.Current.Transfers.Shortlist;
+
+        return () => new ShortlistEditorViewModel(
+            shortlist.Board,
+            shortlist.StatusOptions,
+            shortlist.ActionOptions,
+            PersistShortlistBoardAsync);
+    }
+
+    private async Task PersistShortlistBoardAsync(IReadOnlyList<ShortlistPlayerSnapshot> players)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var shortlist = snapshot.Transfers.Shortlist;
+            var board = players ?? Array.Empty<ShortlistPlayerSnapshot>();
+            var priorityTargets = board
+                .Select(player => new ListEntrySnapshot(
+                    player.Name,
+                    player.Position,
+                    player.Status,
+                    player.Priority))
+                .ToList();
+
+            var updatedShortlist = shortlist with
+            {
+                Board = board,
+                PriorityTargets = priorityTargets
+            };
+
+            var transfers = snapshot.Transfers with { Shortlist = updatedShortlist };
+            return snapshot with { Transfers = transfers };
+        }).ConfigureAwait(false);
+    }
+
+    private Func<CardEditorViewModel>? CreateOverallBalanceFactory()
+    {
+        var snapshot = _clubDataService.Current;
+        var gauge = snapshot.Finance.Summary.OverallBalance;
+
+        return () => new GaugeEditorViewModel(
+            "Adjust Overall Balance",
+            "Reflect the club's latest financial position.",
+            gauge,
+            PersistOverallBalanceAsync);
+    }
+
+    private async Task PersistOverallBalanceAsync(GaugeSnapshot gauge)
+    {
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var summary = snapshot.Finance.Summary with { OverallBalance = gauge };
+            var finance = snapshot.Finance with { Summary = summary };
+            return snapshot with { Finance = finance };
+        }).ConfigureAwait(false);
+    }
+
+    private static IReadOnlyList<ListEntrySnapshot> CreateTrainingUnitListEntries(
+        TrainingUnitsBoardSnapshot board,
+        string unitId)
+    {
+        if (board is null)
+        {
+            return Array.Empty<ListEntrySnapshot>();
+        }
+
+        var unit = board.Units.FirstOrDefault(u => string.Equals(u.Id, unitId, StringComparison.OrdinalIgnoreCase));
+        if (unit is null)
+        {
+            return Array.Empty<ListEntrySnapshot>();
+        }
+
+        return unit.Members
+            .Select(member => new ListEntrySnapshot(
+                member.Name,
+                member.Position,
+                member.Status,
+                member.Accent))
+            .ToList();
+    }
+
+    private static IReadOnlyList<ListEntrySnapshot> CreateTrainingCoachAssignments(TrainingUnitsBoardSnapshot board)
+    {
+        if (board is null)
+        {
+            return Array.Empty<ListEntrySnapshot>();
+        }
+
+        return board.Units
+            .Select(unit =>
+            {
+                var coach = unit.CoachOptions.FirstOrDefault(option => string.Equals(option.Id, unit.CoachId, StringComparison.OrdinalIgnoreCase));
+                var coachName = coach?.Name ?? "Unassigned";
+                return new ListEntrySnapshot(unit.Name, coachName, null, coach?.Accent);
+            })
+            .ToList();
+    }
+}

--- a/WPF/FMUI.Wpf/Services/CardInteractionService.cs
+++ b/WPF/FMUI.Wpf/Services/CardInteractionService.cs
@@ -1,0 +1,1386 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Services;
+
+public interface ICardInteractionService
+{
+    void Initialize(CardSurfaceMetrics metrics);
+
+    void SetActiveSection(string tabIdentifier, string sectionIdentifier);
+
+    void SetCards(IReadOnlyList<CardViewModel> cards);
+
+    void SelectCard(CardViewModel card, SelectionModifier modifier);
+
+    void ClearSelection();
+
+    void BeginDrag(CardViewModel card);
+
+    void UpdateDrag(CardViewModel card, CardDragDelta delta);
+
+    void CompleteDrag(CardViewModel card, CardDragCompleted completed);
+
+    void BeginResize(CardViewModel card, ResizeHandle handle);
+
+    void UpdateResize(CardViewModel card, CardResizeDelta delta);
+
+    void CompleteResize(CardViewModel card, CardResizeCompleted completed);
+
+    void BeginPlayerDrag(CardViewModel card, FormationPlayerViewModel player);
+
+    void UpdatePlayerDrag(CardViewModel card, FormationPlayerViewModel player, FormationPlayerDragDelta delta);
+
+    void CompletePlayerDrag(CardViewModel card, FormationPlayerViewModel player, FormationPlayerDragCompleted completed);
+
+    void UpdateViewport(Rect viewport);
+
+    void NudgeSelection(int columnDelta, int rowDelta);
+
+    CardViewModel CreateCard(CardDefinition definition, bool isCustom, string? presetId);
+
+    void RemoveCards(IReadOnlyList<CardViewModel> cards);
+
+    IReadOnlyList<CardViewModel> GetSelectedCards();
+
+    bool HasSelection { get; }
+
+    bool CanUndo { get; }
+
+    bool CanRedo { get; }
+
+    void Undo();
+
+    void Redo();
+
+    event EventHandler? SelectionChanged;
+
+    event EventHandler? HistoryChanged;
+
+    event EventHandler<IReadOnlyList<CardPreviewSnapshot>>? PreviewChanged;
+
+    event EventHandler<CardMutationEventArgs>? CardsMutated;
+}
+
+public sealed class CardInteractionService : ICardInteractionService
+{
+    private readonly Dictionary<CardViewModel, InteractionState> _activeStates = new();
+    private readonly List<CardViewModel> _trackedCards = new();
+    private readonly Dictionary<string, CardViewModel> _cardLookup = new(StringComparer.Ordinal);
+    private readonly HashSet<CardViewModel> _selectedCards = new();
+    private readonly Stack<CardHistoryEntry> _undoStack = new();
+    private readonly Stack<CardHistoryEntry> _redoStack = new();
+    private readonly ICardLayoutStateService _stateService;
+    private readonly IClubDataService _clubDataService;
+    private CardSurfaceMetrics _metrics = CardSurfaceMetrics.Default;
+    private Rect _viewport;
+    private string _activeTab = string.Empty;
+    private string _activeSection = string.Empty;
+    private CardViewModel? _activeDragController;
+    private IReadOnlyList<CardGeometrySnapshot>? _pendingSnapshot;
+    private readonly List<CardPreviewSnapshot> _currentPreviews = new();
+    private bool _previewHasCollision;
+    private PlayerInteractionState? _activePlayerState;
+
+    public CardInteractionService(ICardLayoutStateService stateService, IClubDataService clubDataService)
+    {
+        _stateService = stateService;
+        _clubDataService = clubDataService;
+    }
+
+    public void Initialize(CardSurfaceMetrics metrics)
+    {
+        _metrics = metrics;
+        _viewport = new Rect(0, 0, metrics.SurfaceWidth, metrics.SurfaceHeight);
+    }
+
+    public void SetActiveSection(string tabIdentifier, string sectionIdentifier)
+    {
+        _activeTab = tabIdentifier;
+        _activeSection = sectionIdentifier;
+    }
+
+    public void SetCards(IReadOnlyList<CardViewModel> cards)
+    {
+        _activeStates.Clear();
+        _trackedCards.Clear();
+        _trackedCards.AddRange(cards);
+        _cardLookup.Clear();
+        foreach (var card in cards)
+        {
+            _cardLookup[card.Id] = card;
+        }
+
+        if (_undoStack.Count > 0 || _redoStack.Count > 0)
+        {
+            _undoStack.Clear();
+            _redoStack.Clear();
+            OnHistoryChanged();
+        }
+
+        _pendingSnapshot = null;
+        _activeDragController = null;
+        _activePlayerState = null;
+
+        if (_selectedCards.Count > 0)
+        {
+            foreach (var selected in _selectedCards)
+            {
+                selected.SetSelected(false);
+            }
+
+            _selectedCards.Clear();
+            OnSelectionChanged();
+        }
+
+        ClearPreview();
+
+        foreach (var card in cards)
+        {
+            UpdateCardVisibility(card);
+        }
+    }
+
+    public void SelectCard(CardViewModel card, SelectionModifier modifier)
+    {
+        if (!_trackedCards.Contains(card))
+        {
+            return;
+        }
+
+        var changed = false;
+
+        switch (modifier)
+        {
+            case SelectionModifier.Replace:
+                if (_selectedCards.Count != 1 || !_selectedCards.Contains(card))
+                {
+                    foreach (var selected in _selectedCards)
+                    {
+                        selected.SetSelected(false);
+                    }
+
+                    _selectedCards.Clear();
+                    _selectedCards.Add(card);
+                    card.SetSelected(true);
+                    changed = true;
+                }
+                break;
+            case SelectionModifier.Add:
+                if (_selectedCards.Add(card))
+                {
+                    card.SetSelected(true);
+                    changed = true;
+                }
+                break;
+            case SelectionModifier.Toggle:
+                if (_selectedCards.Remove(card))
+                {
+                    card.SetSelected(false);
+                    changed = true;
+                }
+                else
+                {
+                    _selectedCards.Add(card);
+                    card.SetSelected(true);
+                    changed = true;
+                }
+                break;
+        }
+
+        if (modifier == SelectionModifier.Replace && _selectedCards.Count == 0)
+        {
+            _selectedCards.Add(card);
+            card.SetSelected(true);
+            changed = true;
+        }
+
+        if (changed)
+        {
+            OnSelectionChanged();
+        }
+    }
+
+    public void ClearSelection()
+    {
+        if (_selectedCards.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var card in _selectedCards)
+        {
+            card.SetSelected(false);
+        }
+
+        _selectedCards.Clear();
+        OnSelectionChanged();
+        ClearPreview();
+    }
+
+    public void BeginDrag(CardViewModel card)
+    {
+        if (_selectedCards.Count == 0)
+        {
+            SelectCard(card, SelectionModifier.Replace);
+        }
+        else if (!_selectedCards.Contains(card))
+        {
+            SelectCard(card, SelectionModifier.Replace);
+        }
+
+        _activeStates.Clear();
+
+        foreach (var selected in _selectedCards)
+        {
+            _activeStates[selected] = InteractionState.CreateDrag(selected.Geometry);
+        }
+
+        _pendingSnapshot = CaptureSnapshot(_selectedCards);
+        _activeDragController = card;
+        UpdatePreview();
+    }
+
+    public void UpdateDrag(CardViewModel card, CardDragDelta delta)
+    {
+        if (_activeDragController != card)
+        {
+            return;
+        }
+
+        if (!_activeStates.TryGetValue(card, out var state) || state.Mode != InteractionMode.Drag)
+        {
+            return;
+        }
+
+        state.HorizontalDelta += delta.HorizontalChange;
+        state.VerticalDelta += delta.VerticalChange;
+
+        var originLeft = _metrics.CalculateLeft(state.OriginalGeometry.Column);
+        var originTop = _metrics.CalculateTop(state.OriginalGeometry.Row);
+
+        var newLeft = originLeft + state.HorizontalDelta;
+        var newTop = originTop + state.VerticalDelta;
+
+        var newColumn = _metrics.SnapColumn(newLeft, state.OriginalGeometry.ColumnSpan);
+        var newRow = _metrics.SnapRow(newTop, state.OriginalGeometry.RowSpan);
+
+        var columnDelta = newColumn - state.OriginalGeometry.Column;
+        var rowDelta = newRow - state.OriginalGeometry.Row;
+
+        foreach (var (selected, selectedState) in _activeStates)
+        {
+            var original = selectedState.OriginalGeometry;
+            var targetColumn = Math.Clamp(original.Column + columnDelta, 0, _metrics.Columns - original.ColumnSpan);
+            var targetRow = Math.Clamp(original.Row + rowDelta, 0, _metrics.Rows - original.RowSpan);
+            selected.UpdateGeometry(targetColumn, targetRow, original.ColumnSpan, original.RowSpan);
+            UpdateCardVisibility(selected);
+        }
+
+        UpdatePreview();
+    }
+
+    public void CompleteDrag(CardViewModel card, CardDragCompleted completed)
+    {
+        if (_activeDragController != card)
+        {
+            return;
+        }
+
+        _activeDragController = null;
+
+        if (!_activeStates.TryGetValue(card, out var state) || state.Mode != InteractionMode.Drag)
+        {
+            _activeStates.Clear();
+            return;
+        }
+
+        if (completed.Canceled)
+        {
+            if (_pendingSnapshot is not null)
+            {
+                ApplySnapshot(_pendingSnapshot);
+            }
+
+            _pendingSnapshot = null;
+            _activeStates.Clear();
+            ClearPreview();
+            return;
+        }
+
+        var hasCollision = _previewHasCollision;
+        ClearPreview();
+
+        if (hasCollision)
+        {
+            if (_pendingSnapshot is not null)
+            {
+                ApplySnapshot(_pendingSnapshot);
+            }
+
+            _pendingSnapshot = null;
+            _activeStates.Clear();
+            return;
+        }
+
+        var updated = new List<CardViewModel>(_selectedCards);
+        PersistGeometries(updated);
+
+        if (_pendingSnapshot is not null)
+        {
+            var after = CaptureSnapshot(updated);
+            CommitHistory(
+                _pendingSnapshot,
+                after,
+                Array.Empty<FormationPlayerPositionSnapshot>(),
+                Array.Empty<FormationPlayerPositionSnapshot>(),
+                Array.Empty<CardMutationSnapshot>(),
+                Array.Empty<CardMutationSnapshot>());
+            _pendingSnapshot = null;
+        }
+
+        _activeStates.Clear();
+    }
+
+    public void BeginResize(CardViewModel card, ResizeHandle handle)
+    {
+        _activeStates.Clear();
+        _activeStates[card] = InteractionState.CreateResize(card.Geometry, handle);
+        _pendingSnapshot = CaptureSnapshot(new[] { card });
+        UpdatePreview();
+    }
+
+    public void UpdateResize(CardViewModel card, CardResizeDelta delta)
+    {
+        if (!_activeStates.TryGetValue(card, out var state) || state.Mode != InteractionMode.Resize)
+        {
+            return;
+        }
+
+        if (state.Handle != delta.Handle)
+        {
+            return;
+        }
+
+        state.HorizontalDelta += delta.HorizontalChange;
+        state.VerticalDelta += delta.VerticalChange;
+
+        var (column, row, columnSpan, rowSpan) = state.OriginalGeometry;
+
+        if (state.Handle is ResizeHandle.East or ResizeHandle.SouthEast)
+        {
+            var spanChange = CalculateSpanChange(state.HorizontalDelta);
+            columnSpan = Math.Clamp(state.OriginalGeometry.ColumnSpan + spanChange, 1, _metrics.Columns - column);
+        }
+
+        if (state.Handle is ResizeHandle.South or ResizeHandle.SouthEast)
+        {
+            var spanChange = CalculateSpanChange(state.VerticalDelta);
+            rowSpan = Math.Clamp(state.OriginalGeometry.RowSpan + spanChange, 1, _metrics.Rows - row);
+        }
+
+        card.UpdateGeometry(column, row, columnSpan, rowSpan);
+        UpdateCardVisibility(card);
+        UpdatePreview();
+    }
+
+    public void CompleteResize(CardViewModel card, CardResizeCompleted completed)
+    {
+        if (!_activeStates.Remove(card, out var state) || state.Mode != InteractionMode.Resize)
+        {
+            return;
+        }
+
+        if (state.Handle != completed.Handle)
+        {
+            return;
+        }
+
+        if (completed.Canceled)
+        {
+            card.UpdateGeometry(
+                state.OriginalGeometry.Column,
+                state.OriginalGeometry.Row,
+                state.OriginalGeometry.ColumnSpan,
+                state.OriginalGeometry.RowSpan);
+            UpdateCardVisibility(card);
+            _pendingSnapshot = null;
+            ClearPreview();
+            return;
+        }
+
+        var hasCollision = _previewHasCollision;
+        ClearPreview();
+
+        if (hasCollision)
+        {
+            if (_pendingSnapshot is not null)
+            {
+                ApplySnapshot(_pendingSnapshot);
+                _pendingSnapshot = null;
+            }
+
+            card.UpdateGeometry(
+                state.OriginalGeometry.Column,
+                state.OriginalGeometry.Row,
+                state.OriginalGeometry.ColumnSpan,
+                state.OriginalGeometry.RowSpan);
+            UpdateCardVisibility(card);
+            return;
+        }
+
+        PersistGeometry(card);
+
+        if (_pendingSnapshot is not null)
+        {
+            var after = CaptureSnapshot(new[] { card });
+            CommitHistory(
+                _pendingSnapshot,
+                after,
+                Array.Empty<FormationPlayerPositionSnapshot>(),
+                Array.Empty<FormationPlayerPositionSnapshot>(),
+                Array.Empty<CardMutationSnapshot>(),
+                Array.Empty<CardMutationSnapshot>());
+            _pendingSnapshot = null;
+        }
+    }
+
+    public void BeginPlayerDrag(CardViewModel card, FormationPlayerViewModel player)
+    {
+        if (!_trackedCards.Contains(card) || !card.HasFormationPlayers)
+        {
+            return;
+        }
+
+        var snapshot = CaptureFormationSnapshot(card);
+        _activePlayerState = PlayerInteractionState.Create(card, player, snapshot);
+    }
+
+    public void UpdatePlayerDrag(CardViewModel card, FormationPlayerViewModel player, FormationPlayerDragDelta delta)
+    {
+        if (_activePlayerState is not { } state || state.Card != card || state.Player != player)
+        {
+            return;
+        }
+
+        var pitchWidth = Math.Max(delta.PitchWidth, 1d);
+        var pitchHeight = Math.Max(delta.PitchHeight, 1d);
+        var tokenWidth = Math.Max(delta.TokenSize, 0d);
+        var normalizedX = state.CurrentX + (delta.HorizontalChange / pitchWidth);
+        var normalizedY = state.CurrentY + (delta.VerticalChange / pitchHeight);
+
+        var halfTokenX = tokenWidth <= 0d ? 0d : (tokenWidth / 2d) / pitchWidth;
+        var halfTokenY = tokenWidth <= 0d ? 0d : (tokenWidth / 2d) / pitchHeight;
+
+        var minX = halfTokenX > 0d && halfTokenX < 0.5d ? halfTokenX : 0d;
+        var maxX = halfTokenX > 0d && halfTokenX < 0.5d ? 1d - halfTokenX : 1d;
+        var minY = halfTokenY > 0d && halfTokenY < 0.5d ? halfTokenY : 0d;
+        var maxY = halfTokenY > 0d && halfTokenY < 0.5d ? 1d - halfTokenY : 1d;
+
+        var clampedX = Math.Clamp(normalizedX, minX, maxX);
+        var clampedY = Math.Clamp(normalizedY, minY, maxY);
+
+        player.UpdateNormalizedPosition(clampedX, clampedY);
+        state.CurrentX = clampedX;
+        state.CurrentY = clampedY;
+    }
+
+    public void CompletePlayerDrag(CardViewModel card, FormationPlayerViewModel player, FormationPlayerDragCompleted completed)
+    {
+        if (_activePlayerState is not { } state || state.Card != card || state.Player != player)
+        {
+            return;
+        }
+
+        _activePlayerState = null;
+
+        if (completed.Canceled)
+        {
+            ApplyPlayerSnapshot(state.Before);
+            return;
+        }
+
+        var after = CaptureFormationSnapshot(card);
+        if (ArePlayerSnapshotsEqual(state.Before, after))
+        {
+            return;
+        }
+
+        PersistFormationPlayers(card);
+        CommitHistory(
+            Array.Empty<CardGeometrySnapshot>(),
+            Array.Empty<CardGeometrySnapshot>(),
+            state.Before,
+            after,
+            Array.Empty<CardMutationSnapshot>(),
+            Array.Empty<CardMutationSnapshot>());
+    }
+
+    public void UpdateViewport(Rect viewport)
+    {
+        if (double.IsNaN(viewport.Width) || double.IsNaN(viewport.Height) || viewport.Width <= 0 || viewport.Height <= 0)
+        {
+            _viewport = new Rect(0, 0, _metrics.SurfaceWidth, _metrics.SurfaceHeight);
+        }
+        else
+        {
+            _viewport = viewport;
+        }
+
+        foreach (var card in _trackedCards)
+        {
+            UpdateCardVisibility(card);
+        }
+    }
+
+    public void NudgeSelection(int columnDelta, int rowDelta)
+    {
+        if (_selectedCards.Count == 0)
+        {
+            return;
+        }
+
+        var before = CaptureSnapshot(_selectedCards);
+        var changed = false;
+
+        foreach (var card in _selectedCards)
+        {
+            var geometry = card.Geometry;
+            var newColumn = Math.Clamp(geometry.Column + columnDelta, 0, _metrics.Columns - geometry.ColumnSpan);
+            var newRow = Math.Clamp(geometry.Row + rowDelta, 0, _metrics.Rows - geometry.RowSpan);
+
+            if (newColumn != geometry.Column || newRow != geometry.Row)
+            {
+                card.UpdateGeometry(newColumn, newRow, geometry.ColumnSpan, geometry.RowSpan);
+                UpdateCardVisibility(card);
+                changed = true;
+            }
+        }
+
+        if (!changed)
+        {
+            return;
+        }
+
+        PersistGeometries(_selectedCards);
+        var after = CaptureSnapshot(_selectedCards);
+        CommitHistory(
+            before,
+            after,
+            Array.Empty<FormationPlayerPositionSnapshot>(),
+            Array.Empty<FormationPlayerPositionSnapshot>(),
+            Array.Empty<CardMutationSnapshot>(),
+            Array.Empty<CardMutationSnapshot>());
+    }
+
+    public IReadOnlyList<CardViewModel> GetSelectedCards()
+    {
+        if (_selectedCards.Count == 0)
+        {
+            return Array.Empty<CardViewModel>();
+        }
+
+        return _selectedCards.ToList();
+    }
+
+    public CardViewModel CreateCard(CardDefinition definition, bool isCustom, string? presetId)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        if (string.IsNullOrWhiteSpace(_activeTab) || string.IsNullOrWhiteSpace(_activeSection))
+        {
+            throw new InvalidOperationException("Cannot create a card when no section is active.");
+        }
+
+        var geometry = ResolveSpawnGeometry(definition);
+        if (geometry.Column != definition.Column || geometry.Row != definition.Row ||
+            geometry.ColumnSpan != definition.ColumnSpan || geometry.RowSpan != definition.RowSpan)
+        {
+            definition = definition with
+            {
+                Column = geometry.Column,
+                Row = geometry.Row,
+                ColumnSpan = geometry.ColumnSpan,
+                RowSpan = geometry.RowSpan
+            };
+        }
+
+        var card = new CardViewModel(definition, _metrics, this, _clubDataService, isCustom, presetId);
+        RegisterCard(card);
+        PersistGeometry(card);
+
+        if (isCustom)
+        {
+            _stateService.AddOrUpdateCustomCard(_activeTab, _activeSection, new CustomCardState(definition, presetId));
+        }
+        else
+        {
+            _stateService.RestoreRemovedCard(_activeTab, _activeSection, definition.Id);
+        }
+
+        var addedSnapshot = CreateMutationSnapshot(card);
+        var geometryAfter = CaptureSnapshot(new[] { card });
+        CommitHistory(
+            Array.Empty<CardGeometrySnapshot>(),
+            geometryAfter,
+            Array.Empty<FormationPlayerPositionSnapshot>(),
+            Array.Empty<FormationPlayerPositionSnapshot>(),
+            new[] { addedSnapshot },
+            Array.Empty<CardMutationSnapshot>());
+
+        CardsMutated?.Invoke(this, new CardMutationEventArgs(MutationOrigin.User, new[] { card }, Array.Empty<CardViewModel>()));
+        return card;
+    }
+
+    public void RemoveCards(IReadOnlyList<CardViewModel> cards)
+    {
+        if (cards is null || cards.Count == 0)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_activeTab) || string.IsNullOrWhiteSpace(_activeSection))
+        {
+            return;
+        }
+
+        if (HasActiveInteraction())
+        {
+            CancelActiveInteraction();
+        }
+
+        var toRemove = new List<CardViewModel>();
+        foreach (var card in cards)
+        {
+            if (card is null)
+            {
+                continue;
+            }
+
+            if (_cardLookup.ContainsKey(card.Id))
+            {
+                toRemove.Add(card);
+            }
+        }
+
+        if (toRemove.Count == 0)
+        {
+            return;
+        }
+
+        var geometryBefore = CaptureSnapshot(toRemove);
+        var formationBefore = new List<FormationPlayerPositionSnapshot>();
+        var removedSnapshots = new List<CardMutationSnapshot>(toRemove.Count);
+
+        foreach (var card in toRemove)
+        {
+            formationBefore.AddRange(CaptureFormationSnapshot(card));
+            removedSnapshots.Add(CreateMutationSnapshot(card));
+            RemoveCardInternal(card, persistState: true);
+        }
+
+        CommitHistory(
+            geometryBefore,
+            Array.Empty<CardGeometrySnapshot>(),
+            formationBefore,
+            Array.Empty<FormationPlayerPositionSnapshot>(),
+            Array.Empty<CardMutationSnapshot>(),
+            removedSnapshots);
+
+        CardsMutated?.Invoke(this, new CardMutationEventArgs(MutationOrigin.User, Array.Empty<CardViewModel>(), toRemove));
+    }
+
+    public bool HasSelection => _selectedCards.Count > 0;
+
+    public bool CanUndo => _undoStack.Count > 0;
+
+    public bool CanRedo => _redoStack.Count > 0;
+
+    public event EventHandler? SelectionChanged;
+
+    public event EventHandler? HistoryChanged;
+
+    public event EventHandler<IReadOnlyList<CardPreviewSnapshot>>? PreviewChanged;
+
+    public event EventHandler<CardMutationEventArgs>? CardsMutated;
+
+    public void Undo()
+    {
+        if (_undoStack.Count == 0)
+        {
+            return;
+        }
+
+        var entry = _undoStack.Pop();
+        var added = new List<CardViewModel>();
+        var removed = new List<CardViewModel>();
+
+        foreach (var snapshot in entry.AddedCards)
+        {
+            var card = RemoveCardFromSnapshot(snapshot);
+            if (card is not null)
+            {
+                removed.Add(card);
+            }
+        }
+
+        foreach (var snapshot in entry.RemovedCards)
+        {
+            var card = AddCardFromSnapshot(snapshot, select: false);
+            if (card is not null)
+            {
+                added.Add(card);
+            }
+        }
+
+        ApplySnapshot(entry.GeometryBefore);
+        ApplyPlayerSnapshot(entry.PlayersBefore);
+        _redoStack.Push(entry);
+        OnHistoryChanged();
+
+        if (added.Count > 0 || removed.Count > 0)
+        {
+            CardsMutated?.Invoke(this, new CardMutationEventArgs(MutationOrigin.UndoRedo, added, removed));
+        }
+    }
+
+    public void Redo()
+    {
+        if (_redoStack.Count == 0)
+        {
+            return;
+        }
+
+        var entry = _redoStack.Pop();
+        var added = new List<CardViewModel>();
+        var removed = new List<CardViewModel>();
+
+        foreach (var snapshot in entry.AddedCards)
+        {
+            var card = AddCardFromSnapshot(snapshot, select: false);
+            if (card is not null)
+            {
+                added.Add(card);
+            }
+        }
+
+        foreach (var snapshot in entry.RemovedCards)
+        {
+            var card = RemoveCardFromSnapshot(snapshot);
+            if (card is not null)
+            {
+                removed.Add(card);
+            }
+        }
+
+        ApplySnapshot(entry.GeometryAfter);
+        ApplyPlayerSnapshot(entry.PlayersAfter);
+        _undoStack.Push(entry);
+        OnHistoryChanged();
+
+        if (added.Count > 0 || removed.Count > 0)
+        {
+            CardsMutated?.Invoke(this, new CardMutationEventArgs(MutationOrigin.UndoRedo, added, removed));
+        }
+    }
+
+    private void RegisterCard(CardViewModel card, bool select = true)
+    {
+        _trackedCards.Add(card);
+        _cardLookup[card.Id] = card;
+        UpdateCardVisibility(card);
+
+        if (select)
+        {
+            if (_selectedCards.Count > 0)
+            {
+                foreach (var selected in _selectedCards)
+                {
+                    selected.SetSelected(false);
+                }
+
+                _selectedCards.Clear();
+            }
+
+            _selectedCards.Add(card);
+            card.SetSelected(true);
+            OnSelectionChanged();
+        }
+    }
+
+    private CardViewModel? AddCardFromSnapshot(CardMutationSnapshot snapshot, bool select)
+    {
+        if (string.IsNullOrWhiteSpace(_activeTab) || string.IsNullOrWhiteSpace(_activeSection))
+        {
+            return null;
+        }
+
+        var card = new CardViewModel(snapshot.Definition, _metrics, this, _clubDataService, snapshot.IsCustom, snapshot.PresetId);
+        RegisterCard(card, select);
+        PersistGeometry(card);
+
+        if (snapshot.IsCustom)
+        {
+            _stateService.AddOrUpdateCustomCard(_activeTab, _activeSection, new CustomCardState(snapshot.Definition, snapshot.PresetId));
+        }
+        else
+        {
+            _stateService.RestoreRemovedCard(_activeTab, _activeSection, snapshot.Definition.Id);
+        }
+
+        if (snapshot.FormationPlayers is { Count: > 0 })
+        {
+            card.ApplyFormationState(snapshot.FormationPlayers);
+            PersistFormationPlayers(card);
+        }
+
+        return card;
+    }
+
+    private CardViewModel? RemoveCardFromSnapshot(CardMutationSnapshot snapshot)
+    {
+        if (!_cardLookup.TryGetValue(snapshot.Definition.Id, out var card))
+        {
+            return null;
+        }
+
+        RemoveCardInternal(card, persistState: true);
+        return card;
+    }
+
+    private void RemoveCardInternal(CardViewModel card, bool persistState)
+    {
+        _trackedCards.Remove(card);
+        _cardLookup.Remove(card.Id);
+        _activeStates.Remove(card);
+
+        if (_selectedCards.Remove(card))
+        {
+            card.SetSelected(false);
+            OnSelectionChanged();
+        }
+
+        card.SetVisibility(false);
+
+        if (!persistState || string.IsNullOrWhiteSpace(_activeTab) || string.IsNullOrWhiteSpace(_activeSection))
+        {
+            return;
+        }
+
+        _stateService.RemoveCardState(_activeTab, _activeSection, card.Id);
+
+        if (card.IsCustom)
+        {
+            _stateService.RemoveCustomCard(_activeTab, _activeSection, card.Id);
+        }
+        else
+        {
+            _stateService.MarkCardRemoved(_activeTab, _activeSection, card.Id);
+        }
+    }
+
+    private void UpdateCardVisibility(CardViewModel card)
+    {
+        var bounds = card.GetBounds();
+        var paddedViewport = _viewport;
+        var padding = _metrics.TileSize + _metrics.Gap;
+        paddedViewport.Inflate(padding * 2, padding * 2);
+        var visible = paddedViewport.IntersectsWith(bounds);
+        card.SetVisibility(visible);
+    }
+
+    private void UpdatePreview()
+    {
+        if (_activeStates.Count == 0)
+        {
+            ClearPreview();
+            return;
+        }
+
+        var activeCards = new List<CardViewModel>(_activeStates.Keys);
+        var activeSet = new HashSet<CardViewModel>(activeCards);
+        var validity = new Dictionary<CardViewModel, bool>(activeCards.Count);
+        var geometries = new Dictionary<CardViewModel, CardGeometry>(activeCards.Count);
+
+        foreach (var card in activeCards)
+        {
+            validity[card] = true;
+            geometries[card] = card.Geometry;
+        }
+
+        foreach (var card in activeCards)
+        {
+            var geometry = geometries[card];
+            foreach (var other in _trackedCards)
+            {
+                if (ReferenceEquals(other, card) || activeSet.Contains(other))
+                {
+                    continue;
+                }
+
+                if (IsOverlap(geometry, other.Geometry))
+                {
+                    validity[card] = false;
+                    break;
+                }
+            }
+        }
+
+        for (var i = 0; i < activeCards.Count; i++)
+        {
+            var first = activeCards[i];
+            var firstGeometry = geometries[first];
+            for (var j = i + 1; j < activeCards.Count; j++)
+            {
+                var second = activeCards[j];
+                if (IsOverlap(firstGeometry, geometries[second]))
+                {
+                    validity[first] = false;
+                    validity[second] = false;
+                }
+            }
+        }
+
+        var previews = new List<CardPreviewSnapshot>(activeCards.Count);
+        var hasCollision = false;
+
+        foreach (var card in activeCards)
+        {
+            var isValid = validity[card];
+            if (!isValid)
+            {
+                hasCollision = true;
+            }
+
+            previews.Add(new CardPreviewSnapshot(card.Id, geometries[card], isValid));
+        }
+
+        _previewHasCollision = hasCollision;
+        _currentPreviews.Clear();
+        _currentPreviews.AddRange(previews);
+        PreviewChanged?.Invoke(this, _currentPreviews.ToArray());
+    }
+
+    private void ClearPreview()
+    {
+        if (_currentPreviews.Count == 0 && !_previewHasCollision)
+        {
+            return;
+        }
+
+        _currentPreviews.Clear();
+        _previewHasCollision = false;
+        PreviewChanged?.Invoke(this, Array.Empty<CardPreviewSnapshot>());
+    }
+
+    private void PersistGeometry(CardViewModel card)
+    {
+        if (string.IsNullOrWhiteSpace(_activeTab) || string.IsNullOrWhiteSpace(_activeSection))
+        {
+            return;
+        }
+
+        _stateService.UpdateGeometry(_activeTab, _activeSection, card.Id, card.Geometry);
+    }
+
+    private void PersistGeometries(IEnumerable<CardViewModel> cards)
+    {
+        if (string.IsNullOrWhiteSpace(_activeTab) || string.IsNullOrWhiteSpace(_activeSection))
+        {
+            return;
+        }
+
+        foreach (var card in cards)
+        {
+            _stateService.UpdateGeometry(_activeTab, _activeSection, card.Id, card.Geometry);
+        }
+    }
+
+    private void PersistFormationPlayers(CardViewModel card)
+    {
+        if (string.IsNullOrWhiteSpace(_activeTab) || string.IsNullOrWhiteSpace(_activeSection))
+        {
+            return;
+        }
+
+        var states = card.GetFormationPlayerStates();
+        if (states.Count == 0)
+        {
+            return;
+        }
+
+        _stateService.UpdateFormationPlayers(_activeTab, _activeSection, card.Id, states);
+    }
+
+    private int CalculateSpanChange(double delta)
+    {
+        var cellSize = _metrics.TileSize + _metrics.Gap;
+        return (int)Math.Round(delta / cellSize, MidpointRounding.AwayFromZero);
+    }
+
+    private IReadOnlyList<CardGeometrySnapshot> CaptureSnapshot(IEnumerable<CardViewModel> cards)
+    {
+        var list = new List<CardGeometrySnapshot>();
+        foreach (var card in cards)
+        {
+            list.Add(new CardGeometrySnapshot(card.Id, card.Geometry));
+        }
+
+        list.Sort((left, right) => string.CompareOrdinal(left.CardId, right.CardId));
+        return list;
+    }
+
+    private IReadOnlyList<FormationPlayerPositionSnapshot> CaptureFormationSnapshot(CardViewModel card)
+    {
+        if (!card.HasFormationPlayers)
+        {
+            return Array.Empty<FormationPlayerPositionSnapshot>();
+        }
+
+        var list = new List<FormationPlayerPositionSnapshot>(card.FormationPlayers.Count);
+        foreach (var player in card.FormationPlayers)
+        {
+            list.Add(new FormationPlayerPositionSnapshot(card.Id, player.Id, player.NormalizedX, player.NormalizedY));
+        }
+
+        list.Sort(static (left, right) =>
+        {
+            var cardComparison = string.CompareOrdinal(left.CardId, right.CardId);
+            return cardComparison != 0
+                ? cardComparison
+                : string.CompareOrdinal(left.PlayerId, right.PlayerId);
+        });
+
+        return list;
+    }
+
+    private void ApplySnapshot(IReadOnlyList<CardGeometrySnapshot> snapshot)
+    {
+        var updated = new List<CardViewModel>();
+
+        foreach (var geometrySnapshot in snapshot)
+        {
+            if (!_cardLookup.TryGetValue(geometrySnapshot.CardId, out var card))
+            {
+                continue;
+            }
+
+            var geometry = geometrySnapshot.Geometry;
+            card.UpdateGeometry(geometry.Column, geometry.Row, geometry.ColumnSpan, geometry.RowSpan);
+            UpdateCardVisibility(card);
+            updated.Add(card);
+        }
+
+        if (updated.Count > 0)
+        {
+            PersistGeometries(updated);
+        }
+    }
+
+    private void ApplyPlayerSnapshot(IReadOnlyList<FormationPlayerPositionSnapshot> snapshot)
+    {
+        if (snapshot is null || snapshot.Count == 0)
+        {
+            return;
+        }
+
+        var updatedCards = new HashSet<CardViewModel>();
+
+        foreach (var playerSnapshot in snapshot)
+        {
+            if (!_cardLookup.TryGetValue(playerSnapshot.CardId, out var card))
+            {
+                continue;
+            }
+
+            card.UpdateFormationPlayer(playerSnapshot.PlayerId, playerSnapshot.X, playerSnapshot.Y);
+            updatedCards.Add(card);
+        }
+
+        foreach (var card in updatedCards)
+        {
+            PersistFormationPlayers(card);
+        }
+    }
+
+    private void CommitHistory(
+        IReadOnlyList<CardGeometrySnapshot> geometryBefore,
+        IReadOnlyList<CardGeometrySnapshot> geometryAfter,
+        IReadOnlyList<FormationPlayerPositionSnapshot> playersBefore,
+        IReadOnlyList<FormationPlayerPositionSnapshot> playersAfter,
+        IReadOnlyList<CardMutationSnapshot> addedCards,
+        IReadOnlyList<CardMutationSnapshot> removedCards)
+    {
+        if (AreSnapshotsEqual(geometryBefore, geometryAfter) &&
+            ArePlayerSnapshotsEqual(playersBefore, playersAfter) &&
+            AreMutationSnapshotsEqual(addedCards, removedCards))
+        {
+            return;
+        }
+
+        _undoStack.Push(new CardHistoryEntry(geometryBefore, geometryAfter, playersBefore, playersAfter, addedCards, removedCards));
+        _redoStack.Clear();
+        OnHistoryChanged();
+    }
+
+    private static bool IsOverlap(CardGeometry first, CardGeometry second)
+    {
+        var firstColumnEnd = first.Column + first.ColumnSpan;
+        var secondColumnEnd = second.Column + second.ColumnSpan;
+        if (firstColumnEnd <= second.Column || secondColumnEnd <= first.Column)
+        {
+            return false;
+        }
+
+        var firstRowEnd = first.Row + first.RowSpan;
+        var secondRowEnd = second.Row + second.RowSpan;
+        if (firstRowEnd <= second.Row || secondRowEnd <= first.Row)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool AreSnapshotsEqual(IReadOnlyList<CardGeometrySnapshot> left, IReadOnlyList<CardGeometrySnapshot> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (!left[i].Equals(right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ArePlayerSnapshotsEqual(
+        IReadOnlyList<FormationPlayerPositionSnapshot> left,
+        IReadOnlyList<FormationPlayerPositionSnapshot> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (!left[i].Equals(right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool AreMutationSnapshotsEqual(
+        IReadOnlyList<CardMutationSnapshot> added,
+        IReadOnlyList<CardMutationSnapshot> removed)
+    {
+        return added.Count == 0 && removed.Count == 0;
+    }
+
+    private CardGeometry ResolveSpawnGeometry(CardDefinition definition)
+    {
+        var spanColumns = Math.Clamp(definition.ColumnSpan, 1, _metrics.Columns);
+        var spanRows = Math.Clamp(definition.RowSpan, 1, _metrics.Rows);
+        var maxColumn = Math.Max(0, _metrics.Columns - spanColumns);
+        var maxRow = Math.Max(0, _metrics.Rows - spanRows);
+        var startColumn = Math.Clamp(definition.Column, 0, maxColumn);
+        var startRow = Math.Clamp(definition.Row, 0, maxRow);
+
+        var positions = new List<(int Column, int Row)>();
+        for (var row = 0; row <= maxRow; row++)
+        {
+            for (var column = 0; column <= maxColumn; column++)
+            {
+                positions.Add((column, row));
+            }
+        }
+
+        if (positions.Count == 0)
+        {
+            return new CardGeometry(0, 0, spanColumns, spanRows);
+        }
+
+        var startIndex = positions.FindIndex(position => position.Column == startColumn && position.Row == startRow);
+        if (startIndex < 0)
+        {
+            startIndex = 0;
+        }
+
+        for (var i = 0; i < positions.Count; i++)
+        {
+            var position = positions[(startIndex + i) % positions.Count];
+            var candidate = new CardGeometry(position.Column, position.Row, spanColumns, spanRows);
+            if (!HasCollision(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return new CardGeometry(startColumn, startRow, spanColumns, spanRows);
+    }
+
+    private bool HasCollision(CardGeometry candidate)
+    {
+        foreach (var existing in _trackedCards)
+        {
+            if (IsOverlap(candidate, existing.Geometry))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool HasActiveInteraction()
+    {
+        return _activeStates.Count > 0
+            || _activeDragController is not null
+            || _activePlayerState is not null
+            || _pendingSnapshot is not null
+            || _previewHasCollision;
+    }
+
+    private void CancelActiveInteraction()
+    {
+        if (_pendingSnapshot is not null)
+        {
+            ApplySnapshot(_pendingSnapshot);
+            _pendingSnapshot = null;
+        }
+
+        if (_activePlayerState is not null)
+        {
+            ApplyPlayerSnapshot(_activePlayerState.Before);
+            _activePlayerState = null;
+        }
+
+        _activeStates.Clear();
+        _activeDragController = null;
+        ClearPreview();
+    }
+
+    private CardMutationSnapshot CreateMutationSnapshot(CardViewModel card)
+    {
+        var formationState = card.HasFormationPlayers ? card.GetFormationPlayerStates() : Array.Empty<FormationPlayerState>();
+        return new CardMutationSnapshot(card.Definition, card.PresetId, card.IsCustom, formationState);
+    }
+
+    private void OnSelectionChanged()
+    {
+        SelectionChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnHistoryChanged()
+    {
+        HistoryChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed class InteractionState
+    {
+        private InteractionState(InteractionMode mode, CardGeometry geometry, ResizeHandle handle)
+        {
+            Mode = mode;
+            OriginalGeometry = geometry;
+            Handle = handle;
+        }
+
+        public static InteractionState CreateDrag(CardGeometry geometry) =>
+            new(InteractionMode.Drag, geometry, ResizeHandle.SouthEast);
+
+        public static InteractionState CreateResize(CardGeometry geometry, ResizeHandle handle) =>
+            new(InteractionMode.Resize, geometry, handle);
+
+        public InteractionMode Mode { get; }
+
+        public CardGeometry OriginalGeometry { get; }
+
+        public ResizeHandle Handle { get; }
+
+        public double HorizontalDelta { get; set; }
+
+        public double VerticalDelta { get; set; }
+    }
+
+    private enum InteractionMode
+    {
+        Drag,
+        Resize
+    }
+
+    private sealed class PlayerInteractionState
+    {
+        private PlayerInteractionState(
+            CardViewModel card,
+            FormationPlayerViewModel player,
+            IReadOnlyList<FormationPlayerPositionSnapshot> before)
+        {
+            Card = card;
+            Player = player;
+            Before = before;
+            StartX = player.NormalizedX;
+            StartY = player.NormalizedY;
+            CurrentX = StartX;
+            CurrentY = StartY;
+        }
+
+        public CardViewModel Card { get; }
+
+        public FormationPlayerViewModel Player { get; }
+
+        public IReadOnlyList<FormationPlayerPositionSnapshot> Before { get; }
+
+        public double StartX { get; }
+
+        public double StartY { get; }
+
+        public double CurrentX { get; set; }
+
+        public double CurrentY { get; set; }
+
+        public static PlayerInteractionState Create(
+            CardViewModel card,
+            FormationPlayerViewModel player,
+            IReadOnlyList<FormationPlayerPositionSnapshot> before) =>
+            new(card, player, before);
+    }
+}
+
+public enum MutationOrigin
+{
+    User,
+    UndoRedo
+}
+
+public sealed class CardMutationEventArgs : EventArgs
+{
+    public CardMutationEventArgs(MutationOrigin origin, IReadOnlyList<CardViewModel> addedCards, IReadOnlyList<CardViewModel> removedCards)
+    {
+        Origin = origin;
+        AddedCards = addedCards ?? Array.Empty<CardViewModel>();
+        RemovedCards = removedCards ?? Array.Empty<CardViewModel>();
+    }
+
+    public MutationOrigin Origin { get; }
+
+    public IReadOnlyList<CardViewModel> AddedCards { get; }
+
+    public IReadOnlyList<CardViewModel> RemovedCards { get; }
+}

--- a/WPF/FMUI.Wpf/Services/CardLayoutCatalog.cs
+++ b/WPF/FMUI.Wpf/Services/CardLayoutCatalog.cs
@@ -1,0 +1,2083 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface ICardLayoutCatalog
+{
+    event EventHandler<LayoutsChangedEventArgs>? LayoutsChanged;
+
+    bool TryGetLayout(string tabIdentifier, string sectionIdentifier, out CardLayout layout);
+}
+
+public sealed class CardLayoutCatalog : ICardLayoutCatalog, IDisposable
+{
+    private readonly IClubDataService _clubDataService;
+    private readonly object _sync = new();
+    private Dictionary<(string Tab, string Section), CardLayout> _layouts;
+    private bool _disposed;
+
+    public CardLayoutCatalog(IClubDataService clubDataService)
+    {
+        _clubDataService = clubDataService;
+        _layouts = BuildLayouts(clubDataService.GetSnapshot());
+        _clubDataService.SnapshotChanged += OnSnapshotChanged;
+    }
+
+    public event EventHandler<LayoutsChangedEventArgs>? LayoutsChanged;
+
+    public bool TryGetLayout(string tabIdentifier, string sectionIdentifier, out CardLayout layout)
+    {
+        lock (_sync)
+        {
+            return _layouts.TryGetValue((tabIdentifier, sectionIdentifier), out layout);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _clubDataService.SnapshotChanged -= OnSnapshotChanged;
+        GC.SuppressFinalize(this);
+    }
+
+    private void OnSnapshotChanged(object? sender, ClubDataSnapshot snapshot)
+    {
+        var layouts = BuildLayouts(snapshot);
+
+        lock (_sync)
+        {
+            _layouts = layouts;
+        }
+
+        var keys = layouts.Keys.ToArray();
+        LayoutsChanged?.Invoke(this, new LayoutsChangedEventArgs(keys, isGlobal: true));
+    }
+
+    private static Dictionary<(string, string), CardLayout> BuildLayouts(ClubDataSnapshot snapshot) =>
+        new()
+        {
+            [("overview", "club-vision")] = BuildClubVisionOverview(snapshot.Overview.ClubVision),
+            [("overview", "dynamics")] = BuildDynamicsOverview(snapshot.Overview.Dynamics),
+            [("overview", "medical-centre")] = BuildMedicalCentre(snapshot.Overview.Medical),
+            [("overview", "analytics")] = BuildAnalyticsOverview(snapshot.Overview.Analytics),
+            [("squad", "selection-info")] = BuildSquadSelectionInfo(snapshot.Squad.SelectionInfo),
+            [("squad", "players")] = BuildSquadPlayers(snapshot.Squad.Players),
+            [("squad", "international")] = BuildSquadInternational(snapshot.Squad.International),
+            [("squad", "squad-depth")] = BuildSquadDepth(snapshot.Squad.Depth),
+            [("tactics", "tactics-overview")] = BuildTacticsOverview(snapshot.Tactics),
+            [("tactics", "set-pieces")] = BuildTacticsSetPieces(snapshot.Tactics.SetPieces),
+            [("tactics", "tactics-analysis")] = BuildTacticsAnalysis(snapshot.Tactics.Analysis),
+            [("training", "training-overview")] = BuildTrainingOverview(snapshot.Training.Overview),
+            [("training", "training-calendar")] = BuildTrainingCalendar(snapshot.Training.Calendar),
+            [("training", "training-units")] = BuildTrainingUnits(snapshot.Training.Units),
+            [("transfers", "transfer-centre")] = BuildTransferCentre(snapshot.Transfers.Centre),
+            [("transfers", "scouting")] = BuildTransfersScouting(snapshot.Transfers.Scouting),
+            [("transfers", "shortlist")] = BuildTransfersShortlist(snapshot.Transfers.Shortlist),
+            [("finances", "finances-summary")] = BuildFinancesSummary(snapshot.Finance.Summary),
+            [("finances", "finances-income")] = BuildFinancesIncome(snapshot.Finance.Income),
+            [("finances", "finances-expenditure")] = BuildFinancesExpenditure(snapshot.Finance.Expenditure),
+            [("fixtures", "fixtures-schedule")] = BuildFixturesSchedule(snapshot.Fixtures.Schedule),
+            [("fixtures", "fixtures-results")] = BuildFixturesResults(snapshot.Fixtures.Results),
+            [("fixtures", "fixtures-calendar")] = BuildFixturesCalendar(snapshot.Fixtures.Calendar),
+        };
+
+    private static CardLayout BuildTacticsOverview(TacticalSnapshot snapshot)
+    {
+        var cards = new List<CardDefinition>
+        {
+            new(
+                Id: "formation-overview",
+                Title: snapshot.FormationName,
+                Subtitle: snapshot.SquadLabel,
+                Kind: CardKind.Formation,
+                Column: 0,
+                Row: 0,
+                ColumnSpan: 22,
+                RowSpan: 14,
+                Description: snapshot.Description,
+                PillText: snapshot.MentalityPill,
+                FormationLines: snapshot.FormationLines
+                    .Select(line => new FormationLineDefinition(
+                        line.Role,
+                        line.Players
+                            .Select(player => new FormationPlayerDefinition(player.Id, player.Name, player.X, player.Y))
+                            .ToList()))
+                    .ToList()),
+            CreateMetricCard("team-fluidity", "Team Fluidity", "Shape cohesion", snapshot.Fluidity, 22, 0, 7, 5),
+            CreateMetricCard("mentality", "Mentality", "In possession mindset", snapshot.Mentality, 29, 0, 8, 5),
+            new(
+                Id: "in-possession",
+                Title: "In Possession",
+                Subtitle: "Selected instructions",
+                Kind: CardKind.List,
+                Column: 22,
+                Row: 5,
+                ColumnSpan: 15,
+                RowSpan: 7,
+                Description: snapshot.InPossession.Description,
+                ListItems: MapInstructionItems(snapshot.InPossession.Items)),
+            new(
+                Id: "in-transition",
+                Title: "In Transition",
+                Subtitle: "Moment reactions",
+                Kind: CardKind.List,
+                Column: 22,
+                Row: 12,
+                ColumnSpan: 15,
+                RowSpan: 7,
+                ListItems: MapInstructionItems(snapshot.InTransition.Items)),
+            new(
+                Id: "out-of-possession",
+                Title: "Out Of Possession",
+                Subtitle: "Defensive block",
+                Kind: CardKind.List,
+                Column: 0,
+                Row: 14,
+                ColumnSpan: 18,
+                RowSpan: 5,
+                ListItems: MapInstructionItems(snapshot.OutOfPossession.Items)),
+            CreateFixtureCard(),
+            new(
+                Id: "tactical-familiarity",
+                Title: "Tactical Familiarity",
+                Subtitle: "Team understanding",
+                Kind: CardKind.Status,
+                Column: 0,
+                Row: 14,
+                ColumnSpan: 8,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("Mentality", "Accomplished"),
+                    new("Passing Style", "Fluid"),
+                    new("Pressing", "Highly Responsive"),
+                    new("Creative Freedom", "Well Adapted"),
+                }),
+            new(
+                Id: "fitness-report",
+                Title: "Fitness Report",
+                Subtitle: "Medical Centre",
+                Kind: CardKind.List,
+                Column: 8,
+                Row: 14,
+                ColumnSpan: 10,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("Gabriel Jesus", "Out (2-3 weeks)", "Sprained Knee Ligaments"),
+                    new("Thomas Partey", "Doubtful", "Lacking match fitness"),
+                    new("Oleksandr Zinchenko", "Match Fit", "Ready for selection"),
+                }),
+            new(
+                Id: "recent-form",
+                Title: "Recent Form",
+                Subtitle: "Last five fixtures",
+                Kind: CardKind.List,
+                Column: 18,
+                Row: 14,
+                ColumnSpan: 19,
+                RowSpan: 5,
+                ListItems: new List<CardListItem>
+                {
+                    new("vs Man City", "W 2-1", "Premier League", "Sat"),
+                    new("vs Chelsea", "D 0-0", "Premier League", "Wed"),
+                    new("vs Everton", "W 3-0", "Premier League", "Sun"),
+                    new("vs PSG", "L 1-2", "Champions League", "Tue"),
+                    new("vs Leicester", "W 4-1", "Premier League", "Sat"),
+                }),
+        };
+
+        var extras = new List<CardPresetDefinition>
+        {
+            CreatePreset(
+                new CardDefinition(
+                    Id: "transition-triggers",
+                    Title: "Transition Triggers",
+                    Subtitle: "Pressing cues",
+                    Kind: CardKind.List,
+                    Column: 0,
+                    Row: 0,
+                    ColumnSpan: 16,
+                    RowSpan: 6,
+                    Description: "Compact summary of the transition instructions",
+                    ListItems: MapInstructionItems(snapshot.InTransition.Items.Take(4).ToList())),
+                "Transition Triggers",
+                "Pin the key pressing reactions from the transition phase"),
+            CreatePreset(
+                CreateListCard(
+                    "analysis-recommendations",
+                    "Analyst Recommendations",
+                    "Coaching calls",
+                    0,
+                    0,
+                    17,
+                    6,
+                    snapshot.Analysis.Recommendations),
+                "Analyst Recommendations",
+                "Surface the analysis team's tactical guidance on the overview"),
+        };
+
+        return CreateLayout("tactics", "tactics-overview", cards, extras);
+    }
+
+    private static CardLayout BuildTacticsSetPieces(SetPieceSnapshot setPieces)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("attacking-corners", "Attacking Corners", "Delivery plans", 0, 0, 18, 7, setPieces.AttackingCorners),
+            CreateListCard("defending-corners", "Defending Corners", "Assignments", 18, 0, 19, 7, setPieces.DefendingCorners),
+            CreateListCard("free-kicks", "Free Kicks", "Primary takers", 0, 7, 18, 6, setPieces.FreeKicks),
+            CreateListCard("throw-ins", "Throw-Ins", "Routine focus", 18, 7, 19, 6, setPieces.ThrowIns),
+            CreateListCard("penalty-takers", "Penalty Order", "Hierarchy", 0, 13, 37, 6, setPieces.PenaltyTakers),
+        };
+
+        return CreateLayout("tactics", "set-pieces", cards);
+    }
+
+    private static CardLayout BuildTacticsAnalysis(TacticalAnalysisSnapshot analysis)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateMetricCard("recent-form", "Recent Form", "Last five matches", analysis.RecentForm, 0, 0, 12, 5),
+            CreateListCard("strengths", "Strengths", "Where we excel", 12, 0, 12, 7, analysis.Strengths),
+            CreateListCard("weaknesses", "Weaknesses", "Risks to manage", 24, 0, 13, 7, analysis.Weaknesses),
+            CreateListCard("key-statistics", "Key Statistics", "Performance snapshot", 0, 5, 18, 7, analysis.Statistics),
+            CreateListCard("recommendations", "Recommendations", "Coaching directives", 18, 5, 19, 7, analysis.Recommendations),
+        };
+
+        return CreateLayout("tactics", "tactics-analysis", cards);
+    }
+
+    private static CardLayout BuildClubVisionOverview(ClubVisionSnapshot clubVision)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateMetricCard("board-confidence", "Board Confidence", "Season to date", clubVision.BoardConfidence, 0, 0, 12, 6),
+            CreateMetricCard("supporter-confidence", "Supporter Confidence", "Mood of the terraces", clubVision.SupporterConfidence, 12, 0, 12, 6),
+            CreateClubVisionExpectationBoardCard(
+                "competition-objectives",
+                "Competition Objectives",
+                "Season targets and board expectations",
+                24,
+                0,
+                13,
+                9,
+                clubVision.ExpectationBoard),
+            CreateClubVisionRoadmapCard(
+                "strategic-roadmap",
+                "Strategic Roadmap",
+                "Five-year milestones and status",
+                0,
+                6,
+                24,
+                6,
+                clubVision.Roadmap),
+            CreateListCard("finance-snapshot", "Finance Snapshot", "Month to date", 0, 12, 18, 7, clubVision.FinanceSnapshot),
+            CreateListCard("top-performers", "Top Performers", "Last five matches", 18, 12, 19, 7, clubVision.TopPerformers),
+        };
+
+        var extras = new List<CardPresetDefinition>
+        {
+            CreatePreset(
+                CreateListCard(
+                    "club-vision-finance-focus",
+                    "Finance Focus",
+                    "Board-monitored lines",
+                    0,
+                    0,
+                    14,
+                    6,
+                    clubVision.FinanceSnapshot.Take(4).ToList()),
+                "Finance Focus",
+                "Compact list of the finance snapshot items under review"),
+            CreatePreset(
+                CreateListCard(
+                    "club-vision-key-objectives",
+                    "Competition Objectives (Top 3)",
+                    "Season priorities",
+                    0,
+                    0,
+                    14,
+                    6,
+                    clubVision.CompetitionExpectations.Take(3).ToList()),
+                "Competition Objectives (Top 3)",
+                "Highlight the highest priority competition targets"),
+        };
+
+        return CreateLayout("overview", "club-vision", cards, extras);
+    }
+
+    private static CardLayout BuildDynamicsOverview(DynamicsSnapshot dynamics)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateMetricCard("team-cohesion", "Team Cohesion", "Unit synergy", dynamics.TeamCohesion, 0, 0, 12, 5),
+            CreateMetricCard("dressing-room", "Dressing Room Atmosphere", "Mood", dynamics.DressingRoomAtmosphere, 12, 0, 12, 5),
+            CreateMetricCard("managerial-support", "Managerial Support", "Leadership trust", dynamics.ManagerialSupport, 24, 0, 13, 5),
+            CreateListCard("social-groups", "Social Groups", "Relationships", 0, 5, 18, 7, dynamics.SocialGroups),
+            CreateListCard("influencers", "Influencers", "Leadership core", 18, 5, 9, 7, dynamics.Influencers),
+            CreateMoraleHeatmapCard(dynamics.MoraleHeatmap),
+            CreateListCard("player-issues", "Player Issues", "Concerns raised", 27, 5, 10, 7, dynamics.PlayerIssues),
+            CreateListCard("meetings", "Upcoming Meetings", "Engagement diary", 18, 12, 9, 7, dynamics.Meetings),
+            CreateListCard("praise", "Recent Praise", "Positive feedback", 27, 12, 10, 7, dynamics.PraiseMoments),
+        };
+
+        var extras = new List<CardPresetDefinition>
+        {
+            CreatePreset(
+                CreateListCard(
+                    "dynamics-leadership-core",
+                    "Leadership Core",
+                    "Influencers & captains",
+                    0,
+                    0,
+                    16,
+                    6,
+                    dynamics.Influencers),
+                "Leadership Core",
+                "Quick access to the dressing room leadership group"),
+            CreatePreset(
+                CreateListCard(
+                    "dynamics-social-landscape",
+                    "Social Landscape",
+                    "Key groups",
+                    0,
+                    0,
+                    18,
+                    6,
+                    dynamics.SocialGroups.Take(4).ToList()),
+                "Social Landscape",
+                "Summarise the dominant social groups in the squad"),
+        };
+
+        return CreateLayout("overview", "dynamics", cards, extras);
+    }
+
+    private static CardLayout BuildMedicalCentre(MedicalSnapshot medical)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("injury-report", "Injury Report", "Current status", 0, 0, 19, 7, medical.InjuryList),
+            CreateMetricCard("risk-assessment", "Risk Assessment", "Squad readiness", medical.RiskAssessment, 19, 0, 9, 5),
+            CreateMetricCard("workload-monitoring", "Workload Monitoring", "Training load", medical.WorkloadMonitoring, 28, 0, 9, 5),
+            CreateListCard("rehab-progress", "Rehab Progress", "Return timelines", 0, 7, 19, 5, medical.RehabProgress),
+            CreateListCard("risk-breakdown", "Risk Breakdown", "Likelihood overview", 19, 5, 18, 7, medical.RiskBreakdown),
+            CreateListCard("staff-notes", "Staff Notes", "Medical guidance", 0, 12, 19, 7, medical.StaffNotes),
+            CreateMedicalTimelineCard("medical-timeline", "Injury Timeline", "Rehab phases", medical.Timeline, 19, 12, 18, 7),
+        };
+
+        return CreateLayout("overview", "medical-centre", cards);
+    }
+
+    private static CardLayout BuildAnalyticsOverview(AnalyticsSnapshot analytics)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateLineChartCard("expected-goals", "Expected Goals Trend", "Rolling average", analytics.ExpectedGoalsTrend, 0, 0, 12, 5),
+            CreateShotMapCard("shot-map", "Shot Map", "Location & outcome", analytics.ShotMap, 12, 0, 12, 7),
+            CreateListCard("possession-zones", "Possession Zones", "Territory split", 24, 0, 13, 7, analytics.PossessionZones),
+            CreateListCard("passing-network", "Passing Network", "Combinations", 0, 5, 18, 7, analytics.PassingNetworks),
+            CreateListCard("team-comparison", "Team Comparison", "League rank", 18, 5, 9, 7, analytics.TeamComparison),
+            CreateListCard("key-stats", "Key Stats", "Performance summary", 27, 5, 10, 7, analytics.KeyStats),
+        };
+
+        return CreateLayout("overview", "analytics", cards);
+    }
+
+    private static CardLayout BuildSquadSelectionInfo(SelectionInfoSnapshot selection)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("matchday-readiness", "Matchday Readiness", "Squad availability", 0, 0, 19, 6, selection.MatchdayReadiness),
+            CreateListCard("fitness-concerns", "Fitness Concerns", "Players to monitor", 19, 0, 18, 6, selection.FitnessConcerns),
+            CreateListCard("suspensions", "Suspensions", "Unavailable", 0, 6, 18, 5, selection.Suspensions),
+            CreateListCard("recent-form", "Recent Form", "Performance trend", 18, 6, 19, 5, selection.RecentForm),
+            CreateListCard("training-focus", "Training Focus", "Session priorities", 0, 11, 37, 8, selection.TrainingFocus),
+        };
+
+        return CreateLayout("squad", "selection-info", cards);
+    }
+
+    private static CardLayout BuildSquadPlayers(PlayersSnapshot players)
+    {
+        var cards = new List<CardDefinition>();
+
+        if (players.Roster is { Count: > 0 })
+        {
+            cards.Add(CreateSquadTableCard(
+                "squad-roster",
+                "Squad Roster",
+                "Filter, compare, and plan selection",
+                MapSquadPlayers(players.Roster),
+                column: 0,
+                row: 0,
+                columnSpan: 25,
+                rowSpan: 12));
+        }
+
+        cards.Add(CreateListCard("key-players", "Key Players", "Impact metrics", 0, 12, 25, 7, players.KeyPlayers));
+        cards.Add(CreateListCard("statistics-leaders", "Statistics Leaders", "Season leaders", 25, 0, 12, 6, players.StatisticsLeaders));
+        cards.Add(CreateListCard("emerging-players", "Emerging Players", "Development watch", 25, 6, 12, 4, players.EmergingPlayers));
+        cards.Add(CreateListCard("contract-status", "Contract Status", "Expiry overview", 25, 10, 12, 4, players.ContractStatus));
+        cards.Add(CreateListCard("transfer-interest", "Transfer Interest", "Clubs monitoring", 25, 14, 12, 5, players.TransferInterest));
+
+        return CreateLayout("squad", "players", cards);
+    }
+
+    private static CardLayout BuildSquadInternational(InternationalSnapshot international)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("call-ups", "International Call-Ups", "Current squads", 0, 0, 18, 7, international.CallUps),
+            CreateListCard("travel-plans", "Travel Plans", "Logistics", 18, 0, 19, 7, international.TravelPlans),
+            CreateListCard("availability", "Availability", "Return timelines", 0, 7, 18, 6, international.Availability),
+            CreateListCard("scouting-reports", "Scouting Reports", "Talent radar", 18, 7, 19, 6, international.ScoutingReports),
+        };
+
+        return CreateLayout("squad", "international", cards);
+    }
+
+    private static CardLayout BuildSquadDepth(SquadDepthSnapshot depth)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("depth-chart", "Depth Chart", "Primary options", 0, 0, 18, 7, depth.DepthChart),
+            CreateListCard("role-battles", "Role Battles", "Selection dilemmas", 18, 0, 19, 7, depth.RoleBattles),
+            CreateListCard("youth-depth", "Youth Depth", "Academy coverage", 0, 7, 18, 6, depth.YouthDepth),
+            CreateListCard("positional-ratings", "Positional Ratings", "Star levels", 18, 7, 19, 6, depth.PositionalRatings),
+        };
+
+        return CreateLayout("squad", "squad-depth", cards);
+    }
+
+    private static CardLayout BuildTrainingOverview(TrainingOverviewSnapshot training)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("upcoming-sessions", "Upcoming Sessions", "Next 5 days", 0, 0, 20, 7, training.UpcomingSessions),
+            CreateGaugeCard("training-intensity", "Training Intensity", "Overall load", training.Intensity, 20, 0, 9, 7),
+            CreateListCard("focus-areas", "Focus Areas", "Current emphasis", 29, 0, 8, 7, training.FocusAreas),
+            CreateWorkloadHeatmapCard(training.WorkloadHeatmap),
+            CreateListCard("unit-coaches", "Unit Coaches", "Specialist assignments", 28, 7, 9, 4, training.UnitCoaches),
+            CreateListCard("medical-workload", "Medical Workload", "Risk watch", 28, 11, 9, 3, training.MedicalWorkload),
+            CreateListCard("match-prep", "Match Prep", "Weekend fixture", 28, 14, 9, 2, training.MatchPreparation),
+            CreateTrainingProgressionCard("training-progression", "Development Trends", "Progress over last month", 0, 15, 20, 4, training.Progression),
+            CreateListCard("individual-focus", "Individual Focus", "Highlighted players", 20, 15, 8, 4, training.IndividualFocus),
+            CreateListCard("youth-development", "Youth Development", "Academy focus", 28, 16, 9, 3, training.YouthDevelopment),
+        };
+
+        var extras = new List<CardPresetDefinition>
+        {
+            CreatePreset(
+                CreateListCard(
+                    "training-medical-flags",
+                    "Medical Flags",
+                    "Players to monitor",
+                    0,
+                    0,
+                    16,
+                    6,
+                    training.MedicalWorkload),
+                "Medical Flags",
+                "Keep the high-risk workload notes pinned to the board"),
+            CreatePreset(
+                CreateMetricCard(
+                    "training-intensity-compact",
+                    "Intensity Snapshot",
+                    "Daily load",
+                    training.Intensity,
+                    0,
+                    0,
+                    10,
+                    4),
+                "Training Intensity (Compact)",
+                "Compact gauge for quick dashboards"),
+        };
+
+        return CreateLayout("training", "training-overview", cards, extras);
+    }
+
+    private static CardLayout BuildTrainingCalendar(TrainingCalendarSnapshot calendar)
+    {
+        var orderedSessions = calendar.SessionDetails is { Count: > 0 }
+            ? TrainingCalendarFormatter.OrderSessions(calendar.SessionDetails).ToList()
+            : new List<TrainingSessionDetailSnapshot>();
+
+        var weekOverviewEntries = orderedSessions.Count > 0
+            ? TrainingCalendarFormatter.BuildWeekOverview(orderedSessions)
+            : calendar.WeekOverview;
+
+        var calendarCard = CreateTrainingCalendarCard(
+            "weekly-calendar",
+            "Weekly Calendar",
+            "Drag sessions between slots to reschedule.",
+            0,
+            0,
+            28,
+            12,
+            orderedSessions);
+
+        var cards = new List<CardDefinition>
+        {
+            calendarCard,
+            CreateListCard("rest-days", "Rest Days", "Recovery blocks", 28, 0, 9, 5, calendar.RestDays),
+            CreateListCard("match-prep-focus", "Match Prep Focus", "Opponent prep", 28, 5, 9, 4, calendar.MatchPrepFocus),
+            CreateListCard("week-overview", "Week Overview", "Session outline", 0, 12, 28, 7, weekOverviewEntries),
+            CreateListCard("milestones", "Upcoming Milestones", "Key dates", 28, 9, 9, 10, calendar.UpcomingMilestones),
+        };
+
+        return CreateLayout("training", "training-calendar", cards);
+    }
+
+    private static CardLayout BuildTrainingUnits(TrainingUnitsSnapshot units)
+    {
+        var cards = new List<CardDefinition>();
+
+        if (units.Board is not null)
+        {
+            cards.Add(CreateTrainingUnitBoardCard(
+                "training-unit-board",
+                "Training Unit Assignments",
+                "Manage player distribution across units.",
+                0,
+                0,
+                28,
+                12,
+                units.Board));
+        }
+
+        cards.Add(CreateListCard("senior-unit", "Senior Unit", "First team", 28, 0, 9, 4, units.SeniorUnit));
+        cards.Add(CreateListCard("youth-unit", "Youth Unit", "Development squads", 28, 4, 9, 4, units.YouthUnit));
+        cards.Add(CreateListCard("goalkeeping-unit", "Goalkeeping", "Shot-stopping focus", 28, 8, 9, 4, units.GoalkeepingUnit));
+        cards.Add(CreateListCard("coach-assignments", "Coach Assignments", "Specialists", 0, 12, 28, 4, units.CoachAssignments));
+
+        return CreateLayout("training", "training-units", cards);
+    }
+
+    private static CardLayout BuildTransferCentre(TransferCentreSnapshot centre)
+    {
+        var negotiations = centre.Negotiations ?? Array.Empty<TransferNegotiationDealSnapshot>();
+
+        var cards = new List<CardDefinition>
+        {
+            CreateGaugeCard("budget-usage", "Budget Usage", "Committed funds", centre.BudgetUsage, 0, 0, 12, 6),
+            CreateNegotiationCard("active-deals", "Active Deals", "Negotiations", 12, 0, 13, 7, negotiations, "Negotiations"),
+            CreateListCard("recent-activity", "Recent Activity", "Completed moves", 25, 0, 12, 7, centre.RecentActivity),
+            CreateListCard("loan-watch", "Loan Watch", "Development tracker", 0, 6, 18, 6, centre.LoanWatch),
+            CreateListCard("clauses", "Clauses", "Financial obligations", 18, 6, 19, 6, centre.Clauses),
+        };
+
+        var extras = new List<CardPresetDefinition>
+        {
+            CreatePreset(
+                CreateListCard(
+                    "transfer-active-compact",
+                    "Active Deals (Compact)",
+                    "Urgent negotiations",
+                    0,
+                    0,
+                    15,
+                    6,
+                    BuildNegotiationSummaries(negotiations, 4)),
+                "Active Deals (Compact)",
+                "Focus on the most urgent ongoing deals"),
+            CreatePreset(
+                CreateListCard(
+                    "transfer-loan-highlights",
+                    "Loan Watch Highlights",
+                    "Key performances",
+                    0,
+                    0,
+                    15,
+                    6,
+                    centre.LoanWatch.Take(3).ToList()),
+                "Loan Watch Highlights",
+                "Track standout loan performances"),
+        };
+
+        return CreateLayout("transfers", "transfer-centre", cards, extras);
+    }
+
+    private static CardLayout BuildTransfersScouting(ScoutingSnapshot scouting)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateScoutAssignmentsCard(
+                "scout-assignments-board",
+                "Assignments Board",
+                "Current focus areas",
+                0,
+                0,
+                18,
+                7,
+                scouting.AssignmentBoard,
+                scouting.AssignmentStages,
+                scouting.AssignmentPriorities,
+                scouting.ScoutPool),
+            CreateListCard("focus-regions", "Focus Regions", "Knowledge coverage", 18, 0, 19, 7, scouting.FocusRegions),
+            CreateListCard("knowledge-levels", "Knowledge Levels", "Global insight", 0, 7, 18, 6, scouting.KnowledgeLevels),
+            CreateListCard("recommended-players", "Recommended Players", "Scouting priority", 18, 7, 19, 6, scouting.RecommendedPlayers),
+            CreateListCard("short-term-focus", "Short-Term Focus", "Upcoming windows", 0, 13, 37, 6, scouting.ShortTermFocus),
+        };
+
+        return CreateLayout("transfers", "scouting", cards);
+    }
+
+    private static CardLayout BuildTransfersShortlist(ShortlistSnapshot shortlist)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateShortlistBoardCard(
+                "shortlist-board",
+                "Shortlist Board",
+                "Primary recruitment targets",
+                0,
+                0,
+                18,
+                7,
+                shortlist.Board,
+                shortlist.StatusOptions,
+                shortlist.ActionOptions),
+            CreateListCard("contract-status", "Contract Status", "Expiry watch", 18, 0, 19, 7, shortlist.ContractStatus),
+            CreateListCard("competition", "Competition", "Clubs interested", 0, 7, 18, 6, shortlist.Competition),
+            CreateListCard("notes", "Notes", "Scouting insights", 18, 7, 19, 6, shortlist.Notes),
+        };
+
+        return CreateLayout("transfers", "shortlist", cards);
+    }
+
+    private static CardLayout BuildFinancesSummary(FinanceSummarySnapshot finance)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateGaugeCard("overall-balance", "Overall Balance", "Current balance", finance.OverallBalance, 0, 0, 12, 6),
+            CreateLineChartCard("profit-month", "Profit This Month", "Monthly variance", finance.ProfitThisMonth, 12, 0, 12, 6, "#FF9F1C"),
+            CreateFinanceBudgetAllocatorCard("budget-allocation", "Budget Allocation", "Adjust departmental spend", finance.BudgetAllocator, 24, 0, 13, 6),
+            CreateFinanceCashflowCard("cashflow-drilldown", "Cash Flow", "Dive into income and spend", finance.Cashflow, 0, 6, 24, 7),
+            CreateListCard("projections", "Projections", "Forecast", 24, 6, 13, 3, finance.Projections),
+            CreateListCard("debts", "Debts", "Long-term", 24, 9, 13, 3, finance.Debts),
+            CreateListCard("sponsor-deals", "Sponsor Deals", "Commercial partners", 24, 12, 13, 3, finance.SponsorDeals),
+            CreateFinanceScenarioCard("scenario-board", "Financial Scenarios", "Toggle initiatives", finance.ScenarioBoard, 0, 13, 24, 6),
+            CreateForecastCard("finance-forecast", "Budget Scenario", "Explore allocation changes", finance.Forecast, 24, 15, 13, 4),
+        };
+
+        var extras = new List<CardPresetDefinition>
+        {
+            CreatePreset(
+                CreateListCard(
+                    "finance-sponsor-deals",
+                    "Sponsor Deals Spotlight",
+                    "Commercial partners",
+                    0,
+                    0,
+                    16,
+                    6,
+                    finance.SponsorDeals),
+                "Sponsor Deals Spotlight",
+                "Highlight active sponsorship agreements"),
+            CreatePreset(
+                CreateListCard(
+                    "finance-debt-obligations",
+                    "Debt Obligations",
+                    "Repayment schedule",
+                    0,
+                    0,
+                    16,
+                    6,
+                    finance.Debts),
+                "Debt Obligations",
+                "Monitor outstanding debt commitments"),
+        };
+
+        return CreateLayout("finances", "finances-summary", cards, extras);
+    }
+
+    private static CardLayout BuildFinancesIncome(FinanceIncomeSnapshot income)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("revenue-streams", "Revenue Streams", "Month to date", 0, 0, 18, 7, income.RevenueStreams),
+            CreateListCard("matchday-income", "Matchday Income", "Breakdown", 18, 0, 19, 7, income.MatchdayIncome),
+            CreateListCard("commercial-income", "Commercial Income", "Year on year", 0, 7, 18, 6, income.CommercialIncome),
+            CreateListCard("competition-prizes", "Competition Prizes", "Earnings", 18, 7, 19, 6, income.CompetitionPrizes),
+        };
+
+        return CreateLayout("finances", "finances-income", cards);
+    }
+
+    private static CardLayout BuildFinancesExpenditure(FinanceExpenditureSnapshot expenditure)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("major-costs", "Major Costs", "Primary spend", 0, 0, 18, 7, expenditure.MajorCosts),
+            CreateListCard("wage-breakdown", "Wage Breakdown", "Squad allocation", 18, 0, 19, 7, expenditure.WageBreakdown),
+            CreateListCard("transfer-spending", "Transfer Spending", "Window summary", 0, 7, 18, 6, expenditure.TransferSpending),
+            CreateListCard("operational-costs", "Operational Costs", "Club operations", 18, 7, 19, 6, expenditure.OperationalCosts),
+        };
+
+        return CreateLayout("finances", "finances-expenditure", cards);
+    }
+
+    private static CardLayout BuildFixturesSchedule(FixturesScheduleSnapshot schedule)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("upcoming-fixtures", "Upcoming Fixtures", "Next matches", 0, 0, 19, 7, schedule.UpcomingFixtures, kind: CardKind.Fixture),
+            CreateListCard("travel-plans", "Travel Plans", "Logistics", 19, 0, 18, 7, schedule.TravelPlans),
+            CreateTimelineCard("fixture-timeline", "Fixture Timeline", "Next six weeks", schedule.FixtureTimeline, 0, 7, 37, 6),
+            CreateListCard("broadcasts", "Broadcasts", "Coverage", 0, 13, 19, 5, schedule.Broadcasts),
+            CreateListCard("preparation-focus", "Preparation Focus", "Coaching notes", 19, 13, 18, 5, schedule.PreparationFocus),
+        };
+
+        var extras = new List<CardPresetDefinition>
+        {
+            CreatePreset(
+                CreateListCard(
+                    "fixtures-upcoming-compact",
+                    "Upcoming Fixtures (Compact)",
+                    "Next opponents",
+                    0,
+                    0,
+                    19,
+                    5,
+                    schedule.UpcomingFixtures.Take(3).ToList(),
+                    kind: CardKind.Fixture),
+                "Upcoming Fixtures (Compact)",
+                "Smaller schedule showing the next three matches"),
+            CreatePreset(
+                CreateListCard(
+                    "fixtures-travel-snapshot",
+                    "Travel Snapshot",
+                    "Logistics focus",
+                    0,
+                    0,
+                    18,
+                    6,
+                    schedule.TravelPlans.Take(4).ToList()),
+                "Travel Snapshot",
+                "Keep imminent travel plans pinned"),
+        };
+
+        return CreateLayout("fixtures", "fixtures-schedule", cards, extras);
+    }
+
+    private static CardLayout BuildFixturesResults(FixturesResultsSnapshot results)
+    {
+        var cards = new List<CardDefinition>
+        {
+            CreateListCard("recent-results", "Recent Results", "Form guide", 0, 0, 19, 7, results.RecentResults, kind: CardKind.Fixture),
+            CreateListCard("player-ratings", "Player Ratings", "Highlights", 19, 0, 18, 5, results.PlayerRatings),
+            CreateListCard("trends", "Trends", "Performance patterns", 19, 5, 18, 5, results.Trends),
+            CreateListCard("key-moments", "Key Moments", "Decisive events", 0, 7, 19, 5, results.KeyMoments),
+        };
+
+        return CreateLayout("fixtures", "fixtures-results", cards);
+    }
+
+    private static CardLayout BuildFixturesCalendar(FixturesCalendarSnapshot calendar)
+    {
+        var calendarCard = new CardDefinition(
+            Id: "fixtures-calendar-grid",
+            Title: "Monthly Planner",
+            Subtitle: "Filter congested periods",
+            Kind: CardKind.FixtureCalendar,
+            Column: 0,
+            Row: 0,
+            ColumnSpan: 25,
+            RowSpan: 12,
+            FixtureCalendar: new FixtureCalendarDefinition(
+                MapFixtureFilters(calendar.Filters),
+                MapFixtureWeeks(calendar.Weeks),
+                "Competition Focus",
+                "Toggle competitions to highlight relevant fixtures"));
+
+        var cards = new List<CardDefinition>
+        {
+            calendarCard,
+            CreateListCard("month-overview", "Month Overview", "Fixture density", 25, 0, 12, 5, calendar.MonthOverview),
+            CreateListCard("cup-draws", "Cup Draws", "Upcoming ties", 25, 5, 12, 3, calendar.CupDraws),
+            CreateListCard("international-breaks", "International Breaks", "Availability", 25, 8, 12, 3, calendar.InternationalBreaks),
+            CreateListCard("reminders", "Reminders", "Key admin", 0, 12, 37, 7, calendar.Reminders),
+        };
+
+        return CreateLayout("fixtures", "fixtures-calendar", cards);
+    }
+
+    private static IReadOnlyList<FixtureCalendarFilterDefinition> MapFixtureFilters(IReadOnlyList<FixtureCalendarFilterSnapshot> filters)
+    {
+        if (filters is not { Count: > 0 })
+        {
+            return Array.Empty<FixtureCalendarFilterDefinition>();
+        }
+
+        var list = new List<FixtureCalendarFilterDefinition>(filters.Count);
+        foreach (var filter in filters)
+        {
+            list.Add(new FixtureCalendarFilterDefinition(
+                filter.Id,
+                filter.DisplayName,
+                filter.IsDefault,
+                filter.Competitions ?? Array.Empty<string>()));
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<FixtureCalendarWeekDefinition> MapFixtureWeeks(IReadOnlyList<FixtureCalendarWeekSnapshot> weeks)
+    {
+        if (weeks is not { Count: > 0 })
+        {
+            return Array.Empty<FixtureCalendarWeekDefinition>();
+        }
+
+        var mapped = new List<FixtureCalendarWeekDefinition>(weeks.Count);
+        foreach (var week in weeks)
+        {
+            var days = week.Days is { Count: > 0 }
+                ? week.Days.Select(MapFixtureDay).ToList()
+                : new List<FixtureCalendarDayDefinition>();
+
+            mapped.Add(new FixtureCalendarWeekDefinition(week.Label, days));
+        }
+
+        return mapped;
+    }
+
+    private static FixtureCalendarDayDefinition MapFixtureDay(FixtureCalendarDaySnapshot day)
+    {
+        var matches = day.Matches is { Count: > 0 }
+            ? day.Matches.Select(MapFixtureMatch).ToList()
+            : new List<FixtureCalendarMatchDefinition>();
+
+        return new FixtureCalendarDayDefinition(day.Label, day.Date, matches);
+    }
+
+    private static FixtureCalendarMatchDefinition MapFixtureMatch(FixtureCalendarMatchSnapshot match)
+    {
+        return new FixtureCalendarMatchDefinition(
+            match.Id,
+            match.Day,
+            match.KickOff,
+            match.Competition,
+            match.Opponent,
+            match.Venue,
+            match.IsHome,
+            match.Importance,
+            match.Result,
+            match.Broadcast,
+            match.TravelNote,
+            match.PreparationNote,
+            match.Status,
+            match.CompetitionAccent,
+            MapEntries(match.KeyPeople ?? Array.Empty<ListEntrySnapshot>()),
+            MapEntries(match.Preparation ?? Array.Empty<ListEntrySnapshot>()));
+    }
+
+    private static CardLayout CreateLayout(
+        string tabIdentifier,
+        string sectionIdentifier,
+        List<CardDefinition> cards,
+        IEnumerable<CardPresetDefinition>? extras = null)
+    {
+        var palette = CreatePalette(cards);
+
+        if (extras is not null)
+        {
+            foreach (var preset in extras)
+            {
+                if (palette.All(existing => !string.Equals(existing.Id, preset.Id, StringComparison.Ordinal)))
+                {
+                    palette.Add(preset);
+                }
+            }
+        }
+
+        return new CardLayout(tabIdentifier, sectionIdentifier, cards, palette);
+    }
+
+    private static List<CardPresetDefinition> CreatePalette(IEnumerable<CardDefinition> cards) =>
+        cards
+            .Select(card => CreatePreset(card))
+            .ToList();
+
+    private static CardPresetDefinition CreatePreset(CardDefinition definition, string? displayName = null, string? description = null)
+    {
+        return new CardPresetDefinition(
+            definition.Id,
+            displayName ?? definition.Title,
+            description ?? definition.Description ?? definition.Subtitle ?? definition.Title,
+            definition);
+    }
+
+    private static IReadOnlyList<CardListItem> MapInstructionItems(IReadOnlyList<InstructionItemSnapshot> items)
+    {
+        if (items.Count == 0)
+        {
+            return System.Array.Empty<CardListItem>();
+        }
+
+        var mapped = new List<CardListItem>(items.Count);
+        foreach (var item in items)
+        {
+            mapped.Add(new CardListItem(item.Label, item.Value, item.Detail));
+        }
+
+        return mapped;
+    }
+
+    private static IReadOnlyList<CardListItem> MapEntries(IReadOnlyList<ListEntrySnapshot> entries)
+    {
+        if (entries is null || entries.Count == 0)
+        {
+            return System.Array.Empty<CardListItem>();
+        }
+
+        var list = new List<CardListItem>(entries.Count);
+        foreach (var entry in entries)
+        {
+            list.Add(new CardListItem(entry.Primary, entry.Secondary, entry.Tertiary, entry.Accent));
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<ChartDataPointDefinition> MapTrendPoints(IReadOnlyList<TrendDataPointSnapshot> points)
+    {
+        if (points is null || points.Count == 0)
+        {
+            return System.Array.Empty<ChartDataPointDefinition>();
+        }
+
+        var list = new List<ChartDataPointDefinition>(points.Count);
+        foreach (var point in points)
+        {
+            list.Add(new ChartDataPointDefinition(point.Label, point.Value));
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<GaugeBandDefinition> MapGaugeBands(IReadOnlyList<GaugeBandSnapshot> bands)
+    {
+        if (bands is null || bands.Count == 0)
+        {
+            return System.Array.Empty<GaugeBandDefinition>();
+        }
+
+        var list = new List<GaugeBandDefinition>(bands.Count);
+        foreach (var band in bands)
+        {
+            list.Add(new GaugeBandDefinition(band.Label, band.Start, band.End, band.Color));
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<TimelineEntryDefinition> MapTimelineEntries(IReadOnlyList<TimelineEntrySnapshot> entries)
+    {
+        if (entries is null || entries.Count == 0)
+        {
+            return System.Array.Empty<TimelineEntryDefinition>();
+        }
+
+        var list = new List<TimelineEntryDefinition>(entries.Count);
+        foreach (var entry in entries)
+        {
+            list.Add(new TimelineEntryDefinition(entry.Label, entry.Detail, entry.Position, entry.Pill, entry.Accent));
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<ShotMapFilterDefinition> MapShotFilters(IReadOnlyList<ShotMapFilterSnapshot> filters)
+    {
+        if (filters is null || filters.Count == 0)
+        {
+            return System.Array.Empty<ShotMapFilterDefinition>();
+        }
+
+        var list = new List<ShotMapFilterDefinition>(filters.Count);
+        foreach (var filter in filters)
+        {
+            list.Add(new ShotMapFilterDefinition(filter.Key, filter.DisplayName, filter.Color, filter.IsDefault));
+        }
+
+        return list;
+    }
+
+    private static IReadOnlyList<ShotMapEventDefinition> MapShotEvents(IReadOnlyList<ShotMapEventSnapshot> events)
+    {
+        if (events is null || events.Count == 0)
+        {
+            return System.Array.Empty<ShotMapEventDefinition>();
+        }
+
+        var list = new List<ShotMapEventDefinition>(events.Count);
+        foreach (var shot in events)
+        {
+            list.Add(new ShotMapEventDefinition(
+                shot.Id,
+                shot.Player,
+                shot.Minute,
+                shot.OutcomeKey,
+                shot.X,
+                shot.Y,
+                shot.ExpectedGoals,
+                shot.Assist,
+                shot.BodyPart,
+                shot.Detail,
+                shot.Accent));
+        }
+
+        return list;
+    }
+
+    private static ShotMapDefinition MapShotMap(ShotMapSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            return new ShotMapDefinition(120, 80, System.Array.Empty<ShotMapFilterDefinition>(), System.Array.Empty<ShotMapEventDefinition>());
+        }
+
+        return new ShotMapDefinition(
+            snapshot.PitchWidth,
+            snapshot.PitchHeight,
+            MapShotFilters(snapshot.Filters),
+            MapShotEvents(snapshot.Events));
+    }
+
+    private static MedicalTimelineDefinition MapMedicalTimeline(MedicalTimelineSnapshot snapshot)
+    {
+        if (snapshot is null || snapshot.Entries is null || snapshot.Entries.Count == 0)
+        {
+            return new MedicalTimelineDefinition(System.Array.Empty<MedicalTimelineEntryDefinition>());
+        }
+
+        var list = new List<MedicalTimelineEntryDefinition>(snapshot.Entries.Count);
+        foreach (var entry in snapshot.Entries)
+        {
+            list.Add(new MedicalTimelineEntryDefinition(
+                entry.Id,
+                entry.Player,
+                entry.Diagnosis,
+                entry.Status,
+                entry.ExpectedReturn,
+                MapTimelineEntries(entry.Phases),
+                entry.Notes,
+                entry.Accent));
+        }
+
+        return new MedicalTimelineDefinition(list);
+    }
+
+    private static IReadOnlyList<FinanceForecastImpactDefinition> MapForecastImpacts(IReadOnlyList<FinanceForecastImpactSnapshot> impacts)
+    {
+        if (impacts is null || impacts.Count == 0)
+        {
+            return System.Array.Empty<FinanceForecastImpactDefinition>();
+        }
+
+        var list = new List<FinanceForecastImpactDefinition>(impacts.Count);
+        foreach (var impact in impacts)
+        {
+            list.Add(new FinanceForecastImpactDefinition(impact.Label, impact.Format, impact.BaseValue, impact.Sensitivity));
+        }
+
+        return list;
+    }
+
+    private static FinanceBudgetAllocatorDefinition MapFinanceBudgetAllocator(FinanceBudgetAllocationSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            return new FinanceBudgetAllocatorDefinition(
+                string.Empty,
+                string.Empty,
+                "{0:+\u00a3#,##0;-\u00a3#,##0;\u00a30} \u2022 \u00a3{1:#,##0}",
+                System.Array.Empty<FinanceBudgetAllocationLineDefinition>());
+        }
+
+        var lines = snapshot.Lines?.Select(line => new FinanceBudgetAllocationLineDefinition(
+            line.Id,
+            line.Label,
+            line.Description,
+            line.Minimum,
+            line.Maximum,
+            line.Step,
+            line.Value,
+            line.Baseline,
+            line.Format,
+            line.Accent)).ToList() ?? new List<FinanceBudgetAllocationLineDefinition>();
+
+        return new FinanceBudgetAllocatorDefinition(snapshot.CommitLabel, snapshot.ResetLabel, snapshot.SummaryFormat, lines);
+    }
+
+    private static FinanceCashflowDefinition MapFinanceCashflow(FinanceCashflowSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            return new FinanceCashflowDefinition(
+                string.Empty,
+                "{0:0.0} \u2022 {1:0.0}",
+                System.Array.Empty<FinanceCashflowCategoryDefinition>());
+        }
+
+        var categories = snapshot.Categories?.Select(category => new FinanceCashflowCategoryDefinition(
+            category.Id,
+            category.Name,
+            category.Description,
+            category.Amount,
+            category.Format,
+            category.Accent,
+            category.Items?.Select(item => new FinanceCashflowItemDefinition(
+                item.Id,
+                item.Name,
+                item.Amount,
+                item.Format,
+                item.Accent,
+                item.Detail)).ToList() ?? new List<FinanceCashflowItemDefinition>()))
+            .ToList() ?? new List<FinanceCashflowCategoryDefinition>();
+
+        return new FinanceCashflowDefinition(snapshot.SummaryLabel, snapshot.SummaryFormat, categories);
+    }
+
+    private static FinanceScenarioDefinition MapFinanceScenario(FinanceScenarioBoardSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            return new FinanceScenarioDefinition(
+                string.Empty,
+                "{0:+0.0;-0.0;0.0} \u2022 {1}",
+                string.Empty,
+                string.Empty,
+                System.Array.Empty<FinanceScenarioOptionDefinition>());
+        }
+
+        var options = snapshot.Options?.Select(option => new FinanceScenarioOptionDefinition(
+            option.Id,
+            option.Title,
+            option.Detail,
+            option.Impact,
+            option.Format,
+            option.IsSelected,
+            option.Accent)).ToList() ?? new List<FinanceScenarioOptionDefinition>();
+
+        return new FinanceScenarioDefinition(
+            snapshot.SummaryLabel,
+            snapshot.SummaryFormat,
+            snapshot.CommitLabel,
+            snapshot.ResetLabel,
+            options);
+    }
+
+    private static ScoutAssignmentDefinition MapScoutAssignment(ScoutAssignmentSnapshot snapshot)
+    {
+        return new ScoutAssignmentDefinition(
+            snapshot.Id,
+            snapshot.Focus,
+            snapshot.Role,
+            snapshot.Region,
+            snapshot.Priority,
+            snapshot.Stage,
+            snapshot.Deadline,
+            snapshot.Scout,
+            snapshot.Notes);
+    }
+
+    private static ScoutOptionDefinition MapScoutOption(ScoutOptionSnapshot snapshot)
+    {
+        return new ScoutOptionDefinition(snapshot.Id, snapshot.Name, snapshot.Region, snapshot.Availability);
+    }
+
+    private static ShortlistPlayerDefinition MapShortlistPlayer(ShortlistPlayerSnapshot snapshot)
+    {
+        return new ShortlistPlayerDefinition(
+            snapshot.Id,
+            snapshot.Name,
+            snapshot.Position,
+            snapshot.Status,
+            snapshot.Action,
+            snapshot.Priority,
+            snapshot.Notes);
+    }
+
+    private static CardDefinition CreateLineChartCard(string id, string title, string subtitle, TrendSnapshot trend, int column, int row, int columnSpan, int rowSpan, string seriesColor = "#2EC4B6")
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.LineChart,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            MetricValue: trend.Metric.Value,
+            MetricLabel: trend.Metric.Summary,
+            PillText: trend.Metric.Pill,
+            ChartSeries: new List<ChartSeriesDefinition>
+            {
+                new(trend.Metric.Value, seriesColor, MapTrendPoints(trend.Points))
+            });
+    }
+
+    private static CardDefinition CreateGaugeCard(string id, string title, string subtitle, GaugeSnapshot gauge, int column, int row, int columnSpan, int rowSpan)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.Gauge,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            Gauge: new GaugeDefinition(
+                gauge.Minimum,
+                gauge.Maximum,
+                gauge.Value,
+                gauge.Target,
+                gauge.Unit,
+                MapGaugeBands(gauge.Bands),
+                gauge.Metric.Value,
+                gauge.Metric.Summary,
+                gauge.Metric.Pill),
+            ListItems: MapEntries(gauge.SupportingItems ?? Array.Empty<ListEntrySnapshot>()));
+    }
+
+    private static CardDefinition CreateTimelineCard(string id, string title, string subtitle, TimelineSnapshot timeline, int column, int row, int columnSpan, int rowSpan)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.Timeline,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            Timeline: MapTimelineEntries(timeline.Events));
+    }
+
+    private static CardDefinition CreateShotMapCard(string id, string title, string subtitle, ShotMapSnapshot shotMap, int column, int row, int columnSpan, int rowSpan)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.ShotMap,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            ShotMap: MapShotMap(shotMap));
+    }
+
+    private static CardDefinition CreateMedicalTimelineCard(string id, string title, string subtitle, MedicalTimelineSnapshot timeline, int column, int row, int columnSpan, int rowSpan)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.MedicalTimeline,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            MedicalTimeline: MapMedicalTimeline(timeline));
+    }
+
+    private static CardDefinition CreateTrainingProgressionCard(
+        string id,
+        string title,
+        string subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        TrainingProgressionSnapshot progression)
+    {
+        if (progression is null)
+        {
+            throw new ArgumentNullException(nameof(progression));
+        }
+
+        var highlights = MapEntries(progression.Highlights ?? Array.Empty<ListEntrySnapshot>());
+        var definition = MapTrainingProgression(progression);
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.TrainingProgression,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            MetricValue: progression.MetricValue,
+            MetricLabel: progression.MetricLabel,
+            Description: progression.Summary,
+            ListItems: highlights,
+            TrainingProgression: definition);
+    }
+
+    private static CardDefinition CreateWorkloadHeatmapCard(TrainingWorkloadHeatmapSnapshot? heatmap)
+    {
+        var definition = MapWorkloadHeatmap(heatmap);
+
+        return new CardDefinition(
+            Id: "training-workload-heatmap",
+            Title: "Workload Heatmap",
+            Subtitle: "Intensity by unit",
+            Kind: CardKind.WorkloadHeatmap,
+            Column: 0,
+            Row: 7,
+            ColumnSpan: 28,
+            RowSpan: 8,
+            WorkloadHeatmap: definition);
+    }
+
+    private static CardDefinition CreateClubVisionRoadmapCard(
+        string id,
+        string title,
+        string? subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        ClubVisionRoadmapSnapshot roadmap)
+    {
+        var phases = roadmap.Phases is { Count: > 0 }
+            ? roadmap.Phases
+                .Select(phase => new ClubVisionRoadmapPhaseDefinition(
+                    phase.Id,
+                    phase.Title,
+                    phase.Timeline,
+                    phase.Status,
+                    phase.Description,
+                    phase.Accent,
+                    phase.Pill))
+                .ToList()
+            : new List<ClubVisionRoadmapPhaseDefinition>();
+
+        var statusOptions = roadmap.StatusOptions is { Count: > 0 }
+            ? new List<string>(roadmap.StatusOptions)
+            : new List<string>();
+
+        var pillOptions = roadmap.PillOptions is { Count: > 0 }
+            ? new List<string>(roadmap.PillOptions)
+            : new List<string>();
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.ClubVisionRoadmap,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            ClubVisionRoadmap: new ClubVisionRoadmapDefinition(phases, statusOptions, pillOptions));
+    }
+
+    private static CardDefinition CreateClubVisionExpectationBoardCard(
+        string id,
+        string title,
+        string? subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        ClubVisionExpectationBoardSnapshot board)
+    {
+        var objectives = board.Objectives is { Count: > 0 }
+            ? board.Objectives
+                .Select(objective => new ClubVisionExpectationDefinition(
+                    objective.Id,
+                    objective.Objective,
+                    objective.Competition,
+                    objective.Priority,
+                    objective.Status,
+                    objective.Deadline,
+                    objective.Notes,
+                    objective.Accent))
+                .ToList()
+            : new List<ClubVisionExpectationDefinition>();
+
+        var statusOptions = board.StatusOptions is { Count: > 0 }
+            ? new List<string>(board.StatusOptions)
+            : new List<string>();
+
+        var priorityOptions = board.PriorityOptions is { Count: > 0 }
+            ? new List<string>(board.PriorityOptions)
+            : new List<string>();
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.ClubVisionExpectations,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            ClubVisionExpectations: new ClubVisionExpectationBoardDefinition(objectives, statusOptions, priorityOptions));
+    }
+
+    private static CardDefinition CreateMoraleHeatmapCard(MoraleHeatmapSnapshot? heatmap)
+    {
+        var definition = MapMoraleHeatmap(heatmap);
+
+        return new CardDefinition(
+            Id: "morale-heatmap",
+            Title: "Morale Heatmap",
+            Subtitle: "Mood by unit",
+            Kind: CardKind.MoraleHeatmap,
+            Column: 0,
+            Row: 12,
+            ColumnSpan: 18,
+            RowSpan: 7,
+            MoraleHeatmap: definition);
+    }
+
+    private static CardDefinition CreateForecastCard(string id, string title, string subtitle, FinanceForecastSnapshot forecast, int column, int row, int columnSpan, int rowSpan)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.Forecast,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            Forecast: new FinanceForecastDefinition(
+                forecast.SliderLabel,
+                forecast.ValueDisplayFormat,
+                forecast.CommitLabel,
+                forecast.SummaryLabel,
+                forecast.Minimum,
+                forecast.Maximum,
+                forecast.Step,
+                forecast.CurrentPercentage,
+                MapForecastImpacts(forecast.Impacts)));
+    }
+
+    private static CardDefinition CreateFinanceBudgetAllocatorCard(
+        string id,
+        string title,
+        string subtitle,
+        FinanceBudgetAllocationSnapshot snapshot,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan)
+    {
+        var definition = MapFinanceBudgetAllocator(snapshot);
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.FinanceBudgetAllocator,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            FinanceBudgetAllocator: definition);
+    }
+
+    private static CardDefinition CreateFinanceCashflowCard(
+        string id,
+        string title,
+        string subtitle,
+        FinanceCashflowSnapshot snapshot,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan)
+    {
+        var definition = MapFinanceCashflow(snapshot);
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.FinanceCashflow,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            FinanceCashflow: definition);
+    }
+
+    private static CardDefinition CreateFinanceScenarioCard(
+        string id,
+        string title,
+        string subtitle,
+        FinanceScenarioBoardSnapshot snapshot,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan)
+    {
+        var definition = MapFinanceScenario(snapshot);
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.FinanceScenarioBoard,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            FinanceScenario: definition);
+    }
+
+    private static CardDefinition CreateScoutAssignmentsCard(
+        string id,
+        string title,
+        string? subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        IReadOnlyList<ScoutAssignmentSnapshot>? assignments,
+        IReadOnlyList<string>? stageOptions,
+        IReadOnlyList<string>? priorityOptions,
+        IReadOnlyList<ScoutOptionSnapshot>? scoutPool)
+    {
+        var assignmentDefinitions = assignments?.Select(MapScoutAssignment).ToList()
+            ?? new List<ScoutAssignmentDefinition>();
+        var stages = stageOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>();
+        var priorities = priorityOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>();
+        var options = scoutPool?.Select(MapScoutOption).ToList()
+            ?? new List<ScoutOptionDefinition>();
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.ScoutAssignments,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            ScoutAssignments: new ScoutAssignmentBoardDefinition(assignmentDefinitions, stages, priorities, options));
+    }
+
+    private static CardDefinition CreateShortlistBoardCard(
+        string id,
+        string title,
+        string? subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        IReadOnlyList<ShortlistPlayerSnapshot>? players,
+        IReadOnlyList<string>? statusOptions,
+        IReadOnlyList<string>? actionOptions)
+    {
+        var playerDefinitions = players?.Select(MapShortlistPlayer).ToList()
+            ?? new List<ShortlistPlayerDefinition>();
+        var statuses = statusOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>();
+        var actions = actionOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>();
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.ShortlistBoard,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            ShortlistBoard: new ShortlistBoardDefinition(playerDefinitions, statuses, actions));
+    }
+
+    private static CardDefinition CreateSquadTableCard(
+        string id,
+        string title,
+        string subtitle,
+        SquadTableDefinition table,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.SquadTable,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            SquadTable: table);
+    }
+
+    private static SquadTableDefinition MapSquadPlayers(IReadOnlyList<SquadPlayerSnapshot> players)
+    {
+        if (players is null || players.Count == 0)
+        {
+            return new SquadTableDefinition(Array.Empty<SquadPlayerDefinition>());
+        }
+
+        var list = new List<SquadPlayerDefinition>(players.Count);
+        foreach (var player in players)
+        {
+            list.Add(new SquadPlayerDefinition(
+                player.Id,
+                player.Name,
+                player.PositionGroup,
+                player.Position,
+                player.Role,
+                player.Morale,
+                player.Condition,
+                player.MatchSharpness,
+                player.AverageRating,
+                player.Appearances,
+                player.Minutes,
+                player.Nationality,
+                player.Status));
+        }
+
+        return new SquadTableDefinition(list);
+    }
+
+    private static TrainingWorkloadHeatmapDefinition MapWorkloadHeatmap(TrainingWorkloadHeatmapSnapshot? heatmap)
+    {
+        if (heatmap is null)
+        {
+            return new TrainingWorkloadHeatmapDefinition(
+                Array.Empty<string>(),
+                Array.Empty<TrainingWorkloadRowDefinition>(),
+                Array.Empty<TrainingIntensityLevelDefinition>());
+        }
+
+        var columns = heatmap.Columns is { Count: > 0 }
+            ? new List<string>(heatmap.Columns)
+            : new List<string>();
+
+        var intensities = heatmap.Intensities is { Count: > 0 }
+            ? heatmap.Intensities
+                .Select(intensity => new TrainingIntensityLevelDefinition(intensity.Key, intensity.DisplayName, intensity.Color, intensity.LoadValue))
+                .ToList()
+            : new List<TrainingIntensityLevelDefinition>();
+
+        var rows = new List<TrainingWorkloadRowDefinition>();
+        if (heatmap.Units is { Count: > 0 })
+        {
+            foreach (var unit in heatmap.Units)
+            {
+                var cells = unit.Cells is { Count: > 0 }
+                    ? unit.Cells
+                        .Select(cell => new TrainingWorkloadCellDefinition(cell.Column, cell.IntensityKey, cell.Load, cell.Detail))
+                        .ToList()
+                    : new List<TrainingWorkloadCellDefinition>();
+
+                rows.Add(new TrainingWorkloadRowDefinition(unit.Label, cells));
+            }
+        }
+
+        return new TrainingWorkloadHeatmapDefinition(columns, rows, intensities, heatmap.LegendTitle, heatmap.LegendSubtitle);
+    }
+
+    private static TrainingProgressionDefinition MapTrainingProgression(TrainingProgressionSnapshot progression)
+    {
+        var periods = progression.Periods is { Count: > 0 }
+            ? new List<string>(progression.Periods)
+            : new List<string>();
+
+        var series = new List<TrainingProgressionSeriesDefinition>();
+
+        if (progression.Series is { Count: > 0 })
+        {
+            foreach (var seriesSnapshot in progression.Series)
+            {
+                var points = new List<TrainingProgressionPointDefinition>();
+
+                if (seriesSnapshot.Points is { Count: > 0 })
+                {
+                    foreach (var point in seriesSnapshot.Points)
+                    {
+                        points.Add(new TrainingProgressionPointDefinition(point.Period, point.Value, point.Detail));
+                    }
+                }
+
+                series.Add(new TrainingProgressionSeriesDefinition(
+                    seriesSnapshot.Id,
+                    seriesSnapshot.Name,
+                    seriesSnapshot.Color,
+                    seriesSnapshot.Accent,
+                    seriesSnapshot.IsHighlighted,
+                    points));
+            }
+        }
+
+        return new TrainingProgressionDefinition(periods, progression.Minimum, progression.Maximum, progression.Summary, series);
+    }
+
+    private static MoraleHeatmapDefinition MapMoraleHeatmap(MoraleHeatmapSnapshot? heatmap)
+    {
+        if (heatmap is null)
+        {
+            return new MoraleHeatmapDefinition(
+                Array.Empty<string>(),
+                Array.Empty<MoraleHeatmapRowDefinition>(),
+                Array.Empty<MoraleIntensityDefinition>());
+        }
+
+        var columns = heatmap.Columns is { Count: > 0 }
+            ? new List<string>(heatmap.Columns)
+            : new List<string>();
+
+        var intensities = heatmap.Intensities is { Count: > 0 }
+            ? heatmap.Intensities
+                .Select(intensity => new MoraleIntensityDefinition(
+                    intensity.Key,
+                    intensity.DisplayName,
+                    intensity.Color,
+                    intensity.Description))
+                .ToList()
+            : new List<MoraleIntensityDefinition>();
+
+        var rows = new List<MoraleHeatmapRowDefinition>();
+        if (heatmap.Rows is { Count: > 0 })
+        {
+            foreach (var row in heatmap.Rows)
+            {
+                var cells = row.Cells is { Count: > 0 }
+                    ? row.Cells
+                        .Select(cell => new MoraleHeatmapCellDefinition(
+                            cell.Column,
+                            cell.IntensityKey,
+                            cell.Label,
+                            cell.Detail))
+                        .ToList()
+                    : new List<MoraleHeatmapCellDefinition>();
+
+                rows.Add(new MoraleHeatmapRowDefinition(row.Label, cells));
+            }
+        }
+
+        return new MoraleHeatmapDefinition(columns, rows, intensities, heatmap.LegendTitle, heatmap.LegendSubtitle);
+    }
+
+    private static CardDefinition CreateTrainingUnitBoardCard(
+        string id,
+        string title,
+        string? subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        TrainingUnitsBoardSnapshot board)
+    {
+        var unitDefinitions = board.Units is { Count: > 0 }
+            ? board.Units
+                .Select(unit => new TrainingUnitGroupDefinition(
+                    unit.Id,
+                    unit.Name,
+                    unit.CoachId,
+                    ResolveCoachName(unit),
+                    ResolveCoachAccent(unit),
+                    unit.CoachOptions
+                        .Select(option => new TrainingUnitCoachOptionDefinition(option.Id, option.Name, option.Accent))
+                        .ToList(),
+                    unit.Members
+                        .Select(member => new TrainingUnitMemberDefinition(
+                            member.Id,
+                            member.Name,
+                            member.Position,
+                            member.Role,
+                            member.Status,
+                            member.Accent,
+                            member.Detail))
+                        .ToList()))
+                .ToList()
+            : new List<TrainingUnitGroupDefinition>();
+
+        var availablePlayers = board.AvailablePlayers is { Count: > 0 }
+            ? board.AvailablePlayers
+                .Select(member => new TrainingUnitMemberDefinition(
+                    member.Id,
+                    member.Name,
+                    member.Position,
+                    member.Role,
+                    member.Status,
+                    member.Accent,
+                    member.Detail))
+                .ToList()
+            : new List<TrainingUnitMemberDefinition>();
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.TrainingUnitBoard,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            TrainingUnitBoard: new TrainingUnitBoardDefinition(unitDefinitions, availablePlayers));
+    }
+
+    private static string? ResolveCoachName(TrainingUnitGroupSnapshot unit)
+    {
+        if (unit.CoachOptions is null || unit.CoachOptions.Count == 0)
+        {
+            return null;
+        }
+
+        var coach = unit.CoachOptions.FirstOrDefault(option => string.Equals(option.Id, unit.CoachId, StringComparison.OrdinalIgnoreCase));
+        return coach?.Name;
+    }
+
+    private static string? ResolveCoachAccent(TrainingUnitGroupSnapshot unit)
+    {
+        if (unit.CoachOptions is null || unit.CoachOptions.Count == 0)
+        {
+            return null;
+        }
+
+        var coach = unit.CoachOptions.FirstOrDefault(option => string.Equals(option.Id, unit.CoachId, StringComparison.OrdinalIgnoreCase));
+        return coach?.Accent;
+    }
+
+    private static CardDefinition CreateTrainingCalendarCard(
+        string id,
+        string title,
+        string? subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        IReadOnlyList<TrainingSessionDetailSnapshot> sessions)
+    {
+        var days = new List<string>(TrainingCalendarFormatter.OrderedDays);
+        var daySet = new HashSet<string>(days, StringComparer.OrdinalIgnoreCase);
+
+        var slots = new List<string>(TrainingCalendarFormatter.OrderedSlots);
+        var slotSet = new HashSet<string>(slots, StringComparer.OrdinalIgnoreCase);
+
+        if (sessions is not null)
+        {
+            foreach (var session in sessions)
+            {
+                if (!string.IsNullOrWhiteSpace(session.Day) && !daySet.Contains(session.Day))
+                {
+                    daySet.Add(session.Day);
+                    days.Add(session.Day);
+                }
+
+                if (!string.IsNullOrWhiteSpace(session.Slot) && !slotSet.Contains(session.Slot))
+                {
+                    slotSet.Add(session.Slot);
+                    slots.Add(session.Slot);
+                }
+            }
+        }
+
+        var mappedSessions = sessions is { Count: > 0 }
+            ? sessions
+                .Select(session => new TrainingCalendarSessionDefinition(
+                    session.Id,
+                    session.Day,
+                    session.Slot,
+                    session.Activity,
+                    session.Focus,
+                    session.Intensity))
+                .ToList()
+            : new List<TrainingCalendarSessionDefinition>();
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.TrainingCalendar,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            TrainingCalendar: new TrainingCalendarDefinition(days, slots, mappedSessions));
+    }
+
+    private static CardDefinition CreateNegotiationCard(
+        string id,
+        string title,
+        string? subtitle,
+        int column,
+        int row,
+        int columnSpan,
+        int rowSpan,
+        IReadOnlyList<TransferNegotiationDealSnapshot> deals,
+        string? description)
+    {
+        var mappedDeals = deals is { Count: > 0 }
+            ? deals.Select(MapNegotiationDeal).ToList()
+            : new List<TransferNegotiationDealDefinition>();
+
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.TransferNegotiation,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            Description: description,
+            Negotiations: new TransferNegotiationDefinition(mappedDeals));
+    }
+
+    private static TransferNegotiationDealDefinition MapNegotiationDeal(TransferNegotiationDealSnapshot deal)
+    {
+        var terms = deal.Terms is { Count: > 0 }
+            ? deal.Terms.Select(MapNegotiationTerm).ToList()
+            : new List<TransferNegotiationTermDefinition>();
+
+        return new TransferNegotiationDealDefinition(
+            deal.Id,
+            deal.Player,
+            deal.Position,
+            deal.Club,
+            deal.Stage,
+            deal.Status,
+            deal.Deadline,
+            deal.Summary,
+            deal.Agent,
+            deal.Response,
+            deal.Accent,
+            deal.StageOptions ?? Array.Empty<string>(),
+            deal.StatusOptions ?? Array.Empty<string>(),
+            terms);
+    }
+
+    private static TransferNegotiationTermDefinition MapNegotiationTerm(TransferNegotiationTermSnapshot term)
+    {
+        return new TransferNegotiationTermDefinition(
+            term.Id,
+            term.Label,
+            term.Format,
+            term.Minimum,
+            term.Maximum,
+            term.Step,
+            term.Value,
+            term.Target,
+            term.Tooltip);
+    }
+
+    private static CardDefinition CreateMetricCard(string id, string title, string subtitle, MetricSnapshot metric, int column, int row, int columnSpan, int rowSpan)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: CardKind.Metric,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            MetricValue: metric.Value,
+            MetricLabel: metric.Summary,
+            PillText: metric.Pill);
+    }
+
+    private static CardDefinition CreateListCard(string id, string title, string? subtitle, int column, int row, int columnSpan, int rowSpan, IReadOnlyList<ListEntrySnapshot> entries, string? description = null, CardKind kind = CardKind.List)
+    {
+        return new CardDefinition(
+            Id: id,
+            Title: title,
+            Subtitle: subtitle,
+            Kind: kind,
+            Column: column,
+            Row: row,
+            ColumnSpan: columnSpan,
+            RowSpan: rowSpan,
+            Description: description,
+            ListItems: MapEntries(entries));
+    }
+
+    private static IReadOnlyList<ListEntrySnapshot> BuildNegotiationSummaries(
+        IReadOnlyList<TransferNegotiationDealSnapshot> deals,
+        int take)
+    {
+        if (deals is null || deals.Count == 0)
+        {
+            return Array.Empty<ListEntrySnapshot>();
+        }
+
+        var items = new List<ListEntrySnapshot>();
+        var count = Math.Max(0, take);
+
+        foreach (var deal in deals.Take(count))
+        {
+            items.Add(CreateNegotiationSummary(deal));
+        }
+
+        return items;
+    }
+
+    private static ListEntrySnapshot CreateNegotiationSummary(TransferNegotiationDealSnapshot deal)
+    {
+        var feeTerm = deal.Terms?.FirstOrDefault(t => string.Equals(t.Id, "fee", StringComparison.OrdinalIgnoreCase));
+        var secondary = feeTerm is not null
+            ? string.Format(CultureInfo.InvariantCulture, feeTerm.Format, feeTerm.Value)
+            : deal.Stage;
+
+        return new ListEntrySnapshot(
+            deal.Player,
+            secondary,
+            deal.Status,
+            deal.Accent);
+    }
+
+    private static CardDefinition CreateFixtureCard()
+    {
+        return new CardDefinition(
+            Id: "match-preview",
+            Title: "Next Fixture",
+            Subtitle: "Premier League",
+            Kind: CardKind.Fixture,
+            Column: 18,
+            Row: 0,
+            ColumnSpan: 19,
+            RowSpan: 7,
+            Description: "Arsenal vs Manchester City",
+            ListItems: new List<CardListItem>
+            {
+                new("Venue", "Emirates Stadium"),
+                new("Kick-Off", "Sat 17:30"),
+                new("Form", "Arsenal WWWDL", "Man City WWLWW"),
+            });
+    }
+}
+
+public sealed class LayoutsChangedEventArgs : EventArgs
+{
+    public LayoutsChangedEventArgs(IReadOnlyList<(string Tab, string Section)> sections, bool isGlobal)
+    {
+        Sections = sections;
+        IsGlobal = isGlobal;
+    }
+
+    public IReadOnlyList<(string Tab, string Section)> Sections { get; }
+
+    public bool IsGlobal { get; }
+}

--- a/WPF/FMUI.Wpf/Services/CardLayoutStatePersistence.cs
+++ b/WPF/FMUI.Wpf/Services/CardLayoutStatePersistence.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface ICardLayoutStatePersistence
+{
+    CardLayoutStateSnapshot Load();
+
+    void Save(CardLayoutStateSnapshot snapshot);
+}
+
+public sealed record CardLayoutStateOptions(string StoragePath);
+
+public sealed class FileCardLayoutStatePersistence : ICardLayoutStatePersistence
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string _storagePath;
+
+    public FileCardLayoutStatePersistence(CardLayoutStateOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.StoragePath))
+        {
+            throw new ArgumentException("Storage path cannot be null or empty.", nameof(options));
+        }
+
+        _storagePath = options.StoragePath;
+    }
+
+    public CardLayoutStateSnapshot Load()
+    {
+        try
+        {
+            if (!File.Exists(_storagePath))
+            {
+                return CardLayoutStateSnapshot.Empty;
+            }
+
+            using var stream = File.OpenRead(_storagePath);
+            var snapshot = JsonSerializer.Deserialize<CardLayoutStateSnapshot>(stream, SerializerOptions);
+            return snapshot ?? CardLayoutStateSnapshot.Empty;
+        }
+        catch (IOException)
+        {
+            return CardLayoutStateSnapshot.Empty;
+        }
+        catch (JsonException)
+        {
+            return CardLayoutStateSnapshot.Empty;
+        }
+    }
+
+    public void Save(CardLayoutStateSnapshot snapshot)
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_storagePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var temporaryPath = _storagePath + ".tmp";
+            using (var stream = File.Create(temporaryPath))
+            {
+                JsonSerializer.Serialize(stream, snapshot, SerializerOptions);
+            }
+
+            File.Move(temporaryPath, _storagePath, overwrite: true);
+        }
+        catch (IOException)
+        {
+            // Persisting layout state is a non-critical operation; ignore transient IO failures.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Persisting layout state is a non-critical operation; ignore access violations.
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/Services/CardLayoutStateService.cs
+++ b/WPF/FMUI.Wpf/Services/CardLayoutStateService.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface ICardLayoutStateService
+{
+    bool TryGetGeometry(string tabIdentifier, string sectionIdentifier, string cardId, out CardGeometry geometry);
+
+    void UpdateGeometry(string tabIdentifier, string sectionIdentifier, string cardId, CardGeometry geometry);
+
+    void ResetSection(string tabIdentifier, string sectionIdentifier);
+
+    bool TryGetFormationPlayers(string tabIdentifier, string sectionIdentifier, string cardId, out IReadOnlyList<FormationPlayerState> players);
+
+    void UpdateFormationPlayers(string tabIdentifier, string sectionIdentifier, string cardId, IReadOnlyList<FormationPlayerState> players);
+}
+
+public sealed class CardLayoutStateService : ICardLayoutStateService
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<(string Tab, string Section), Dictionary<string, CardGeometry>> _state;
+    private readonly Dictionary<(string Tab, string Section, string CardId), Dictionary<string, FormationPlayerState>> _formationState;
+    private readonly ICardLayoutStatePersistence _persistence;
+
+    public CardLayoutStateService(ICardLayoutStatePersistence persistence)
+    {
+        _persistence = persistence;
+        var snapshot = persistence.Load();
+        _state = InitializeState(snapshot);
+        _formationState = InitializeFormationState(snapshot);
+    }
+
+    public bool TryGetGeometry(string tabIdentifier, string sectionIdentifier, string cardId, out CardGeometry geometry)
+    {
+        lock (_gate)
+        {
+            geometry = default;
+
+            if (!_state.TryGetValue((tabIdentifier, sectionIdentifier), out var section))
+            {
+                return false;
+            }
+
+            return section.TryGetValue(cardId, out geometry);
+        }
+    }
+
+    public void UpdateGeometry(string tabIdentifier, string sectionIdentifier, string cardId, CardGeometry geometry)
+    {
+        lock (_gate)
+        {
+            if (!_state.TryGetValue((tabIdentifier, sectionIdentifier), out var section))
+            {
+                section = new Dictionary<string, CardGeometry>(StringComparer.OrdinalIgnoreCase);
+                _state[(tabIdentifier, sectionIdentifier)] = section;
+            }
+
+            section[cardId] = geometry;
+            Persist();
+        }
+    }
+
+    public void ResetSection(string tabIdentifier, string sectionIdentifier)
+    {
+        lock (_gate)
+        {
+            var removed = false;
+            if (_state.Remove((tabIdentifier, sectionIdentifier)))
+            {
+                removed = true;
+            }
+
+            var keysToRemove = new List<(string Tab, string Section, string CardId)>();
+            foreach (var key in _formationState.Keys)
+            {
+                if (string.Equals(key.Tab, tabIdentifier, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(key.Section, sectionIdentifier, StringComparison.OrdinalIgnoreCase))
+                {
+                    keysToRemove.Add(key);
+                }
+            }
+
+            foreach (var key in keysToRemove)
+            {
+                if (_formationState.Remove(key))
+                {
+                    removed = true;
+                }
+            }
+
+            if (removed)
+            {
+                Persist();
+            }
+        }
+    }
+
+    public bool TryGetFormationPlayers(string tabIdentifier, string sectionIdentifier, string cardId, out IReadOnlyList<FormationPlayerState> players)
+    {
+        lock (_gate)
+        {
+            players = Array.Empty<FormationPlayerState>();
+
+            if (!_formationState.TryGetValue((tabIdentifier, sectionIdentifier, cardId), out var snapshot))
+            {
+                return false;
+            }
+
+            if (snapshot.Count == 0)
+            {
+                return false;
+            }
+
+            players = snapshot.Values.ToList();
+            return true;
+        }
+    }
+
+    public void UpdateFormationPlayers(string tabIdentifier, string sectionIdentifier, string cardId, IReadOnlyList<FormationPlayerState> players)
+    {
+        lock (_gate)
+        {
+            if (players is null || players.Count == 0)
+            {
+                if (_formationState.Remove((tabIdentifier, sectionIdentifier, cardId)))
+                {
+                    Persist();
+                }
+
+                return;
+            }
+
+            if (!_formationState.TryGetValue((tabIdentifier, sectionIdentifier, cardId), out var cardPlayers))
+            {
+                cardPlayers = new Dictionary<string, FormationPlayerState>(StringComparer.OrdinalIgnoreCase);
+                _formationState[(tabIdentifier, sectionIdentifier, cardId)] = cardPlayers;
+            }
+
+            cardPlayers.Clear();
+            foreach (var player in players)
+            {
+                if (string.IsNullOrWhiteSpace(player.PlayerId))
+                {
+                    continue;
+                }
+
+                cardPlayers[player.PlayerId] = player;
+            }
+
+            Persist();
+        }
+    }
+
+    private Dictionary<(string Tab, string Section), Dictionary<string, CardGeometry>> InitializeState(CardLayoutStateSnapshot snapshot)
+    {
+        var state = new Dictionary<(string Tab, string Section), Dictionary<string, CardGeometry>>();
+
+        if (snapshot.Layouts is null)
+        {
+            return state;
+        }
+
+        foreach (var tab in snapshot.Layouts)
+        {
+            foreach (var section in tab.Value)
+            {
+                state[(tab.Key, section.Key)] = new Dictionary<string, CardGeometry>(section.Value, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        return state;
+    }
+
+    private Dictionary<(string Tab, string Section, string CardId), Dictionary<string, FormationPlayerState>> InitializeFormationState(CardLayoutStateSnapshot snapshot)
+    {
+        var state = new Dictionary<(string, string, string), Dictionary<string, FormationPlayerState>>();
+
+        if (snapshot.Formations is null)
+        {
+            return state;
+        }
+
+        foreach (var tab in snapshot.Formations)
+        {
+            foreach (var section in tab.Value)
+            {
+                foreach (var card in section.Value)
+                {
+                    state[(tab.Key, section.Key, card.Key)] = new Dictionary<string, FormationPlayerState>(card.Value, StringComparer.OrdinalIgnoreCase);
+                }
+            }
+        }
+
+        return state;
+    }
+
+    private void Persist()
+    {
+        var layouts = new Dictionary<string, Dictionary<string, Dictionary<string, CardGeometry>>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (key, cards) in _state)
+        {
+            if (!layouts.TryGetValue(key.Tab, out var sectionDictionary))
+            {
+                sectionDictionary = new Dictionary<string, Dictionary<string, CardGeometry>>(StringComparer.OrdinalIgnoreCase);
+                layouts[key.Tab] = sectionDictionary;
+            }
+
+            sectionDictionary[key.Section] = new Dictionary<string, CardGeometry>(cards, StringComparer.OrdinalIgnoreCase);
+        }
+
+        var formations = new Dictionary<string, Dictionary<string, Dictionary<string, Dictionary<string, FormationPlayerState>>>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (key, players) in _formationState)
+        {
+            if (!formations.TryGetValue(key.Tab, out var sectionDictionary))
+            {
+                sectionDictionary = new Dictionary<string, Dictionary<string, Dictionary<string, FormationPlayerState>>>(StringComparer.OrdinalIgnoreCase);
+                formations[key.Tab] = sectionDictionary;
+            }
+
+            if (!sectionDictionary.TryGetValue(key.Section, out var cardDictionary))
+            {
+                cardDictionary = new Dictionary<string, Dictionary<string, FormationPlayerState>>(StringComparer.OrdinalIgnoreCase);
+                sectionDictionary[key.Section] = cardDictionary;
+            }
+
+            cardDictionary[key.CardId] = new Dictionary<string, FormationPlayerState>(players, StringComparer.OrdinalIgnoreCase);
+        }
+
+        _persistence.Save(new CardLayoutStateSnapshot(layouts, formations));
+    }
+}

--- a/WPF/FMUI.Wpf/Services/ClubDataService.cs
+++ b/WPF/FMUI.Wpf/Services/ClubDataService.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface IClubDataService
+{
+    ClubDataSnapshot Current { get; }
+
+    ClubDataSnapshot GetSnapshot();
+
+    event EventHandler<ClubDataSnapshot>? SnapshotChanged;
+
+    Task RefreshAsync(CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Func<ClubDataSnapshot, ClubDataSnapshot> updater, CancellationToken cancellationToken = default);
+}
+
+public sealed class ClubDataService : IClubDataService
+{
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    private readonly string _basePath;
+    private readonly string _overridePath;
+
+    private ClubDataSnapshot _snapshot;
+
+    public ClubDataService()
+    {
+        var baseDirectory = AppContext.BaseDirectory;
+        var dataDirectory = Path.Combine(baseDirectory, "Data");
+        Directory.CreateDirectory(dataDirectory);
+
+        _basePath = Path.Combine(dataDirectory, "club-data.json");
+        _overridePath = Path.Combine(dataDirectory, "club-data.user.json");
+        _snapshot = LoadSnapshot();
+    }
+
+    public event EventHandler<ClubDataSnapshot>? SnapshotChanged;
+
+    public ClubDataSnapshot Current => _snapshot;
+
+    public ClubDataSnapshot GetSnapshot() => _snapshot;
+
+    public async Task RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await Task.Run(LoadSnapshot, cancellationToken).ConfigureAwait(false);
+        await SetSnapshotAsync(_ => snapshot, persistOverride: false, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(Func<ClubDataSnapshot, ClubDataSnapshot> updater, CancellationToken cancellationToken = default)
+    {
+        if (updater is null)
+        {
+            throw new ArgumentNullException(nameof(updater));
+        }
+
+        return SetSnapshotAsync(updater, persistOverride: true, cancellationToken);
+    }
+
+    private ClubDataSnapshot LoadSnapshot()
+    {
+        if (!File.Exists(_basePath))
+        {
+            throw new FileNotFoundException("Unable to locate the club data seed payload.", _basePath);
+        }
+
+        var overrideSnapshot = TryLoadSnapshot(_overridePath);
+        if (overrideSnapshot is not null)
+        {
+            return overrideSnapshot;
+        }
+
+        var seed = TryLoadSnapshot(_basePath);
+        return seed ?? throw new InvalidOperationException("The club data payload could not be deserialized.");
+    }
+
+    private ClubDataSnapshot? TryLoadSnapshot(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        using var stream = File.OpenRead(path);
+        return JsonSerializer.Deserialize<ClubDataSnapshot>(stream, _serializerOptions);
+    }
+
+    private async Task SetSnapshotAsync(
+        Func<ClubDataSnapshot, ClubDataSnapshot> mutator,
+        bool persistOverride,
+        CancellationToken cancellationToken)
+    {
+        ClubDataSnapshot snapshot;
+
+        await _mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            snapshot = mutator(_snapshot) ?? throw new InvalidOperationException("Club data mutator produced a null snapshot.");
+            _snapshot = snapshot;
+
+            if (persistOverride)
+            {
+                await PersistOverrideAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+
+        SnapshotChanged?.Invoke(this, snapshot);
+    }
+
+    private async Task PersistOverrideAsync(ClubDataSnapshot snapshot, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_overridePath)!);
+
+        await using var stream = new FileStream(
+            _overridePath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            4096,
+            useAsync: true);
+
+        await JsonSerializer.SerializeAsync(stream, snapshot, _serializerOptions, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/WPF/FMUI.Wpf/Services/NavigationCatalog.cs
+++ b/WPF/FMUI.Wpf/Services/NavigationCatalog.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface INavigationCatalog
+{
+    IReadOnlyList<NavigationTab> GetTabs();
+}
+
+public sealed class NavigationCatalog : INavigationCatalog
+{
+    public IReadOnlyList<NavigationTab> GetTabs() => new List<NavigationTab>
+    {
+        new("Overview", "overview", new List<NavigationSubItem>
+        {
+            new("Club Vision", "club-vision"),
+            new("Dynamics", "dynamics"),
+            new("Medical Centre", "medical-centre"),
+            new("Analytics", "analytics"),
+        }),
+        new("Squad", "squad", new List<NavigationSubItem>
+        {
+            new("Selection Info", "selection-info"),
+            new("Players", "players"),
+            new("International", "international"),
+            new("Squad Depth", "squad-depth"),
+        }),
+        new("Tactics", "tactics", new List<NavigationSubItem>
+        {
+            new("Overview", "tactics-overview"),
+            new("Set Pieces", "set-pieces"),
+            new("Analysis", "tactics-analysis"),
+        }),
+        new("Training", "training", new List<NavigationSubItem>
+        {
+            new("Overview", "training-overview"),
+            new("Calendar", "training-calendar"),
+            new("Units", "training-units"),
+        }),
+        new("Transfers", "transfers", new List<NavigationSubItem>
+        {
+            new("Centre", "transfer-centre"),
+            new("Scouting", "scouting"),
+            new("Shortlist", "shortlist"),
+        }),
+        new("Finances", "finances", new List<NavigationSubItem>
+        {
+            new("Summary", "finances-summary"),
+            new("Income", "finances-income"),
+            new("Expenditure", "finances-expenditure"),
+        }),
+        new("Fixtures", "fixtures", new List<NavigationSubItem>
+        {
+            new("Schedule", "fixtures-schedule"),
+            new("Results", "fixtures-results"),
+            new("Calendar", "fixtures-calendar"),
+        }),
+    };
+}

--- a/WPF/FMUI.Wpf/Services/NavigationIndicatorService.cs
+++ b/WPF/FMUI.Wpf/Services/NavigationIndicatorService.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface INavigationIndicatorService
+{
+    event EventHandler? IndicatorsChanged;
+
+    NavigationIndicatorSnapshot GetIndicator(string tabIdentifier, string sectionIdentifier);
+}
+
+public sealed class NavigationIndicatorService : INavigationIndicatorService
+{
+    private static readonly string[] CriticalKeywords =
+    {
+        "critical",
+        "injur",
+        "fracture",
+        "sprain",
+        "strain",
+        "tear",
+        "rupture",
+        "out",
+        "severe",
+        "urgent",
+        "crisis",
+        "eliminated",
+        "hamstring",
+        "groin",
+        "knee",
+        "ankle",
+        "fractured"
+    };
+
+    private static readonly string[] WarningKeywords =
+    {
+        "medium",
+        "monitor",
+        "fatigue",
+        "fatigued",
+        "tight",
+        "tightness",
+        "manage",
+        "late test",
+        "consider",
+        "decision",
+        "assess",
+        "loan",
+        "progress",
+        "negotiat",
+        "alert",
+        "pending",
+        "caution",
+        "long haul"
+    };
+
+    private readonly IClubDataService _clubDataService;
+    private readonly Dictionary<(string Tab, string Section), Func<ClubDataSnapshot, NavigationIndicatorSnapshot>> _evaluators;
+
+    public NavigationIndicatorService(IClubDataService clubDataService)
+    {
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+        _clubDataService.SnapshotChanged += OnSnapshotChanged;
+
+        _evaluators = new Dictionary<(string Tab, string Section), Func<ClubDataSnapshot, NavigationIndicatorSnapshot>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [("overview", "club-vision")] = EvaluateClubVision,
+            [("overview", "dynamics")] = EvaluateDynamics,
+            [("overview", "medical-centre")] = EvaluateMedical,
+            [("squad", "selection-info")] = EvaluateSelectionInfo,
+            [("squad", "players")] = EvaluateSquadTransfers,
+            [("training", "training-overview")] = EvaluateTrainingMedicalLoad,
+            [("transfers", "transfer-centre")] = EvaluateTransferCentre,
+            [("fixtures", "fixtures-schedule")] = EvaluateFixtureSchedule
+        };
+    }
+
+    public event EventHandler? IndicatorsChanged;
+
+    public NavigationIndicatorSnapshot GetIndicator(string tabIdentifier, string sectionIdentifier)
+    {
+        if (string.IsNullOrWhiteSpace(tabIdentifier))
+        {
+            throw new ArgumentException("Tab identifier cannot be null or whitespace.", nameof(tabIdentifier));
+        }
+
+        if (string.IsNullOrWhiteSpace(sectionIdentifier))
+        {
+            throw new ArgumentException("Section identifier cannot be null or whitespace.", nameof(sectionIdentifier));
+        }
+
+        if (_evaluators.TryGetValue((tabIdentifier, sectionIdentifier), out var evaluator))
+        {
+            var snapshot = _clubDataService.GetSnapshot();
+            return evaluator(snapshot);
+        }
+
+        return NavigationIndicatorSnapshot.None;
+    }
+
+    private void OnSnapshotChanged(object? sender, ClubDataSnapshot snapshot)
+    {
+        IndicatorsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateClubVision(ClubDataSnapshot snapshot)
+    {
+        var expectations = snapshot.Overview.ClubVision.CompetitionExpectations;
+        return BuildListIndicator(
+            expectations,
+            singularMessage: "{0} expectation is off target",
+            pluralMessage: "{0} competition expectations need action");
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateDynamics(ClubDataSnapshot snapshot)
+    {
+        var issues = snapshot.Overview.Dynamics.PlayerIssues;
+        return BuildListIndicator(
+            issues,
+            singularMessage: "Issue raised by {0}",
+            pluralMessage: "{0} player issues require attention");
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateMedical(ClubDataSnapshot snapshot)
+    {
+        var injuries = snapshot.Overview.Medical.InjuryList;
+        return BuildListIndicator(
+            injuries,
+            singularMessage: "Medical flag for {0}",
+            pluralMessage: "{0} medical cases active");
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateSelectionInfo(ClubDataSnapshot snapshot)
+    {
+        var concerns = snapshot.Squad.SelectionInfo.FitnessConcerns;
+        return BuildListIndicator(
+            concerns,
+            singularMessage: "Fitness concern: {0}",
+            pluralMessage: "{0} fitness concerns to manage");
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateSquadTransfers(ClubDataSnapshot snapshot)
+    {
+        var interest = snapshot.Squad.Players.TransferInterest;
+        return BuildListIndicator(
+            interest,
+            singularMessage: "Transfer interest in {0}",
+            pluralMessage: "{0} players attracting bids");
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateTrainingMedicalLoad(ClubDataSnapshot snapshot)
+    {
+        var workload = snapshot.Training.Overview.MedicalWorkload;
+        return BuildListIndicator(
+            workload,
+            singularMessage: "Training risk: {0}",
+            pluralMessage: "{0} players flagged by medical team");
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateTransferCentre(ClubDataSnapshot snapshot)
+    {
+        var deals = snapshot.Transfers.Centre.ActiveDeals;
+        return BuildListIndicator(
+            deals,
+            singularMessage: "Deal in progress: {0}",
+            pluralMessage: "{0} active deals underway");
+    }
+
+    private static NavigationIndicatorSnapshot EvaluateFixtureSchedule(ClubDataSnapshot snapshot)
+    {
+        var fixtures = snapshot.Fixtures.Schedule.UpcomingFixtures;
+        if (fixtures.Count == 0)
+        {
+            return NavigationIndicatorSnapshot.None;
+        }
+
+        var tooltip = fixtures.Count == 1
+            ? string.Format(CultureInfo.CurrentCulture, "Next fixture: {0}", fixtures[0].Primary)
+            : string.Format(CultureInfo.CurrentCulture, "{0} fixtures this fortnight", fixtures.Count);
+
+        return new NavigationIndicatorSnapshot(fixtures.Count, NavigationIndicatorSeverity.Info, tooltip);
+    }
+
+    private static NavigationIndicatorSnapshot BuildListIndicator(
+        IReadOnlyList<ListEntrySnapshot> entries,
+        string singularMessage,
+        string pluralMessage)
+    {
+        if (entries is null || entries.Count == 0)
+        {
+            return NavigationIndicatorSnapshot.None;
+        }
+
+        var severity = NavigationIndicatorSeverity.None;
+        var concerningCount = 0;
+        string? firstLabel = null;
+
+        foreach (var entry in entries)
+        {
+            var entrySeverity = EvaluateEntrySeverity(entry);
+            if (entrySeverity >= NavigationIndicatorSeverity.Warning)
+            {
+                concerningCount++;
+                firstLabel ??= entry.Primary ?? entry.Secondary ?? entry.Tertiary ?? "item";
+            }
+
+            severity = Max(severity, entrySeverity);
+        }
+
+        if (concerningCount == 0)
+        {
+            return NavigationIndicatorSnapshot.None;
+        }
+
+        var tooltip = concerningCount == 1
+            ? string.Format(CultureInfo.CurrentCulture, singularMessage, firstLabel)
+            : string.Format(CultureInfo.CurrentCulture, pluralMessage, concerningCount);
+
+        return new NavigationIndicatorSnapshot(concerningCount, severity, tooltip);
+    }
+
+    private static NavigationIndicatorSeverity EvaluateEntrySeverity(ListEntrySnapshot entry)
+    {
+        if (entry is null)
+        {
+            return NavigationIndicatorSeverity.None;
+        }
+
+        var severity = NavigationIndicatorSeverity.None;
+
+        severity = Max(severity, EvaluateTextSeverity(entry.Accent));
+        severity = Max(severity, EvaluateTextSeverity(entry.Primary));
+        severity = Max(severity, EvaluateTextSeverity(entry.Secondary));
+        severity = Max(severity, EvaluateTextSeverity(entry.Tertiary));
+
+        return severity;
+    }
+
+    private static NavigationIndicatorSeverity EvaluateTextSeverity(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return NavigationIndicatorSeverity.None;
+        }
+
+        var text = value.Trim();
+        var comparison = CultureInfo.CurrentCulture.CompareInfo;
+
+        foreach (var keyword in CriticalKeywords)
+        {
+            if (comparison.IndexOf(text, keyword, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) >= 0)
+            {
+                return NavigationIndicatorSeverity.Critical;
+            }
+        }
+
+        foreach (var keyword in WarningKeywords)
+        {
+            if (comparison.IndexOf(text, keyword, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) >= 0)
+            {
+                return NavigationIndicatorSeverity.Warning;
+            }
+        }
+
+        return NavigationIndicatorSeverity.Info;
+    }
+
+    private static NavigationIndicatorSeverity Max(NavigationIndicatorSeverity left, NavigationIndicatorSeverity right)
+    {
+        return (NavigationIndicatorSeverity)Math.Max((int)left, (int)right);
+    }
+}

--- a/WPF/FMUI.Wpf/Services/NavigationPermissionService.cs
+++ b/WPF/FMUI.Wpf/Services/NavigationPermissionService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface INavigationPermissionService
+{
+    event EventHandler? PermissionsChanged;
+
+    bool IsTabVisible(string tabId);
+
+    bool IsSectionVisible(string tabId, string sectionId);
+}
+
+public sealed class NavigationPermissionService : INavigationPermissionService
+{
+    private readonly IClubDataService _clubDataService;
+    private readonly object _sync = new();
+    private Dictionary<string, bool> _tabVisibility = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<(string Tab, string Section), bool> _sectionVisibility =
+        new(TabSectionComparer.Instance);
+
+    public NavigationPermissionService(IClubDataService clubDataService)
+    {
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+
+        ApplySnapshot(clubDataService.Current.NavigationPermissions);
+        _clubDataService.SnapshotChanged += OnSnapshotChanged;
+    }
+
+    public event EventHandler? PermissionsChanged;
+
+    public bool IsTabVisible(string tabId)
+    {
+        if (string.IsNullOrWhiteSpace(tabId))
+        {
+            return true;
+        }
+
+        lock (_sync)
+        {
+            return !_tabVisibility.TryGetValue(tabId, out var isVisible) || isVisible;
+        }
+    }
+
+    public bool IsSectionVisible(string tabId, string sectionId)
+    {
+        if (string.IsNullOrWhiteSpace(tabId) || string.IsNullOrWhiteSpace(sectionId))
+        {
+            return true;
+        }
+
+        lock (_sync)
+        {
+            return !_sectionVisibility.TryGetValue((tabId, sectionId), out var isVisible) || isVisible;
+        }
+    }
+
+    private void OnSnapshotChanged(object? sender, ClubDataSnapshot snapshot)
+    {
+        ApplySnapshot(snapshot.NavigationPermissions);
+    }
+
+    private void ApplySnapshot(NavigationPermissionsSnapshot? permissions)
+    {
+        var tabVisibility = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        var sectionVisibility = new Dictionary<(string Tab, string Section), bool>(TabSectionComparer.Instance);
+
+        if (permissions?.Tabs is { Count: > 0 })
+        {
+            foreach (var tab in permissions.Tabs)
+            {
+                var tabId = tab.TabId ?? string.Empty;
+                tabVisibility[tabId] = tab.IsVisible;
+
+                if (tab.Sections is { Count: > 0 })
+                {
+                    foreach (var section in tab.Sections)
+                    {
+                        sectionVisibility[(tabId, section.SectionId ?? string.Empty)] = section.IsVisible;
+                    }
+                }
+            }
+        }
+
+        lock (_sync)
+        {
+            _tabVisibility = tabVisibility;
+            _sectionVisibility = sectionVisibility;
+        }
+
+        PermissionsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private sealed class TabSectionComparer : IEqualityComparer<(string Tab, string Section)>
+    {
+        public static TabSectionComparer Instance { get; } = new();
+
+        public bool Equals((string Tab, string Section) x, (string Tab, string Section) y)
+        {
+            return string.Equals(x.Tab, y.Tab, StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(x.Section, y.Section, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode((string Tab, string Section) obj)
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = (hash * 23) + StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Tab ?? string.Empty);
+                hash = (hash * 23) + StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Section ?? string.Empty);
+                return hash;
+            }
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/Services/TrainingCalendarFormatter.cs
+++ b/WPF/FMUI.Wpf/Services/TrainingCalendarFormatter.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+internal static class TrainingCalendarFormatter
+{
+    private static readonly string[] DaySequence =
+    {
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+    };
+
+    private static readonly Dictionary<string, int> DayIndex = DaySequence
+        .Select((day, index) => (day, index))
+        .ToDictionary(pair => pair.day, pair => pair.index, StringComparer.OrdinalIgnoreCase);
+
+    private static readonly string[] SlotSequence =
+    {
+        "Morning",
+        "Afternoon",
+        "Evening"
+    };
+
+    private static readonly Dictionary<string, int> SlotIndex = SlotSequence
+        .Select((slot, index) => (slot, index))
+        .ToDictionary(pair => pair.slot, pair => pair.index, StringComparer.OrdinalIgnoreCase);
+
+    private static readonly IReadOnlyList<string> OrderedDaysCache = Array.AsReadOnly(DaySequence);
+
+    private static readonly IReadOnlyList<string> OrderedSlotsCache = Array.AsReadOnly(SlotSequence);
+
+    public static IReadOnlyList<string> OrderedDays => OrderedDaysCache;
+
+    public static IReadOnlyList<string> OrderedSlots => OrderedSlotsCache;
+
+    public static IReadOnlyList<TrainingSessionDetailSnapshot> OrderSessions(IReadOnlyList<TrainingSessionDetailSnapshot> sessions)
+    {
+        if (sessions is null || sessions.Count == 0)
+        {
+            return Array.Empty<TrainingSessionDetailSnapshot>();
+        }
+
+        return sessions
+            .OrderBy(session => GetDayIndex(session.Day))
+            .ThenBy(session => GetSlotIndex(session.Slot))
+            .ToList();
+    }
+
+    public static IReadOnlyList<ListEntrySnapshot> BuildWeekOverview(IReadOnlyList<TrainingSessionDetailSnapshot> sessions)
+    {
+        var orderedSessions = OrderSessions(sessions);
+        if (orderedSessions.Count == 0)
+        {
+            return Array.Empty<ListEntrySnapshot>();
+        }
+
+        var groups = orderedSessions
+            .GroupBy(session => NormalizeDay(session.Day))
+            .OrderBy(group => GetDayIndex(group.Key))
+            .ToList();
+
+        var overview = new List<ListEntrySnapshot>(groups.Count);
+        foreach (var group in groups)
+        {
+            var entries = group
+                .OrderBy(session => GetSlotIndex(session.Slot))
+                .ToList();
+
+            var secondary = entries[0].Activity;
+            var tertiarySegments = new List<string>(entries.Count);
+
+            foreach (var entry in entries)
+            {
+                var focus = string.IsNullOrWhiteSpace(entry.Focus) ? null : entry.Focus;
+                var intensity = string.IsNullOrWhiteSpace(entry.Intensity) ? null : entry.Intensity;
+
+                var detailParts = new List<string>(3) { entry.Slot };
+                detailParts.Add(entry.Activity);
+
+                if (focus is not null)
+                {
+                    detailParts.Add(focus);
+                }
+
+                if (intensity is not null)
+                {
+                    detailParts.Add(intensity);
+                }
+
+                tertiarySegments.Add(string.Join(" – ", detailParts));
+            }
+
+            var tertiary = tertiarySegments.Count > 0
+                ? string.Join(" • ", tertiarySegments)
+                : null;
+
+            overview.Add(new ListEntrySnapshot(group.Key, secondary, tertiary));
+        }
+
+        return overview;
+    }
+
+    public static IReadOnlyList<CardListItem> BuildWeekOverviewCardItems(IReadOnlyList<TrainingSessionDetailSnapshot> sessions)
+    {
+        var overview = BuildWeekOverview(sessions);
+        if (overview.Count == 0)
+        {
+            return Array.Empty<CardListItem>();
+        }
+
+        return overview.Select(entry => new CardListItem(entry.Primary, entry.Secondary, entry.Tertiary, entry.Accent)).ToList();
+    }
+
+    private static int GetDayIndex(string? day)
+    {
+        if (day is null)
+        {
+            return DaySequence.Length;
+        }
+
+        return DayIndex.TryGetValue(day, out var index) ? index : DaySequence.Length;
+    }
+
+    private static int GetSlotIndex(string? slot)
+    {
+        if (slot is null)
+        {
+            return SlotSequence.Length;
+        }
+
+        return SlotIndex.TryGetValue(slot, out var index) ? index : SlotSequence.Length;
+    }
+
+    private static string NormalizeDay(string day)
+    {
+        if (string.IsNullOrWhiteSpace(day))
+        {
+            return "Unscheduled";
+        }
+
+        return DaySequence.FirstOrDefault(candidate => string.Equals(candidate, day, StringComparison.OrdinalIgnoreCase))
+            ?? day;
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/CardPresetViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/CardPresetViewModel.cs
@@ -1,0 +1,31 @@
+using System;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class CardPresetViewModel
+{
+    private readonly CardPresetDefinition _definition;
+
+    public CardPresetViewModel(CardPresetDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+    }
+
+    public string Id => _definition.Id;
+
+    public string DisplayName => _definition.DisplayName;
+
+    public string? Description => _definition.Description;
+
+    public CardKind Kind => _definition.Template.Kind;
+
+    public CardDefinition CreateDefinition()
+    {
+        var template = _definition.Template;
+        return template with
+        {
+            Id = $"{template.Id}-{Guid.NewGuid():N}"
+        };
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/CardSurfaceViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/CardSurfaceViewModel.cs
@@ -1,0 +1,540 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+using FMUI.Wpf.ViewModels.Editors;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class CardSurfaceViewModel : ObservableObject, IDisposable
+{
+    private readonly ICardLayoutCatalog _catalog;
+    private readonly ICardInteractionService _interactionService;
+    private readonly ICardLayoutStateService _stateService;
+    private readonly ICardEditorCatalog _editorCatalog;
+    private readonly IClubDataService _clubDataService;
+    private readonly IDisposable _subscription;
+    private string? _emptyMessage;
+    private Rect _viewport;
+    private readonly RelayCommand _undoCommand;
+    private readonly RelayCommand _redoCommand;
+    private readonly RelayCommand _nudgeLeftCommand;
+    private readonly RelayCommand _nudgeRightCommand;
+    private readonly RelayCommand _nudgeUpCommand;
+    private readonly RelayCommand _nudgeDownCommand;
+    private readonly RelayCommand _clearSelectionCommand;
+    private readonly ObservableCollection<CardPreviewViewModel> _previews = new();
+    private readonly ObservableCollection<CardPresetViewModel> _palette = new();
+    private readonly RelayCommand _openPaletteCommand;
+    private readonly RelayCommand _closePaletteCommand;
+    private readonly RelayCommand _createCardCommand;
+    private readonly RelayCommand _removeSelectedCardsCommand;
+    private readonly RelayCommand _closeEditorCommand;
+    private string _currentTabIdentifier = string.Empty;
+    private string _currentSectionIdentifier = string.Empty;
+    private CardEditorViewModel? _activeEditor;
+    private bool _isEditorOpen;
+
+    public CardSurfaceViewModel(
+        ICardLayoutCatalog catalog,
+        ICardInteractionService interactionService,
+        ICardLayoutStateService stateService,
+        ICardEditorCatalog editorCatalog,
+        IEventAggregator eventAggregator,
+        IClubDataService clubDataService)
+    {
+        _catalog = catalog;
+        _interactionService = interactionService;
+        _stateService = stateService;
+        _editorCatalog = editorCatalog;
+        _clubDataService = clubDataService;
+        Metrics = CardSurfaceMetrics.Default;
+        _viewport = new Rect(0, 0, Metrics.SurfaceWidth, Metrics.SurfaceHeight);
+        _interactionService.Initialize(Metrics);
+        Cards.CollectionChanged += OnCardsCollectionChanged;
+        EmptyMessage = "Select a section to view its tactical dashboard.";
+        _subscription = eventAggregator.Subscribe<NavigationSectionChangedEvent>(OnNavigationSectionChanged);
+        _undoCommand = new RelayCommand(() => _interactionService.Undo(), () => _interactionService.CanUndo);
+        _redoCommand = new RelayCommand(() => _interactionService.Redo(), () => _interactionService.CanRedo);
+        _nudgeLeftCommand = CreateNudgeCommand(-1, 0);
+        _nudgeRightCommand = CreateNudgeCommand(1, 0);
+        _nudgeUpCommand = CreateNudgeCommand(0, -1);
+        _nudgeDownCommand = CreateNudgeCommand(0, 1);
+        _clearSelectionCommand = new RelayCommand(() => _interactionService.ClearSelection(), () => _interactionService.HasSelection);
+        _openPaletteCommand = new RelayCommand(() => IsPaletteOpen = true, () => _palette.Count > 0);
+        _closePaletteCommand = new RelayCommand(() => IsPaletteOpen = false);
+        _createCardCommand = new RelayCommand(CreateSelectedCard, () => SelectedPreset is not null);
+        _removeSelectedCardsCommand = new RelayCommand(RemoveSelectedCards, () => _interactionService.HasSelection);
+        _closeEditorCommand = new RelayCommand(CloseEditor);
+        _interactionService.SelectionChanged += OnSelectionChanged;
+        _interactionService.HistoryChanged += OnHistoryChanged;
+        _interactionService.PreviewChanged += OnPreviewChanged;
+        _interactionService.CardsMutated += OnCardsMutated;
+        Previews = new ReadOnlyObservableCollection<CardPreviewViewModel>(_previews);
+        Palette = new ReadOnlyObservableCollection<CardPresetViewModel>(_palette);
+        _catalog.LayoutsChanged += OnLayoutsChanged;
+    }
+
+    public ObservableCollection<CardViewModel> Cards { get; } = new();
+
+    public CardSurfaceMetrics Metrics { get; }
+
+    public double SurfaceWidth => Metrics.SurfaceWidth;
+
+    public double SurfaceHeight => Metrics.SurfaceHeight;
+
+    public bool HasCards => Cards.Count > 0;
+
+    public bool HasSelection => _interactionService.HasSelection;
+
+    public ReadOnlyObservableCollection<CardPreviewViewModel> Previews { get; }
+
+    public bool HasPreview => _previews.Count > 0;
+
+    public bool PreviewHasCollision => _previews.Any(preview => !preview.IsValid);
+
+    public ReadOnlyObservableCollection<CardPresetViewModel> Palette { get; }
+
+    private bool _isPaletteOpen;
+    public bool IsPaletteOpen
+    {
+        get => _isPaletteOpen;
+        private set
+        {
+            if (SetProperty(ref _isPaletteOpen, value) && value)
+            {
+                if (SelectedPreset is null && _palette.Count > 0)
+                {
+                    SelectedPreset = _palette[0];
+                }
+            }
+        }
+    }
+
+    private CardPresetViewModel? _selectedPreset;
+    public CardPresetViewModel? SelectedPreset
+    {
+        get => _selectedPreset;
+        set
+        {
+            if (SetProperty(ref _selectedPreset, value))
+            {
+                _createCardCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string? EmptyMessage
+    {
+        get => _emptyMessage;
+        private set => SetProperty(ref _emptyMessage, value);
+    }
+
+    public ICommand UndoCommand => _undoCommand;
+
+    public ICommand RedoCommand => _redoCommand;
+
+    public ICommand NudgeLeftCommand => _nudgeLeftCommand;
+
+    public ICommand NudgeRightCommand => _nudgeRightCommand;
+
+    public ICommand NudgeUpCommand => _nudgeUpCommand;
+
+    public ICommand NudgeDownCommand => _nudgeDownCommand;
+
+    public ICommand ClearSelectionCommand => _clearSelectionCommand;
+
+    public ICommand OpenPaletteCommand => _openPaletteCommand;
+
+    public ICommand ClosePaletteCommand => _closePaletteCommand;
+
+    public ICommand CreateCardCommand => _createCardCommand;
+
+    public ICommand RemoveSelectedCardsCommand => _removeSelectedCardsCommand;
+
+    public ICommand CloseEditorCommand => _closeEditorCommand;
+
+    public CardEditorViewModel? ActiveEditor
+    {
+        get => _activeEditor;
+        private set => SetProperty(ref _activeEditor, value);
+    }
+
+    public bool IsEditorOpen
+    {
+        get => _isEditorOpen;
+        private set => SetProperty(ref _isEditorOpen, value);
+    }
+
+    public void Dispose()
+    {
+        Cards.CollectionChanged -= OnCardsCollectionChanged;
+        _interactionService.SelectionChanged -= OnSelectionChanged;
+        _interactionService.HistoryChanged -= OnHistoryChanged;
+        _interactionService.PreviewChanged -= OnPreviewChanged;
+        _interactionService.CardsMutated -= OnCardsMutated;
+        _subscription.Dispose();
+        _catalog.LayoutsChanged -= OnLayoutsChanged;
+        _interactionService.SetCards(Array.Empty<CardViewModel>());
+    }
+
+    private void Clear()
+    {
+        Cards.Clear();
+        EmptyMessage = "Select a section to view its tactical dashboard.";
+        _interactionService.SetActiveSection(string.Empty, string.Empty);
+        _interactionService.SetCards(Array.Empty<CardViewModel>());
+        _palette.Clear();
+        SelectedPreset = null;
+        IsPaletteOpen = false;
+        CloseEditor();
+        _openPaletteCommand.RaiseCanExecuteChanged();
+        _removeSelectedCardsCommand.RaiseCanExecuteChanged();
+        _currentTabIdentifier = string.Empty;
+        _currentSectionIdentifier = string.Empty;
+    }
+
+    private void LoadSection(string tabIdentifier, string sectionIdentifier)
+    {
+        _palette.Clear();
+        SelectedPreset = null;
+        IsPaletteOpen = false;
+        CloseEditor();
+        _currentTabIdentifier = tabIdentifier;
+        _currentSectionIdentifier = sectionIdentifier;
+
+        if (_catalog.TryGetLayout(tabIdentifier, sectionIdentifier, out var layout))
+        {
+            foreach (var preset in layout.Palette)
+            {
+                _palette.Add(new CardPresetViewModel(preset));
+            }
+
+            Cards.Clear();
+            _interactionService.SetActiveSection(tabIdentifier, sectionIdentifier);
+
+            foreach (var definition in layout.Cards)
+            {
+                if (_stateService.IsCardRemoved(tabIdentifier, sectionIdentifier, definition.Id))
+                {
+                    continue;
+                }
+
+                var card = new CardViewModel(definition, Metrics, _interactionService, _clubDataService, isCustom: false, presetId: null);
+                ApplyPersistedState(tabIdentifier, sectionIdentifier, card);
+                ConfigureEditor(card);
+                Cards.Add(card);
+            }
+
+            var customCards = _stateService.GetCustomCards(tabIdentifier, sectionIdentifier);
+            foreach (var custom in customCards)
+            {
+                var card = new CardViewModel(custom.Definition, Metrics, _interactionService, _clubDataService, isCustom: true, presetId: custom.PresetId);
+                ApplyPersistedState(tabIdentifier, sectionIdentifier, card);
+                ConfigureEditor(card);
+                Cards.Add(card);
+            }
+
+            EmptyMessage = Cards.Count == 0
+                ? "No cards pinned yet. Open the catalog to add tactical widgets."
+                : null;
+
+            _interactionService.SetCards(Cards);
+            _interactionService.UpdateViewport(_viewport);
+            _openPaletteCommand.RaiseCanExecuteChanged();
+            SelectedPreset = _palette.FirstOrDefault();
+            _removeSelectedCardsCommand.RaiseCanExecuteChanged();
+        }
+        else
+        {
+            Cards.Clear();
+            EmptyMessage = "Layout coming soon for this section.";
+            _interactionService.SetActiveSection(string.Empty, string.Empty);
+            _interactionService.SetCards(Array.Empty<CardViewModel>());
+            _openPaletteCommand.RaiseCanExecuteChanged();
+            _removeSelectedCardsCommand.RaiseCanExecuteChanged();
+            CloseEditor();
+        }
+    }
+
+    private void OnLayoutsChanged(object? sender, LayoutsChangedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(_currentTabIdentifier) || string.IsNullOrWhiteSpace(_currentSectionIdentifier))
+        {
+            return;
+        }
+
+        var shouldReload = e.IsGlobal || e.Sections.Any(section =>
+            string.Equals(section.Tab, _currentTabIdentifier, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(section.Section, _currentSectionIdentifier, StringComparison.OrdinalIgnoreCase));
+
+        if (!shouldReload)
+        {
+            return;
+        }
+
+        void Reload() => LoadSection(_currentTabIdentifier, _currentSectionIdentifier);
+
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+        {
+            Reload();
+        }
+        else
+        {
+            dispatcher.Invoke(Reload);
+        }
+    }
+
+    private void OnNavigationSectionChanged(NavigationSectionChangedEvent navigationEvent)
+    {
+        if (string.IsNullOrWhiteSpace(navigationEvent.SectionIdentifier))
+        {
+            Clear();
+            return;
+        }
+
+        LoadSection(navigationEvent.TabIdentifier, navigationEvent.SectionIdentifier);
+    }
+
+    private void OnCardsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasCards));
+    }
+
+    public void UpdateViewport(Rect viewport)
+    {
+        _viewport = viewport;
+        _interactionService.UpdateViewport(viewport);
+    }
+
+    private RelayCommand CreateNudgeCommand(int columnDelta, int rowDelta) =>
+        new(() => _interactionService.NudgeSelection(columnDelta, rowDelta), () => _interactionService.HasSelection);
+
+    private void OnSelectionChanged(object? sender, EventArgs e)
+    {
+        OnPropertyChanged(nameof(HasSelection));
+        _nudgeLeftCommand.RaiseCanExecuteChanged();
+        _nudgeRightCommand.RaiseCanExecuteChanged();
+        _nudgeUpCommand.RaiseCanExecuteChanged();
+        _nudgeDownCommand.RaiseCanExecuteChanged();
+        _clearSelectionCommand.RaiseCanExecuteChanged();
+        _removeSelectedCardsCommand.RaiseCanExecuteChanged();
+    }
+
+    private void OnHistoryChanged(object? sender, EventArgs e)
+    {
+        _undoCommand.RaiseCanExecuteChanged();
+        _redoCommand.RaiseCanExecuteChanged();
+    }
+
+    private void OnPreviewChanged(object? sender, IReadOnlyList<CardPreviewSnapshot> snapshots)
+    {
+        _previews.Clear();
+
+        foreach (var snapshot in snapshots)
+        {
+            _previews.Add(new CardPreviewViewModel(snapshot, Metrics));
+        }
+
+        OnPropertyChanged(nameof(HasPreview));
+        OnPropertyChanged(nameof(PreviewHasCollision));
+    }
+
+    private void ApplyPersistedState(string tabIdentifier, string sectionIdentifier, CardViewModel card)
+    {
+        if (_stateService.TryGetGeometry(tabIdentifier, sectionIdentifier, card.Id, out var geometry))
+        {
+            card.UpdateGeometry(geometry.Column, geometry.Row, geometry.ColumnSpan, geometry.RowSpan);
+        }
+
+        if (card.HasFormationPlayers &&
+            _stateService.TryGetFormationPlayers(tabIdentifier, sectionIdentifier, card.Id, out var players))
+        {
+            card.ApplyFormationState(players);
+        }
+    }
+
+    private void OnCardsMutated(object? sender, CardMutationEventArgs e)
+    {
+        if (e.AddedCards.Count > 0)
+        {
+            foreach (var card in e.AddedCards)
+            {
+                if (!Cards.Contains(card))
+                {
+                    Cards.Add(card);
+                }
+                ConfigureEditor(card);
+            }
+        }
+
+        if (e.RemovedCards.Count > 0)
+        {
+            foreach (var card in e.RemovedCards)
+            {
+                Cards.Remove(card);
+            }
+
+            if (e.RemovedCards.Count > 0)
+            {
+                CloseEditor();
+            }
+        }
+
+        if (e.Origin == MutationOrigin.User && e.AddedCards.Count > 0)
+        {
+            IsPaletteOpen = false;
+        }
+
+        if (Cards.Count == 0)
+        {
+            EmptyMessage = "No cards pinned yet. Open the catalog to add tactical widgets.";
+        }
+        else if (!string.IsNullOrWhiteSpace(EmptyMessage))
+        {
+            EmptyMessage = null;
+        }
+
+        OnPropertyChanged(nameof(HasCards));
+    }
+
+    private void CreateSelectedCard()
+    {
+        var preset = SelectedPreset;
+        if (preset is null)
+        {
+            return;
+        }
+
+        var definition = preset.CreateDefinition();
+        _interactionService.CreateCard(definition, isCustom: true, presetId: preset.Id);
+    }
+
+    private void RemoveSelectedCards()
+    {
+        var selection = _interactionService.GetSelectedCards();
+        if (selection.Count == 0)
+        {
+            return;
+        }
+
+        _interactionService.RemoveCards(selection);
+    }
+
+    private void ConfigureEditor(CardViewModel card)
+    {
+        if (card is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_currentTabIdentifier) || string.IsNullOrWhiteSpace(_currentSectionIdentifier))
+        {
+            card.ConfigureEditor(null, false);
+            return;
+        }
+
+        var supportsEditing = _editorCatalog.SupportsEditing(_currentTabIdentifier, _currentSectionIdentifier, card.Definition);
+        card.ConfigureEditor(OnEditorRequested, supportsEditing);
+    }
+
+    private void OnEditorRequested(CardViewModel card)
+    {
+        if (string.IsNullOrWhiteSpace(_currentTabIdentifier) || string.IsNullOrWhiteSpace(_currentSectionIdentifier))
+        {
+            return;
+        }
+
+        var editor = _editorCatalog.CreateEditor(_currentTabIdentifier, _currentSectionIdentifier, card.Definition);
+        if (editor is null)
+        {
+            return;
+        }
+
+        CloseEditor();
+        IsPaletteOpen = false;
+        ActiveEditor = editor;
+        ActiveEditor.CloseRequested += OnEditorCloseRequested;
+        IsEditorOpen = true;
+    }
+
+    private void OnEditorCloseRequested(object? sender, EventArgs e)
+    {
+        CloseEditor();
+    }
+
+    private void CloseEditor()
+    {
+        if (ActiveEditor is not null)
+        {
+            ActiveEditor.CloseRequested -= OnEditorCloseRequested;
+            ActiveEditor = null;
+        }
+
+        IsEditorOpen = false;
+    }
+}
+
+public sealed record CardSurfaceMetrics(int Columns, int Rows, double TileSize, double Gap, double Padding)
+{
+    public static CardSurfaceMetrics Default { get; } = new(37, 19, 32, 6, 18);
+
+    public double SurfaceWidth => Padding * 2 + Columns * TileSize + (Columns - 1) * Gap;
+
+    public double SurfaceHeight => Padding * 2 + Rows * TileSize + (Rows - 1) * Gap;
+
+    public double CalculateLeft(int column) => Padding + column * (TileSize + Gap);
+
+    public double CalculateTop(int row) => Padding + row * (TileSize + Gap);
+
+    public double CalculateWidth(int span) => span * TileSize + (span - 1) * Gap;
+
+    public double CalculateHeight(int span) => span * TileSize + (span - 1) * Gap;
+
+    public int SnapColumn(double left, int span)
+    {
+        var cellSize = TileSize + Gap;
+        var normalized = Math.Round((left - Padding) / cellSize, MidpointRounding.AwayFromZero);
+        var column = (int)Math.Clamp(normalized, 0, Columns - span);
+        return column;
+    }
+
+    public int SnapRow(double top, int span)
+    {
+        var cellSize = TileSize + Gap;
+        var normalized = Math.Round((top - Padding) / cellSize, MidpointRounding.AwayFromZero);
+        var row = (int)Math.Clamp(normalized, 0, Rows - span);
+        return row;
+    }
+}
+
+public sealed class CardPreviewViewModel
+{
+    private readonly CardPreviewSnapshot _snapshot;
+    private readonly CardSurfaceMetrics _metrics;
+
+    public CardPreviewViewModel(CardPreviewSnapshot snapshot, CardSurfaceMetrics metrics)
+    {
+        _snapshot = snapshot;
+        _metrics = metrics;
+    }
+
+    public string CardId => _snapshot.CardId;
+
+    public double Left => _metrics.CalculateLeft(_snapshot.Geometry.Column);
+
+    public double Top => _metrics.CalculateTop(_snapshot.Geometry.Row);
+
+    public double Width => _metrics.CalculateWidth(_snapshot.Geometry.ColumnSpan);
+
+    public double Height => _metrics.CalculateHeight(_snapshot.Geometry.RowSpan);
+
+    public bool IsValid => _snapshot.IsValid;
+}

--- a/WPF/FMUI.Wpf/ViewModels/CardViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/CardViewModel.cs
@@ -1,0 +1,1793 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Data;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class CardViewModel : ObservableObject
+{
+    private readonly CardDefinition _definition;
+    private readonly CardSurfaceMetrics _metrics;
+    private readonly ICardInteractionService _interactionService;
+    private readonly Dictionary<string, FormationPlayerViewModel> _formationPlayerLookup = new(StringComparer.OrdinalIgnoreCase);
+    private readonly RelayCommand _openEditorCommand;
+    private Action<CardViewModel>? _requestEditor;
+    private int _column;
+    private int _row;
+    private int _columnSpan;
+    private int _rowSpan;
+    private bool _isVisible = true;
+    private bool _isSelected;
+
+    private bool _isEditorAvailable;
+
+    public CardViewModel(
+        CardDefinition definition,
+        CardSurfaceMetrics metrics,
+        ICardInteractionService interactionService,
+        IClubDataService clubDataService,
+        bool isCustom = false,
+        string? presetId = null)
+    {
+        _definition = definition;
+        _metrics = metrics;
+        _interactionService = interactionService;
+        _column = definition.Column;
+        _row = definition.Row;
+        _columnSpan = definition.ColumnSpan;
+        _rowSpan = definition.RowSpan;
+        IsCustom = isCustom;
+        PresetId = presetId;
+        ListItems = definition.ListItems is { Count: > 0 }
+            ? new ReadOnlyCollection<CardListItemViewModel>(CreateListItems(definition.ListItems))
+            : System.Array.Empty<CardListItemViewModel>();
+
+        if (definition.FormationLines is { Count: > 0 })
+        {
+            var formation = CreateFormationViewModels(definition.FormationLines, interactionService, this);
+            FormationLines = formation.Lines;
+            FormationPlayers = formation.Players;
+        }
+        else
+        {
+            FormationLines = System.Array.Empty<FormationLineViewModel>();
+            FormationPlayers = System.Array.Empty<FormationPlayerViewModel>();
+        }
+
+        ChartSeries = definition.ChartSeries is { Count: > 0 }
+            ? new ReadOnlyCollection<ChartSeriesViewModel>(CreateChartSeries(definition.ChartSeries))
+            : System.Array.Empty<ChartSeriesViewModel>();
+
+        Gauge = definition.Gauge is not null ? new GaugeViewModel(definition.Gauge) : null;
+
+        Forecast = definition.Forecast is not null
+            ? new FinanceForecastViewModel(definition.Forecast, clubDataService)
+            : null;
+
+        FinanceCashflow = definition.FinanceCashflow is not null
+            ? new FinanceCashflowViewModel(definition.FinanceCashflow)
+            : null;
+
+        FinanceBudgetAllocator = definition.FinanceBudgetAllocator is not null
+            ? new FinanceBudgetAllocatorViewModel(definition.FinanceBudgetAllocator, clubDataService)
+            : null;
+
+        FinanceScenario = definition.FinanceScenario is not null
+            ? new FinanceScenarioBoardViewModel(definition.FinanceScenario, clubDataService)
+            : null;
+
+        SquadTable = definition.SquadTable is not null
+            ? new SquadTableViewModel(definition.SquadTable)
+            : null;
+
+        WorkloadHeatmap = definition.WorkloadHeatmap is not null
+            ? new TrainingWorkloadHeatmapViewModel(definition.WorkloadHeatmap)
+            : null;
+
+        MoraleHeatmap = definition.MoraleHeatmap is not null
+            ? new MoraleHeatmapViewModel(definition.MoraleHeatmap)
+            : null;
+
+        TrainingCalendar = definition.TrainingCalendar is not null
+            ? new TrainingCalendarViewModel(definition.TrainingCalendar, clubDataService)
+            : null;
+
+        FixtureCalendar = definition.FixtureCalendar is not null
+            ? new FixtureCalendarViewModel(definition.FixtureCalendar, clubDataService)
+            : null;
+
+        Negotiations = definition.Negotiations is not null
+            ? new TransferNegotiationCardViewModel(definition.Negotiations)
+            : null;
+
+        ScoutAssignments = definition.ScoutAssignments is not null
+            ? new ScoutAssignmentBoardViewModel(definition.ScoutAssignments)
+            : null;
+
+        ShortlistBoard = definition.ShortlistBoard is not null
+            ? new ShortlistBoardViewModel(definition.ShortlistBoard)
+            : null;
+
+        TrainingUnitBoard = definition.TrainingUnitBoard is not null
+            ? new TrainingUnitBoardViewModel(definition.TrainingUnitBoard)
+            : null;
+
+        TrainingProgression = definition.TrainingProgression is not null
+            ? new TrainingProgressionViewModel(definition.TrainingProgression)
+            : null;
+
+        ShotMap = definition.ShotMap is not null
+            ? new ShotMapViewModel(definition.ShotMap)
+            : null;
+
+        MedicalTimeline = definition.MedicalTimeline is not null
+            ? new MedicalTimelineViewModel(definition.MedicalTimeline)
+            : null;
+
+        ClubVisionRoadmap = definition.ClubVisionRoadmap is not null
+            ? new ClubVisionRoadmapViewModel(definition.ClubVisionRoadmap, clubDataService)
+            : null;
+
+        ClubVisionExpectations = definition.ClubVisionExpectations is not null
+            ? new ClubVisionExpectationBoardViewModel(definition.ClubVisionExpectations, clubDataService)
+            : null;
+
+        TimelineEntries = definition.Timeline is { Count: > 0 }
+            ? new ReadOnlyCollection<TimelineEntryViewModel>(CreateTimeline(definition.Timeline))
+            : System.Array.Empty<TimelineEntryViewModel>();
+        BeginDragCommand = new RelayCommand(_ => _interactionService.BeginDrag(this));
+        DragDeltaCommand = new RelayCommand(param =>
+        {
+            if (param is CardDragDelta delta)
+            {
+                _interactionService.UpdateDrag(this, delta);
+            }
+        });
+        CompleteDragCommand = new RelayCommand(param =>
+        {
+            var completed = param as CardDragCompleted ?? new CardDragCompleted(false);
+            _interactionService.CompleteDrag(this, completed);
+        });
+
+        BeginResizeCommand = new RelayCommand(param =>
+        {
+            if (param is ResizeHandle handle)
+            {
+                _interactionService.BeginResize(this, handle);
+            }
+        });
+
+        ResizeDeltaCommand = new RelayCommand(param =>
+        {
+            if (param is CardResizeDelta delta)
+            {
+                _interactionService.UpdateResize(this, delta);
+            }
+        });
+
+        CompleteResizeCommand = new RelayCommand(param =>
+        {
+            if (param is CardResizeCompleted completed)
+            {
+                _interactionService.CompleteResize(this, completed);
+            }
+        });
+
+        _openEditorCommand = new RelayCommand(
+            _ => _requestEditor?.Invoke(this),
+            _ => _isEditorAvailable && _requestEditor is not null);
+    }
+
+    public CardDefinition Definition => _definition;
+
+    public string Title => _definition.Title;
+
+    public string Id => _definition.Id;
+
+    public string? Subtitle => _definition.Subtitle;
+
+    public string? Description => _definition.Description;
+
+    public string? PillText => _definition.PillText;
+
+    public string? MetricValue => _definition.MetricValue;
+
+    public string? MetricLabel => _definition.MetricLabel;
+
+    public CardKind Kind => _definition.Kind;
+
+    public IReadOnlyList<CardListItemViewModel> ListItems { get; }
+
+    public IReadOnlyList<FormationLineViewModel> FormationLines { get; }
+
+    public IReadOnlyList<FormationPlayerViewModel> FormationPlayers { get; }
+
+    public IReadOnlyList<ChartSeriesViewModel> ChartSeries { get; }
+
+    public GaugeViewModel? Gauge { get; }
+
+    public FinanceForecastViewModel? Forecast { get; }
+
+    public FinanceCashflowViewModel? FinanceCashflow { get; }
+
+    public FinanceBudgetAllocatorViewModel? FinanceBudgetAllocator { get; }
+
+    public FinanceScenarioBoardViewModel? FinanceScenario { get; }
+
+    public SquadTableViewModel? SquadTable { get; }
+
+    public TrainingWorkloadHeatmapViewModel? WorkloadHeatmap { get; }
+
+    public MoraleHeatmapViewModel? MoraleHeatmap { get; }
+
+    public TrainingCalendarViewModel? TrainingCalendar { get; }
+
+    public FixtureCalendarViewModel? FixtureCalendar { get; }
+
+    public TransferNegotiationCardViewModel? Negotiations { get; }
+
+    public ScoutAssignmentBoardViewModel? ScoutAssignments { get; }
+
+    public ShortlistBoardViewModel? ShortlistBoard { get; }
+
+    public TrainingUnitBoardViewModel? TrainingUnitBoard { get; }
+
+    public TrainingProgressionViewModel? TrainingProgression { get; }
+
+    public ShotMapViewModel? ShotMap { get; }
+
+    public MedicalTimelineViewModel? MedicalTimeline { get; }
+
+    public ClubVisionRoadmapViewModel? ClubVisionRoadmap { get; }
+
+    public ClubVisionExpectationBoardViewModel? ClubVisionExpectations { get; }
+
+    public IReadOnlyList<TimelineEntryViewModel> TimelineEntries { get; }
+
+    public bool HasSubtitle => !string.IsNullOrWhiteSpace(Subtitle);
+
+    public bool HasDescription => !string.IsNullOrWhiteSpace(Description);
+
+    public bool HasPill => !string.IsNullOrWhiteSpace(PillText);
+
+    public bool HasMetric => !string.IsNullOrWhiteSpace(MetricValue);
+
+    public bool HasListItems => ListItems.Count > 0;
+
+    public bool HasFormation => FormationLines.Count > 0;
+
+    public bool HasFormationPlayers => FormationPlayers.Count > 0;
+
+    public bool HasChartSeries => ChartSeries.Count > 0;
+
+    public bool HasGauge => Gauge is not null;
+
+    public bool HasForecast => Forecast is not null;
+
+    public bool HasSquadTable => SquadTable is not null;
+
+    public bool HasWorkloadHeatmap => WorkloadHeatmap is not null;
+
+    public bool HasMoraleHeatmap => MoraleHeatmap is not null;
+
+    public bool HasTrainingCalendar => TrainingCalendar is not null;
+
+    public bool HasFixtureCalendar => FixtureCalendar is not null;
+
+    public bool HasNegotiations => Negotiations is not null && Negotiations.HasDeals;
+
+    public bool HasScoutAssignments => ScoutAssignments is not null;
+
+    public bool HasShortlistBoard => ShortlistBoard is not null;
+
+    public bool HasTrainingProgression => TrainingProgression is not null;
+
+    public bool HasShotMap => ShotMap is not null;
+
+    public bool HasMedicalTimeline => MedicalTimeline is not null && MedicalTimeline.HasEntries;
+
+    public bool HasTimeline => TimelineEntries.Count > 0;
+
+    public double Left => _metrics.CalculateLeft(_column);
+
+    public double Top => _metrics.CalculateTop(_row);
+
+    public double Width => _metrics.CalculateWidth(_columnSpan);
+
+    public double Height => _metrics.CalculateHeight(_rowSpan);
+
+    public CardSurfaceMetrics Metrics => _metrics;
+
+    public CardGeometry Geometry => new(_column, _row, _columnSpan, _rowSpan);
+
+    public bool IsCustom { get; }
+
+    public string? PresetId { get; }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        private set => SetProperty(ref _isVisible, value);
+    }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        private set => SetProperty(ref _isSelected, value);
+    }
+
+    public bool IsEditorAvailable
+    {
+        get => _isEditorAvailable;
+        private set
+        {
+            if (SetProperty(ref _isEditorAvailable, value))
+            {
+                _openEditorCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public ICommand BeginDragCommand { get; }
+
+    public ICommand DragDeltaCommand { get; }
+
+    public ICommand CompleteDragCommand { get; }
+
+    public ICommand BeginResizeCommand { get; }
+
+    public ICommand ResizeDeltaCommand { get; }
+
+    public ICommand CompleteResizeCommand { get; }
+
+    public ICommand OpenEditorCommand => _openEditorCommand;
+
+    public Rect GetBounds() => new(Left, Top, Width, Height);
+
+    internal void RequestSelection(SelectionModifier modifier)
+    {
+        _interactionService.SelectCard(this, modifier);
+    }
+
+    internal void ConfigureEditor(Action<CardViewModel>? requestEditor, bool isAvailable)
+    {
+        _requestEditor = requestEditor;
+        IsEditorAvailable = isAvailable && requestEditor is not null;
+    }
+
+    internal void UpdateGeometry(int column, int row, int columnSpan, int rowSpan)
+    {
+        if (_column != column)
+        {
+            _column = column;
+            OnPropertyChanged(nameof(Left));
+        }
+
+        if (_row != row)
+        {
+            _row = row;
+            OnPropertyChanged(nameof(Top));
+        }
+
+        if (_columnSpan != columnSpan)
+        {
+            _columnSpan = columnSpan;
+            OnPropertyChanged(nameof(Width));
+        }
+
+        if (_rowSpan != rowSpan)
+        {
+            _rowSpan = rowSpan;
+            OnPropertyChanged(nameof(Height));
+        }
+    }
+
+    internal void SetVisibility(bool visible)
+    {
+        IsVisible = visible;
+    }
+
+    internal void SetSelected(bool selected)
+    {
+        IsSelected = selected;
+    }
+
+    internal bool TryGetFormationPlayer(string playerId, out FormationPlayerViewModel player)
+        => _formationPlayerLookup.TryGetValue(playerId, out player!);
+
+    internal IReadOnlyList<FormationPlayerState> GetFormationPlayerStates()
+    {
+        if (!HasFormationPlayers)
+        {
+            return System.Array.Empty<FormationPlayerState>();
+        }
+
+        var states = new List<FormationPlayerState>(FormationPlayers.Count);
+        foreach (var player in FormationPlayers)
+        {
+            states.Add(new FormationPlayerState(player.Id, player.NormalizedX, player.NormalizedY));
+        }
+
+        return states;
+    }
+
+    internal void ApplyFormationState(IReadOnlyList<FormationPlayerState> states)
+    {
+        if (!HasFormationPlayers || states is null || states.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var state in states)
+        {
+            if (_formationPlayerLookup.TryGetValue(state.PlayerId, out var player))
+            {
+                player.UpdateNormalizedPosition(state.X, state.Y);
+            }
+        }
+    }
+
+    internal void UpdateFormationPlayer(string playerId, double normalizedX, double normalizedY)
+    {
+        if (_formationPlayerLookup.TryGetValue(playerId, out var player))
+        {
+            player.UpdateNormalizedPosition(normalizedX, normalizedY);
+        }
+    }
+
+    private static IList<CardListItemViewModel> CreateListItems(IReadOnlyList<CardListItem> items)
+    {
+        var list = new List<CardListItemViewModel>(items.Count);
+        foreach (var item in items)
+        {
+            list.Add(new CardListItemViewModel(item));
+        }
+
+        return list;
+    }
+
+    private static (ReadOnlyCollection<FormationLineViewModel> Lines, ReadOnlyCollection<FormationPlayerViewModel> Players) CreateFormationViewModels(
+        IReadOnlyList<FormationLineDefinition> definitions,
+        ICardInteractionService interactionService,
+        CardViewModel owner)
+    {
+        var allPlayers = new List<FormationPlayerViewModel>();
+        var lines = new List<FormationLineViewModel>(definitions.Count);
+
+        foreach (var definition in definitions)
+        {
+            var linePlayers = new List<FormationPlayerViewModel>();
+            foreach (var player in definition.Players)
+            {
+                var playerViewModel = new FormationPlayerViewModel(
+                    player.Id,
+                    player.Name,
+                    player.X,
+                    player.Y,
+                    interactionService,
+                    owner);
+                linePlayers.Add(playerViewModel);
+                allPlayers.Add(playerViewModel);
+                owner._formationPlayerLookup[player.Id] = playerViewModel;
+            }
+
+            lines.Add(new FormationLineViewModel(definition.Role, linePlayers));
+        }
+
+        return (
+            new ReadOnlyCollection<FormationLineViewModel>(lines),
+            new ReadOnlyCollection<FormationPlayerViewModel>(allPlayers));
+    }
+
+    private static IList<ChartSeriesViewModel> CreateChartSeries(IReadOnlyList<ChartSeriesDefinition> definitions)
+    {
+        var series = new List<ChartSeriesViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            series.Add(new ChartSeriesViewModel(definition));
+        }
+
+        return series;
+    }
+
+    private static IList<TimelineEntryViewModel> CreateTimeline(IReadOnlyList<TimelineEntryDefinition> definitions)
+    {
+        var entries = new List<TimelineEntryViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            entries.Add(new TimelineEntryViewModel(definition));
+        }
+
+        return entries;
+    }
+}
+
+internal static class BrushUtilities
+{
+    private static readonly BrushConverter Converter = new();
+
+    public static SolidColorBrush CreateFrozenBrush(string color, SolidColorBrush? fallback = null)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+        {
+            return fallback ?? Brushes.Transparent;
+        }
+
+        try
+        {
+            var brush = (SolidColorBrush)Converter.ConvertFromString(color)!;
+            if (!brush.IsFrozen)
+            {
+                brush.Freeze();
+            }
+
+            return brush;
+        }
+        catch
+        {
+            return fallback ?? Brushes.Transparent;
+        }
+    }
+}
+
+public sealed class ChartSeriesViewModel
+{
+    private readonly ChartSeriesDefinition _definition;
+
+    public ChartSeriesViewModel(ChartSeriesDefinition definition)
+    {
+        _definition = definition;
+        Points = new ReadOnlyCollection<ChartDataPointViewModel>(CreatePoints(definition.Points));
+        Stroke = BrushUtilities.CreateFrozenBrush(definition.Color, Brushes.DeepSkyBlue);
+    }
+
+    public string Name => _definition.Name;
+
+    public IReadOnlyList<ChartDataPointViewModel> Points { get; }
+
+    public Brush Stroke { get; }
+
+    public double Minimum => Points.Count == 0 ? 0 : Points.Min(p => p.Value);
+
+    public double Maximum => Points.Count == 0 ? 0 : Points.Max(p => p.Value);
+
+    private static IList<ChartDataPointViewModel> CreatePoints(IReadOnlyList<ChartDataPointDefinition> points)
+    {
+        var list = new List<ChartDataPointViewModel>(points.Count);
+        foreach (var point in points)
+        {
+            list.Add(new ChartDataPointViewModel(point));
+        }
+
+        return list;
+    }
+}
+
+public sealed class ChartDataPointViewModel
+{
+    private readonly ChartDataPointDefinition _definition;
+
+    public ChartDataPointViewModel(ChartDataPointDefinition definition)
+    {
+        _definition = definition;
+    }
+
+    public string Label => _definition.Label;
+
+    public double Value => _definition.Value;
+}
+
+public sealed class GaugeViewModel
+{
+    private readonly GaugeDefinition _definition;
+
+    public GaugeViewModel(GaugeDefinition definition)
+    {
+        _definition = definition;
+        Bands = new ReadOnlyCollection<GaugeBandViewModel>(CreateBands(definition.Bands));
+    }
+
+    public double Minimum => _definition.Minimum;
+
+    public double Maximum => _definition.Maximum;
+
+    public double Value => _definition.Value;
+
+    public double Target => _definition.Target;
+
+    public string Unit => _definition.Unit;
+
+    public IReadOnlyList<GaugeBandViewModel> Bands { get; }
+
+    public string DisplayValue => _definition.DisplayValue ?? $"{Value:0.#}{Unit}";
+
+    public string? DisplaySummary => _definition.DisplaySummary;
+
+    public string? DisplayPill => _definition.DisplayPill;
+
+    public bool HasDisplayPill => !string.IsNullOrWhiteSpace(DisplayPill);
+
+    private static IList<GaugeBandViewModel> CreateBands(IReadOnlyList<GaugeBandDefinition> bands)
+    {
+        var list = new List<GaugeBandViewModel>(bands.Count);
+        foreach (var band in bands)
+        {
+            list.Add(new GaugeBandViewModel(band));
+        }
+
+        return list;
+    }
+}
+
+public sealed class GaugeBandViewModel
+{
+    private readonly GaugeBandDefinition _definition;
+
+    public GaugeBandViewModel(GaugeBandDefinition definition)
+    {
+        _definition = definition;
+        Brush = BrushUtilities.CreateFrozenBrush(definition.Color, Brushes.Gray);
+    }
+
+    public string Label => _definition.Label;
+
+    public double Start => _definition.Start;
+
+    public double End => _definition.End;
+
+    public Brush Brush { get; }
+}
+
+public sealed class TimelineEntryViewModel
+{
+    private readonly TimelineEntryDefinition _definition;
+
+    public TimelineEntryViewModel(TimelineEntryDefinition definition)
+    {
+        _definition = definition;
+    }
+
+    public string Label => _definition.Label;
+
+    public string? Detail => _definition.Detail;
+
+    public double Position => _definition.Position;
+
+    public string? Pill => _definition.Pill;
+
+    public string? Accent => _definition.Accent;
+
+    public bool HasDetail => !string.IsNullOrWhiteSpace(Detail);
+
+    public bool HasPill => !string.IsNullOrWhiteSpace(Pill);
+
+    public Brush? AccentBrush => string.IsNullOrWhiteSpace(Accent)
+        ? null
+        : BrushUtilities.CreateFrozenBrush(Accent!, Brushes.SlateBlue);
+}
+
+public sealed class SquadTableViewModel : ObservableObject
+{
+    private const string AllFilter = "All";
+
+    private readonly ObservableCollection<SquadPlayerRowViewModel> _players;
+    private readonly ListCollectionView _view;
+    private readonly RelayCommand _clearFiltersCommand;
+    private readonly RelayCommand _compareCommand;
+    private readonly RelayCommand _clearSelectionCommand;
+    private readonly RelayCommand _dismissComparisonCommand;
+    private readonly ReadOnlyCollection<string> _positionFilters;
+    private readonly ReadOnlyCollection<string> _roleFilters;
+    private string _selectedPositionFilter = AllFilter;
+    private string _selectedRoleFilter = AllFilter;
+    private string? _searchText;
+    private int _selectedCount;
+    private bool _hasComparison;
+    private string? _comparisonSummary;
+    private IReadOnlyList<string> _comparisonPlayers = Array.Empty<string>();
+    private IReadOnlyList<SquadComparisonMetricViewModel> _comparisonMetrics = Array.Empty<SquadComparisonMetricViewModel>();
+
+    public SquadTableViewModel(SquadTableDefinition definition)
+    {
+        _players = new ObservableCollection<SquadPlayerRowViewModel>(CreatePlayers(definition.Players));
+        foreach (var player in _players)
+        {
+            player.PropertyChanged += OnPlayerPropertyChanged;
+        }
+
+        _view = (ListCollectionView)CollectionViewSource.GetDefaultView(_players);
+        _view.Filter = FilterPlayer;
+        _view.SortDescriptions.Add(new SortDescription(nameof(SquadPlayerRowViewModel.AverageRating), ListSortDirection.Descending));
+
+        _positionFilters = new ReadOnlyCollection<string>(BuildFilterList(definition.Players.Select(p => p.PositionGroup)));
+        _roleFilters = new ReadOnlyCollection<string>(BuildFilterList(definition.Players.Select(p => p.Role)));
+
+        PositionFilters = _positionFilters;
+        RoleFilters = _roleFilters;
+
+        _clearFiltersCommand = new RelayCommand(ClearFilters);
+        _compareCommand = new RelayCommand(ExecuteCompare, () => SelectedCount >= 2);
+        _clearSelectionCommand = new RelayCommand(ClearSelection, () => SelectedCount > 0);
+        _dismissComparisonCommand = new RelayCommand(() => HasComparison = false);
+    }
+
+    public ICollectionView PlayersView => _view;
+
+    public IReadOnlyList<string> PositionFilters { get; }
+
+    public IReadOnlyList<string> RoleFilters { get; }
+
+    public string SelectedPositionFilter
+    {
+        get => _selectedPositionFilter;
+        set
+        {
+            if (SetProperty(ref _selectedPositionFilter, NormalizeFilter(value)))
+            {
+                RefreshFilters();
+            }
+        }
+    }
+
+    public string SelectedRoleFilter
+    {
+        get => _selectedRoleFilter;
+        set
+        {
+            if (SetProperty(ref _selectedRoleFilter, NormalizeFilter(value)))
+            {
+                RefreshFilters();
+            }
+        }
+    }
+
+    public string? SearchText
+    {
+        get => _searchText;
+        set
+        {
+            if (SetProperty(ref _searchText, value))
+            {
+                RefreshFilters();
+            }
+        }
+    }
+
+    public int SelectedCount
+    {
+        get => _selectedCount;
+        private set
+        {
+            if (SetProperty(ref _selectedCount, value))
+            {
+                _compareCommand.RaiseCanExecuteChanged();
+                _clearSelectionCommand.RaiseCanExecuteChanged();
+
+                if (value < 2 && HasComparison)
+                {
+                    HasComparison = false;
+                }
+            }
+        }
+    }
+
+    public bool HasComparison
+    {
+        get => _hasComparison;
+        private set
+        {
+            if (SetProperty(ref _hasComparison, value) && !value)
+            {
+                ComparisonSummary = null;
+                ComparisonPlayers = Array.Empty<string>();
+                ComparisonMetrics = Array.Empty<SquadComparisonMetricViewModel>();
+            }
+        }
+    }
+
+    public string? ComparisonSummary
+    {
+        get => _comparisonSummary;
+        private set => SetProperty(ref _comparisonSummary, value);
+    }
+
+    public IReadOnlyList<string> ComparisonPlayers
+    {
+        get => _comparisonPlayers;
+        private set
+        {
+            if (SetProperty(ref _comparisonPlayers, value))
+            {
+                OnPropertyChanged(nameof(ComparisonPlayersDisplay));
+            }
+        }
+    }
+
+    public string ComparisonPlayersDisplay => _comparisonPlayers.Count == 0
+        ? string.Empty
+        : string.Join(" • ", _comparisonPlayers);
+
+    public IReadOnlyList<SquadComparisonMetricViewModel> ComparisonMetrics
+    {
+        get => _comparisonMetrics;
+        private set => SetProperty(ref _comparisonMetrics, value);
+    }
+
+    public ICommand ClearFiltersCommand => _clearFiltersCommand;
+
+    public ICommand CompareCommand => _compareCommand;
+
+    public ICommand ClearSelectionCommand => _clearSelectionCommand;
+
+    public ICommand DismissComparisonCommand => _dismissComparisonCommand;
+
+    private void ClearFilters()
+    {
+        SelectedPositionFilter = AllFilter;
+        SelectedRoleFilter = AllFilter;
+        SearchText = string.Empty;
+    }
+
+    private void ClearSelection()
+    {
+        foreach (var player in _players)
+        {
+            player.IsSelected = false;
+        }
+    }
+
+    private void ExecuteCompare()
+    {
+        var selected = _players.Where(p => p.IsSelected).ToList();
+        if (selected.Count < 2)
+        {
+            HasComparison = false;
+            return;
+        }
+
+        var metrics = new List<SquadComparisonMetricViewModel>
+        {
+            SquadComparisonMetricViewModel.Create("Average Rating", selected, p => p.AverageRating, "0.00"),
+            SquadComparisonMetricViewModel.Create("Condition", selected, p => p.ConditionPercentage, "0", "%"),
+            SquadComparisonMetricViewModel.Create("Sharpness", selected, p => p.MatchSharpnessPercentage, "0", "%"),
+            SquadComparisonMetricViewModel.Create("Minutes", selected, p => p.Minutes, "0", " min")
+        };
+
+        ComparisonMetrics = new ReadOnlyCollection<SquadComparisonMetricViewModel>(metrics);
+        ComparisonPlayers = new ReadOnlyCollection<string>(selected.Select(p => p.Name).ToList());
+        ComparisonSummary = selected.Count == 2
+            ? $"{selected[0].Name} vs {selected[1].Name}"
+            : $"Comparing {selected.Count} players";
+        HasComparison = true;
+    }
+
+    private void RefreshFilters()
+    {
+        _view.Refresh();
+    }
+
+    private void OnPlayerPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SquadPlayerRowViewModel.IsSelected))
+        {
+            SelectedCount = _players.Count(player => player.IsSelected);
+        }
+    }
+
+    private bool FilterPlayer(object? item)
+    {
+        if (item is not SquadPlayerRowViewModel player)
+        {
+            return false;
+        }
+
+        if (!string.Equals(_selectedPositionFilter, AllFilter, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(player.PositionGroup, _selectedPositionFilter, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.Equals(_selectedRoleFilter, AllFilter, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(player.Role, _selectedRoleFilter, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_searchText))
+        {
+            return true;
+        }
+
+        var comparison = _searchText.Trim();
+        if (comparison.Length == 0)
+        {
+            return true;
+        }
+
+        return player.Name.Contains(comparison, StringComparison.OrdinalIgnoreCase)
+            || player.Position.Contains(comparison, StringComparison.OrdinalIgnoreCase)
+            || player.Role.Contains(comparison, StringComparison.OrdinalIgnoreCase)
+            || (!string.IsNullOrWhiteSpace(player.Nationality) &&
+                player.Nationality.Contains(comparison, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizeFilter(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? AllFilter : value;
+    }
+
+    private static List<SquadPlayerRowViewModel> CreatePlayers(IReadOnlyList<SquadPlayerDefinition> definitions)
+    {
+        if (definitions is null || definitions.Count == 0)
+        {
+            return new List<SquadPlayerRowViewModel>();
+        }
+
+        var players = new List<SquadPlayerRowViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            players.Add(new SquadPlayerRowViewModel(definition));
+        }
+
+        return players;
+    }
+
+    private static List<string> BuildFilterList(IEnumerable<string> source)
+    {
+        var list = new List<string> { AllFilter };
+        if (source is not null)
+        {
+            foreach (var value in source
+                .Where(static v => !string.IsNullOrWhiteSpace(v))
+                .Select(static v => v.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(static v => v, StringComparer.OrdinalIgnoreCase))
+            {
+                list.Add(value);
+            }
+        }
+
+        return list;
+    }
+}
+
+public sealed class SquadPlayerRowViewModel : ObservableObject
+{
+    private bool _isSelected;
+
+    public SquadPlayerRowViewModel(SquadPlayerDefinition definition)
+    {
+        Id = definition.Id;
+        Name = definition.Name;
+        PositionGroup = definition.PositionGroup;
+        Position = definition.Position;
+        Role = definition.Role;
+        Morale = definition.Morale;
+        Condition = definition.Condition;
+        MatchSharpness = definition.MatchSharpness;
+        AverageRating = definition.AverageRating;
+        Appearances = definition.Appearances;
+        Minutes = definition.Minutes;
+        Nationality = definition.Nationality;
+        Status = definition.Status;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string PositionGroup { get; }
+
+    public string Position { get; }
+
+    public string Role { get; }
+
+    public string Morale { get; }
+
+    public double Condition { get; }
+
+    public double MatchSharpness { get; }
+
+    public double AverageRating { get; }
+
+    public int Appearances { get; }
+
+    public int Minutes { get; }
+
+    public string? Nationality { get; }
+
+    public string? Status { get; }
+
+    public bool HasStatus => !string.IsNullOrWhiteSpace(Status);
+
+    public double ConditionPercentage => Condition * 100.0;
+
+    public double MatchSharpnessPercentage => MatchSharpness * 100.0;
+
+    public string ConditionDisplay => Condition.ToString("P0", CultureInfo.InvariantCulture);
+
+    public string MatchSharpnessDisplay => MatchSharpness.ToString("P0", CultureInfo.InvariantCulture);
+
+    public string AverageRatingDisplay => AverageRating.ToString("0.00", CultureInfo.InvariantCulture);
+
+    public string AppearancesDisplay => Appearances.ToString("N0", CultureInfo.InvariantCulture);
+
+    public string MinutesDisplay => Minutes.ToString("N0", CultureInfo.InvariantCulture);
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+}
+
+public sealed class SquadComparisonMetricViewModel
+{
+    public SquadComparisonMetricViewModel(string metric, string leaderName, string leaderValue, bool isTie)
+    {
+        Metric = metric;
+        LeaderName = leaderName;
+        LeaderValue = leaderValue;
+        IsTie = isTie;
+    }
+
+    public string Metric { get; }
+
+    public string LeaderName { get; }
+
+    public string LeaderValue { get; }
+
+    public bool IsTie { get; }
+
+    public string? TieBadge => IsTie ? "Tied" : null;
+
+    public static SquadComparisonMetricViewModel Create(
+        string metric,
+        IReadOnlyList<SquadPlayerRowViewModel> players,
+        Func<SquadPlayerRowViewModel, double> selector,
+        string format,
+        string? suffix = null)
+    {
+        if (players is null || players.Count == 0)
+        {
+            return new SquadComparisonMetricViewModel(metric, "—", "—", false);
+        }
+
+        var max = players.Max(selector);
+        var tolerance = Math.Abs(max) < 0.0001 ? 0.0005 : Math.Max(Math.Abs(max) * 0.0005, 0.0005);
+        var leaders = players
+            .Where(player => Math.Abs(selector(player) - max) <= tolerance)
+            .Select(player => player.Name)
+            .ToList();
+
+        var formatted = max.ToString(format, CultureInfo.InvariantCulture);
+        if (!string.IsNullOrWhiteSpace(suffix))
+        {
+            formatted += suffix;
+        }
+
+        var leaderName = string.Join(" • ", leaders);
+        return new SquadComparisonMetricViewModel(metric, leaderName, formatted, leaders.Count > 1);
+    }
+}
+
+public sealed class ScoutAssignmentBoardViewModel
+{
+    public ScoutAssignmentBoardViewModel(ScoutAssignmentBoardDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Assignments = new ReadOnlyCollection<ScoutAssignmentRowViewModel>(
+            definition.Assignments?.Select(static assignment => new ScoutAssignmentRowViewModel(assignment)).ToList()
+            ?? new List<ScoutAssignmentRowViewModel>());
+
+        StageOptions = new ReadOnlyCollection<string>(
+            definition.StageOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>());
+
+        PriorityOptions = new ReadOnlyCollection<string>(
+            definition.PriorityOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>());
+
+        ScoutOptions = new ReadOnlyCollection<ScoutOptionViewModel>(
+            definition.ScoutOptions?.Select(static option => new ScoutOptionViewModel(option)).ToList()
+            ?? new List<ScoutOptionViewModel>());
+
+        TotalAssignments = Assignments.Count;
+        HighPriorityAssignments = Assignments.Count(static assignment => assignment.IsHighPriority);
+        AwaitingReportAssignments = Assignments.Count(static assignment => assignment.IsAwaitingReport);
+    }
+
+    public IReadOnlyList<ScoutAssignmentRowViewModel> Assignments { get; }
+
+    public IReadOnlyList<string> StageOptions { get; }
+
+    public IReadOnlyList<string> PriorityOptions { get; }
+
+    public IReadOnlyList<ScoutOptionViewModel> ScoutOptions { get; }
+
+    public int TotalAssignments { get; }
+
+    public int HighPriorityAssignments { get; }
+
+    public int AwaitingReportAssignments { get; }
+
+    public bool HasAssignments => Assignments.Count > 0;
+}
+
+public sealed class ScoutAssignmentRowViewModel
+{
+    private readonly ScoutAssignmentDefinition _definition;
+
+    public ScoutAssignmentRowViewModel(ScoutAssignmentDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        PriorityBrush = CreatePriorityBrush(definition.Priority);
+        StageBrush = CreateStageBrush(definition.Stage);
+    }
+
+    public string Id => _definition.Id;
+
+    public string Focus => _definition.Focus;
+
+    public string Role => _definition.Role;
+
+    public string Region => _definition.Region;
+
+    public string Priority => _definition.Priority;
+
+    public string Stage => _definition.Stage;
+
+    public string Deadline => _definition.Deadline;
+
+    public string Scout => _definition.Scout;
+
+    public string? Notes => _definition.Notes;
+
+    public bool HasNotes => !string.IsNullOrWhiteSpace(Notes);
+
+    public Brush PriorityBrush { get; }
+
+    public Brush StageBrush { get; }
+
+    public bool IsHighPriority => string.Equals(Priority, "High", StringComparison.OrdinalIgnoreCase);
+
+    public bool IsAwaitingReport => string.Equals(Stage, "Awaiting Report", StringComparison.OrdinalIgnoreCase);
+
+    private static Brush CreatePriorityBrush(string priority)
+    {
+        if (string.Equals(priority, "High", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FFE05D5D", Brushes.IndianRed);
+        }
+
+        if (string.Equals(priority, "Medium", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF3AA0FF", Brushes.SteelBlue);
+        }
+
+        if (string.Equals(priority, "Low", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF2EC4B6", Brushes.CadetBlue);
+        }
+
+        return BrushUtilities.CreateFrozenBrush("#FF2B3545", Brushes.DimGray);
+    }
+
+    private static Brush CreateStageBrush(string stage)
+    {
+        if (string.Equals(stage, "New", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF2EC4B6", Brushes.Teal);
+        }
+
+        if (string.Equals(stage, "In Progress", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF3AA0FF", Brushes.DodgerBlue);
+        }
+
+        if (string.Equals(stage, "Awaiting Report", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FFE4B123", Brushes.Goldenrod);
+        }
+
+        if (string.Equals(stage, "Complete", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF4CE577", Brushes.SeaGreen);
+        }
+
+        return BrushUtilities.CreateFrozenBrush("#FF2B3545", Brushes.SlateGray);
+    }
+}
+
+public sealed class ScoutOptionViewModel
+{
+    private readonly ScoutOptionDefinition _definition;
+
+    public ScoutOptionViewModel(ScoutOptionDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+    }
+
+    public string Id => _definition.Id;
+
+    public string Name => _definition.Name;
+
+    public string Region => _definition.Region;
+
+    public string Availability => _definition.Availability;
+
+    public string Display => string.IsNullOrWhiteSpace(Availability)
+        ? $"{Name} • {Region}"
+        : $"{Name} • {Region} ({Availability})";
+}
+
+public sealed class ShortlistBoardViewModel
+{
+    public ShortlistBoardViewModel(ShortlistBoardDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Players = new ReadOnlyCollection<ShortlistPlayerRowViewModel>(
+            definition.Players?.Select(static player => new ShortlistPlayerRowViewModel(player)).ToList()
+            ?? new List<ShortlistPlayerRowViewModel>());
+
+        StatusOptions = new ReadOnlyCollection<string>(
+            definition.StatusOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>());
+
+        ActionOptions = new ReadOnlyCollection<string>(
+            definition.ActionOptions?.Where(static option => !string.IsNullOrWhiteSpace(option)).ToList()
+            ?? new List<string>());
+
+        MakeOfferCount = Players.Count(static player => player.IsMakeOffer);
+        ScoutFollowUpCount = Players.Count(static player => player.RequiresScoutFollowUp);
+        PriorityTargetCount = Players.Count(static player => player.IsPriorityTarget);
+    }
+
+    public IReadOnlyList<ShortlistPlayerRowViewModel> Players { get; }
+
+    public IReadOnlyList<string> StatusOptions { get; }
+
+    public IReadOnlyList<string> ActionOptions { get; }
+
+    public int MakeOfferCount { get; }
+
+    public int ScoutFollowUpCount { get; }
+
+    public int PriorityTargetCount { get; }
+
+    public bool HasPlayers => Players.Count > 0;
+}
+
+public sealed class ShortlistPlayerRowViewModel
+{
+    private readonly ShortlistPlayerDefinition _definition;
+
+    public ShortlistPlayerRowViewModel(ShortlistPlayerDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        StatusBrush = CreateStatusBrush(definition.Status);
+        ActionBrush = CreateActionBrush(definition.Action);
+    }
+
+    public string Id => _definition.Id;
+
+    public string Name => _definition.Name;
+
+    public string Position => _definition.Position;
+
+    public string Status => _definition.Status;
+
+    public string Action => _definition.Action;
+
+    public string? Priority => _definition.Priority;
+
+    public string? Notes => _definition.Notes;
+
+    public bool HasPriority => !string.IsNullOrWhiteSpace(Priority);
+
+    public bool HasNotes => !string.IsNullOrWhiteSpace(Notes);
+
+    public Brush StatusBrush { get; }
+
+    public Brush ActionBrush { get; }
+
+    public bool IsMakeOffer => string.Equals(Status, "Make Offer", StringComparison.OrdinalIgnoreCase);
+
+    public bool RequiresScoutFollowUp => string.Equals(Action, "Assign Scout", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(Status, "Scout", StringComparison.OrdinalIgnoreCase);
+
+    public bool IsPriorityTarget => string.Equals(Priority, "Priority", StringComparison.OrdinalIgnoreCase);
+
+    private static Brush CreateStatusBrush(string status)
+    {
+        if (string.Equals(status, "Make Offer", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF2EC4B6", Brushes.Teal);
+        }
+
+        if (string.Equals(status, "Monitor", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF3AA0FF", Brushes.SteelBlue);
+        }
+
+        if (string.Equals(status, "Scout", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FFE4B123", Brushes.DarkGoldenrod);
+        }
+
+        if (string.Equals(status, "No Action", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF2B3545", Brushes.Gray);
+        }
+
+        return BrushUtilities.CreateFrozenBrush("#FF2B3545", Brushes.DimGray);
+    }
+
+    private static Brush CreateActionBrush(string action)
+    {
+        if (string.Equals(action, "Advance", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF4CE577", Brushes.SeaGreen);
+        }
+
+        if (string.Equals(action, "Assign Scout", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FF3AA0FF", Brushes.DodgerBlue);
+        }
+
+        if (string.Equals(action, "Hold", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FFE4B123", Brushes.DarkGoldenrod);
+        }
+
+        if (string.Equals(action, "Remove", StringComparison.OrdinalIgnoreCase))
+        {
+            return BrushUtilities.CreateFrozenBrush("#FFE05D5D", Brushes.IndianRed);
+        }
+
+        return BrushUtilities.CreateFrozenBrush("#FF2B3545", Brushes.DimGray);
+    }
+}
+
+public sealed class MoraleHeatmapViewModel
+{
+    public MoraleHeatmapViewModel(MoraleHeatmapDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        var columns = definition.Columns?.ToList() ?? new List<string>();
+        var columnSet = new HashSet<string>(columns, StringComparer.OrdinalIgnoreCase);
+
+        if (definition.Rows is { Count: > 0 })
+        {
+            foreach (var row in definition.Rows)
+            {
+                if (row.Cells is { Count: > 0 })
+                {
+                    foreach (var cell in row.Cells)
+                    {
+                        if (!string.IsNullOrWhiteSpace(cell.Column) && columnSet.Add(cell.Column))
+                        {
+                            columns.Add(cell.Column);
+                        }
+                    }
+                }
+            }
+        }
+
+        Columns = new ReadOnlyCollection<string>(columns);
+
+        var intensities = new Dictionary<string, MoraleIntensityViewModel>(StringComparer.OrdinalIgnoreCase);
+        if (definition.Intensities is { Count: > 0 })
+        {
+            foreach (var intensity in definition.Intensities)
+            {
+                intensities[intensity.Key] = new MoraleIntensityViewModel(intensity);
+            }
+        }
+
+        Intensities = new ReadOnlyCollection<MoraleIntensityViewModel>(intensities.Values.ToList());
+
+        if (definition.Rows is { Count: > 0 })
+        {
+            var rows = new List<MoraleHeatmapRowViewModel>(definition.Rows.Count);
+            foreach (var row in definition.Rows)
+            {
+                rows.Add(new MoraleHeatmapRowViewModel(row, Columns, intensities));
+            }
+
+            Rows = new ReadOnlyCollection<MoraleHeatmapRowViewModel>(rows);
+        }
+        else
+        {
+            Rows = Array.Empty<MoraleHeatmapRowViewModel>();
+        }
+
+        LegendTitle = definition.LegendTitle;
+        LegendSubtitle = definition.LegendSubtitle;
+    }
+
+    public IReadOnlyList<string> Columns { get; }
+
+    public IReadOnlyList<MoraleHeatmapRowViewModel> Rows { get; }
+
+    public IReadOnlyList<MoraleIntensityViewModel> Intensities { get; }
+
+    public string? LegendTitle { get; }
+
+    public string? LegendSubtitle { get; }
+
+    public bool HasLegendTitle => !string.IsNullOrWhiteSpace(LegendTitle);
+
+    public bool HasLegendSubtitle => !string.IsNullOrWhiteSpace(LegendSubtitle);
+
+    public bool HasLegend => Intensities.Count > 0;
+}
+
+public sealed class MoraleHeatmapRowViewModel
+{
+    public MoraleHeatmapRowViewModel(
+        MoraleHeatmapRowDefinition definition,
+        IReadOnlyList<string> columns,
+        IReadOnlyDictionary<string, MoraleIntensityViewModel> intensities)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Label = definition.Label;
+
+        var cells = new List<MoraleHeatmapCellViewModel>(columns.Count);
+        var lookup = definition.Cells?.ToDictionary(cell => cell.Column, StringComparer.OrdinalIgnoreCase)
+                     ?? new Dictionary<string, MoraleHeatmapCellDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var column in columns)
+        {
+            lookup.TryGetValue(column, out var cell);
+            cells.Add(new MoraleHeatmapCellViewModel(column, cell, intensities));
+        }
+
+        Cells = new ReadOnlyCollection<MoraleHeatmapCellViewModel>(cells);
+    }
+
+    public string Label { get; }
+
+    public IReadOnlyList<MoraleHeatmapCellViewModel> Cells { get; }
+}
+
+public sealed class MoraleHeatmapCellViewModel
+{
+    private readonly MoraleHeatmapCellDefinition? _definition;
+    private readonly MoraleIntensityViewModel? _intensity;
+
+    public MoraleHeatmapCellViewModel(
+        string column,
+        MoraleHeatmapCellDefinition? definition,
+        IReadOnlyDictionary<string, MoraleIntensityViewModel> intensities)
+    {
+        Column = column;
+        _definition = definition;
+
+        if (definition is not null && intensities.TryGetValue(definition.IntensityKey, out var intensity))
+        {
+            _intensity = intensity;
+        }
+    }
+
+    public string Column { get; }
+
+    public string DisplayLabel => string.IsNullOrWhiteSpace(_definition?.Label) ? "—" : _definition!.Label;
+
+    public string IntensityDisplay => _intensity?.DisplayName ?? "Unassigned";
+
+    public string? Detail => _definition?.Detail;
+
+    public bool HasDetail => !string.IsNullOrWhiteSpace(Detail);
+
+    public Brush BackgroundBrush => _intensity?.Brush ?? BrushUtilities.CreateFrozenBrush("#1A2534", Brushes.DimGray);
+
+    public string Tooltip
+    {
+        get
+        {
+            if (_definition is null)
+            {
+                return $"{Column}: No morale data";
+            }
+
+            var detail = string.IsNullOrWhiteSpace(_definition.Detail) ? string.Empty : $"\n{_definition.Detail}";
+            var descriptor = _intensity?.Description;
+            var descriptorText = string.IsNullOrWhiteSpace(descriptor) ? string.Empty : $"\n{descriptor}";
+            return $"{_definition.Label} — {IntensityDisplay}{detail}{descriptorText}";
+        }
+    }
+}
+
+public sealed class MoraleIntensityViewModel
+{
+    private readonly MoraleIntensityDefinition _definition;
+
+    public MoraleIntensityViewModel(MoraleIntensityDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        Brush = BrushUtilities.CreateFrozenBrush(definition.Color, Brushes.SlateBlue);
+    }
+
+    public string Key => _definition.Key;
+
+    public string DisplayName => _definition.DisplayName;
+
+    public string? Description => _definition.Description;
+
+    public Brush Brush { get; }
+}
+
+public sealed class TrainingWorkloadHeatmapViewModel
+{
+    public TrainingWorkloadHeatmapViewModel(TrainingWorkloadHeatmapDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Columns = new ReadOnlyCollection<string>(definition.Columns?.ToList() ?? new List<string>());
+
+        var intensities = new Dictionary<string, TrainingIntensityLevelViewModel>(StringComparer.OrdinalIgnoreCase);
+        if (definition.Intensities is not null)
+        {
+            foreach (var intensity in definition.Intensities)
+            {
+                intensities[intensity.Key] = new TrainingIntensityLevelViewModel(intensity);
+            }
+        }
+
+        Intensities = new ReadOnlyCollection<TrainingIntensityLevelViewModel>(intensities.Values.ToList());
+
+        if (definition.Rows is not null)
+        {
+            var rows = new List<TrainingWorkloadHeatmapRowViewModel>(definition.Rows.Count);
+            foreach (var row in definition.Rows)
+            {
+                rows.Add(new TrainingWorkloadHeatmapRowViewModel(row, Columns, intensities));
+            }
+
+            Rows = new ReadOnlyCollection<TrainingWorkloadHeatmapRowViewModel>(rows);
+        }
+        else
+        {
+            Rows = Array.Empty<TrainingWorkloadHeatmapRowViewModel>();
+        }
+
+        LegendTitle = definition.LegendTitle;
+        LegendSubtitle = definition.LegendSubtitle;
+    }
+
+    public IReadOnlyList<string> Columns { get; }
+
+    public IReadOnlyList<TrainingWorkloadHeatmapRowViewModel> Rows { get; }
+
+    public IReadOnlyList<TrainingIntensityLevelViewModel> Intensities { get; }
+
+    public string? LegendTitle { get; }
+
+    public string? LegendSubtitle { get; }
+
+    public bool HasLegendTitle => !string.IsNullOrWhiteSpace(LegendTitle);
+
+    public bool HasLegendSubtitle => !string.IsNullOrWhiteSpace(LegendSubtitle);
+
+    public bool HasLegend => Intensities.Count > 0;
+}
+
+public sealed class TrainingWorkloadHeatmapRowViewModel
+{
+    public TrainingWorkloadHeatmapRowViewModel(
+        TrainingWorkloadRowDefinition definition,
+        IReadOnlyList<string> columns,
+        IReadOnlyDictionary<string, TrainingIntensityLevelViewModel> intensities)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Label = definition.Label;
+
+        var cells = new List<TrainingWorkloadHeatmapCellViewModel>(columns.Count);
+        var lookup = definition.Cells?.ToDictionary(cell => cell.Column, StringComparer.OrdinalIgnoreCase)
+                     ?? new Dictionary<string, TrainingWorkloadCellDefinition>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var column in columns)
+        {
+            lookup.TryGetValue(column, out var cell);
+            cells.Add(new TrainingWorkloadHeatmapCellViewModel(column, cell, intensities));
+        }
+
+        Cells = new ReadOnlyCollection<TrainingWorkloadHeatmapCellViewModel>(cells);
+    }
+
+    public string Label { get; }
+
+    public IReadOnlyList<TrainingWorkloadHeatmapCellViewModel> Cells { get; }
+}
+
+public sealed class TrainingWorkloadHeatmapCellViewModel
+{
+    private readonly TrainingWorkloadCellDefinition? _definition;
+    private readonly TrainingIntensityLevelViewModel? _intensity;
+
+    public TrainingWorkloadHeatmapCellViewModel(
+        string column,
+        TrainingWorkloadCellDefinition? definition,
+        IReadOnlyDictionary<string, TrainingIntensityLevelViewModel> intensities)
+    {
+        Column = column;
+        _definition = definition;
+
+        if (definition is not null && intensities.TryGetValue(definition.IntensityKey, out var intensity))
+        {
+            _intensity = intensity;
+        }
+    }
+
+    public string Column { get; }
+
+    public double Load => _definition?.Load ?? 0;
+
+    public string DisplayLoad => Load.Equals(0) ? "0" : Load.ToString("0.#");
+
+    public string IntensityDisplay => _intensity?.DisplayName ?? "Unassigned";
+
+    public Brush BackgroundBrush => _intensity?.Brush ?? BrushUtilities.CreateFrozenBrush("#1A2534", Brushes.DimGray);
+
+    public string Tooltip => _definition is null
+        ? $"{Column}: No session load configured"
+        : string.IsNullOrWhiteSpace(_definition.Detail)
+            ? $"{Column}: {IntensityDisplay} ({DisplayLoad})"
+            : $"{Column}: {IntensityDisplay} ({DisplayLoad})\n{_definition.Detail}";
+}
+
+public sealed class TrainingIntensityLevelViewModel
+{
+    private readonly TrainingIntensityLevelDefinition _definition;
+
+    public TrainingIntensityLevelViewModel(TrainingIntensityLevelDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        Brush = BrushUtilities.CreateFrozenBrush(definition.Color, Brushes.SlateBlue);
+    }
+
+    public string Key => _definition.Key;
+
+    public string DisplayName => _definition.DisplayName;
+
+    public Brush Brush { get; }
+
+    public double LoadValue => _definition.LoadValue;
+}
+
+public sealed class CardListItemViewModel
+{
+    private readonly CardListItem _model;
+
+    public CardListItemViewModel(CardListItem model)
+    {
+        _model = model;
+    }
+
+    public string Primary => _model.Primary;
+
+    public string? Secondary => _model.Secondary;
+
+    public string? Tertiary => _model.Tertiary;
+
+    public string? Accent => _model.Accent;
+
+    public bool HasSecondary => !string.IsNullOrWhiteSpace(Secondary);
+
+    public bool HasTertiary => !string.IsNullOrWhiteSpace(Tertiary);
+
+    public bool HasAccent => !string.IsNullOrWhiteSpace(Accent);
+}
+
+public sealed class FormationLineViewModel
+{
+    public FormationLineViewModel(string role, IReadOnlyList<FormationPlayerViewModel> players)
+    {
+        Role = role;
+        Players = new ReadOnlyCollection<FormationPlayerViewModel>(new List<FormationPlayerViewModel>(players));
+    }
+
+    public string Role { get; }
+
+    public IReadOnlyList<FormationPlayerViewModel> Players { get; }
+}
+
+public sealed class FormationPlayerViewModel : ObservableObject
+{
+    private readonly ICardInteractionService _interactionService;
+    private readonly CardViewModel _owner;
+    private double _normalizedX;
+    private double _normalizedY;
+
+    public FormationPlayerViewModel(
+        string id,
+        string name,
+        double normalizedX,
+        double normalizedY,
+        ICardInteractionService interactionService,
+        CardViewModel owner)
+    {
+        Id = id;
+        Name = name;
+        _normalizedX = normalizedX;
+        _normalizedY = normalizedY;
+        _interactionService = interactionService;
+        _owner = owner;
+
+        BeginDragCommand = new RelayCommand(_ => _interactionService.BeginPlayerDrag(_owner, this));
+        DragDeltaCommand = new RelayCommand(parameter =>
+        {
+            if (parameter is FormationPlayerDragDelta delta)
+            {
+                _interactionService.UpdatePlayerDrag(_owner, this, delta);
+            }
+        });
+        CompleteDragCommand = new RelayCommand(parameter =>
+        {
+            var completed = parameter as FormationPlayerDragCompleted ?? new FormationPlayerDragCompleted(false);
+            _interactionService.CompletePlayerDrag(_owner, this, completed);
+        });
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public double NormalizedX
+    {
+        get => _normalizedX;
+        private set => SetProperty(ref _normalizedX, value);
+    }
+
+    public double NormalizedY
+    {
+        get => _normalizedY;
+        private set => SetProperty(ref _normalizedY, value);
+    }
+
+    public ICommand BeginDragCommand { get; }
+
+    public ICommand DragDeltaCommand { get; }
+
+    public ICommand CompleteDragCommand { get; }
+
+    internal void UpdateNormalizedPosition(double normalizedX, double normalizedY)
+    {
+        NormalizedX = normalizedX;
+        NormalizedY = normalizedY;
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/ClubVisionExpectationBoardViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/ClubVisionExpectationBoardViewModel.cs
@@ -1,0 +1,265 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class ClubVisionExpectationBoardViewModel : ObservableObject
+{
+    private readonly ReadOnlyCollection<ClubVisionExpectationRowViewModel> _objectives;
+    private readonly ReadOnlyCollection<ClubVisionExpectationFilterViewModel> _statusFilters;
+    private readonly RelayCommand _selectStatusCommand;
+    private ClubVisionExpectationFilterViewModel? _selectedStatus;
+    private string _summary;
+
+    public ClubVisionExpectationBoardViewModel(ClubVisionExpectationBoardDefinition definition, IClubDataService clubDataService)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        if (clubDataService is null)
+        {
+            throw new ArgumentNullException(nameof(clubDataService));
+        }
+
+        _objectives = new ReadOnlyCollection<ClubVisionExpectationRowViewModel>(
+            definition.Objectives?
+                .Select(ClubVisionExpectationRowViewModel.FromDefinition)
+                .ToList() ?? new List<ClubVisionExpectationRowViewModel>());
+
+        _statusFilters = new ReadOnlyCollection<ClubVisionExpectationFilterViewModel>(
+            BuildFilters(_objectives, definition.StatusOptions));
+
+        _selectStatusCommand = new RelayCommand(
+            parameter =>
+            {
+                if (parameter is ClubVisionExpectationFilterViewModel filter)
+                {
+                    SelectedStatus = filter;
+                }
+            },
+            parameter => parameter is ClubVisionExpectationFilterViewModel filter && filter != SelectedStatus);
+
+        _summary = BuildSummary();
+
+        if (_statusFilters.Count > 0)
+        {
+            SelectedStatus = _statusFilters[0];
+        }
+    }
+
+    public IReadOnlyList<ClubVisionExpectationRowViewModel> Objectives => _objectives;
+
+    public IReadOnlyList<ClubVisionExpectationFilterViewModel> StatusFilters => _statusFilters;
+
+    public ICommand SelectStatusCommand => _selectStatusCommand;
+
+    public ClubVisionExpectationFilterViewModel? SelectedStatus
+    {
+        get => _selectedStatus;
+        private set
+        {
+            if (SetProperty(ref _selectedStatus, value))
+            {
+                foreach (var filter in _statusFilters)
+                {
+                    filter.IsSelected = ReferenceEquals(filter, value);
+                }
+
+                UpdateObjectiveVisibility(value);
+                _summary = BuildSummary();
+                OnPropertyChanged(nameof(Summary));
+                _selectStatusCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string Summary => _summary;
+
+    public bool HasObjectives => _objectives.Count > 0;
+
+    private void UpdateObjectiveVisibility(ClubVisionExpectationFilterViewModel? filter)
+    {
+        if (filter is null || filter.Key is null)
+        {
+            foreach (var objective in _objectives)
+            {
+                objective.IsVisible = true;
+            }
+
+            return;
+        }
+
+        var key = filter.Key;
+        foreach (var objective in _objectives)
+        {
+            objective.IsVisible = string.Equals(objective.Status, key, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private string BuildSummary()
+    {
+        if (_objectives.Count == 0)
+        {
+            return "No objectives configured";
+        }
+
+        var visible = _objectives.Count(o => o.IsVisible);
+        var total = _objectives.Count;
+        var urgent = _objectives.Count(o => o.IsVisible && o.IsUrgent);
+
+        if (visible == total)
+        {
+            return urgent > 0
+                ? $"{total} objectives • {urgent} urgent" : $"{total} objectives monitored";
+        }
+
+        return urgent > 0
+            ? $"{visible} of {total} objectives shown • {urgent} urgent"
+            : $"{visible} of {total} objectives shown";
+    }
+
+    private static List<ClubVisionExpectationFilterViewModel> BuildFilters(
+        IReadOnlyList<ClubVisionExpectationRowViewModel> objectives,
+        IReadOnlyList<string> statusOptions)
+    {
+        var filters = new List<ClubVisionExpectationFilterViewModel>
+        {
+            ClubVisionExpectationFilterViewModel.CreateAll(objectives)
+        };
+
+        if (statusOptions is { Count: > 0 })
+        {
+            foreach (var option in statusOptions.Where(o => !string.IsNullOrWhiteSpace(o)))
+            {
+                filters.Add(ClubVisionExpectationFilterViewModel.Create(option, objectives));
+            }
+        }
+
+        return filters;
+    }
+}
+
+public sealed class ClubVisionExpectationRowViewModel : ObservableObject
+{
+    private bool _isVisible = true;
+
+    private ClubVisionExpectationRowViewModel(
+        string id,
+        string objective,
+        string competition,
+        string priority,
+        string status,
+        string deadline,
+        string? notes,
+        string? accent,
+        bool isUrgent)
+    {
+        Id = id;
+        Objective = objective;
+        Competition = competition;
+        Priority = priority;
+        Status = status;
+        Deadline = deadline;
+        Notes = notes;
+        Accent = accent;
+        IsUrgent = isUrgent;
+    }
+
+    public string Id { get; }
+
+    public string Objective { get; }
+
+    public string Competition { get; }
+
+    public string Priority { get; }
+
+    public string Status { get; }
+
+    public string Deadline { get; }
+
+    public string? Notes { get; }
+
+    public string? Accent { get; }
+
+    public bool IsUrgent { get; }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => SetProperty(ref _isVisible, value);
+    }
+
+    public static ClubVisionExpectationRowViewModel FromDefinition(ClubVisionExpectationDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        var urgent = string.Equals(definition.Priority, "Critical", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(definition.Priority, "High", StringComparison.OrdinalIgnoreCase);
+
+        return new ClubVisionExpectationRowViewModel(
+            definition.Id,
+            definition.Objective,
+            definition.Competition,
+            definition.Priority,
+            definition.Status,
+            definition.Deadline,
+            definition.Notes,
+            definition.Accent,
+            urgent);
+    }
+}
+
+public sealed class ClubVisionExpectationFilterViewModel : ObservableObject
+{
+    private bool _isSelected;
+
+    private ClubVisionExpectationFilterViewModel(string? key, string label, int count)
+    {
+        Key = key;
+        Label = label;
+        Count = count;
+    }
+
+    public string? Key { get; }
+
+    public string Label { get; }
+
+    public int Count { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+
+    public static ClubVisionExpectationFilterViewModel CreateAll(IReadOnlyList<ClubVisionExpectationRowViewModel> objectives)
+    {
+        var count = objectives?.Count ?? 0;
+        return new ClubVisionExpectationFilterViewModel(null, count == 1 ? "All (1)" : $"All ({count})", count);
+    }
+
+    public static ClubVisionExpectationFilterViewModel Create(
+        string status,
+        IReadOnlyList<ClubVisionExpectationRowViewModel> objectives)
+    {
+        if (objectives is null || objectives.Count == 0)
+        {
+            return new ClubVisionExpectationFilterViewModel(status, status, 0);
+        }
+
+        var count = objectives.Count(obj => string.Equals(obj.Status, status, StringComparison.OrdinalIgnoreCase));
+        var label = count == 0 ? status : $"{status} ({count})";
+        return new ClubVisionExpectationFilterViewModel(status, label, count);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/ClubVisionRoadmapViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/ClubVisionRoadmapViewModel.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class ClubVisionRoadmapViewModel : ObservableObject
+{
+    private readonly ReadOnlyCollection<ClubVisionRoadmapPhaseViewModel> _phases;
+    private readonly ReadOnlyCollection<ClubVisionRoadmapStatusViewModel> _statusFilters;
+    private readonly RelayCommand _selectStatusCommand;
+    private ClubVisionRoadmapStatusViewModel? _selectedStatus;
+    private string _summary;
+
+    public ClubVisionRoadmapViewModel(ClubVisionRoadmapDefinition definition, IClubDataService clubDataService)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        if (clubDataService is null)
+        {
+            throw new ArgumentNullException(nameof(clubDataService));
+        }
+
+        _phases = new ReadOnlyCollection<ClubVisionRoadmapPhaseViewModel>(
+            definition.Phases?
+                .Select(ClubVisionRoadmapPhaseViewModel.FromDefinition)
+                .ToList() ?? new List<ClubVisionRoadmapPhaseViewModel>());
+
+        _statusFilters = new ReadOnlyCollection<ClubVisionRoadmapStatusViewModel>(
+            BuildStatusFilters(_phases, definition.StatusOptions));
+
+        _selectStatusCommand = new RelayCommand(
+            parameter =>
+            {
+                if (parameter is ClubVisionRoadmapStatusViewModel status)
+                {
+                    SelectedStatus = status;
+                }
+            },
+            parameter => parameter is ClubVisionRoadmapStatusViewModel status && status != SelectedStatus);
+
+        _summary = BuildSummary();
+
+        if (_statusFilters.Count > 0)
+        {
+            SelectedStatus = _statusFilters[0];
+        }
+    }
+
+    public IReadOnlyList<ClubVisionRoadmapPhaseViewModel> Phases => _phases;
+
+    public IReadOnlyList<ClubVisionRoadmapStatusViewModel> StatusFilters => _statusFilters;
+
+    public ICommand SelectStatusCommand => _selectStatusCommand;
+
+    public ClubVisionRoadmapStatusViewModel? SelectedStatus
+    {
+        get => _selectedStatus;
+        private set
+        {
+            if (SetProperty(ref _selectedStatus, value))
+            {
+                foreach (var status in _statusFilters)
+                {
+                    status.IsSelected = ReferenceEquals(status, value);
+                }
+
+                UpdatePhaseVisibility(value);
+                _summary = BuildSummary();
+                OnPropertyChanged(nameof(Summary));
+                _selectStatusCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string Summary => _summary;
+
+    private void UpdatePhaseVisibility(ClubVisionRoadmapStatusViewModel? status)
+    {
+        if (status is null || status.Key is null)
+        {
+            foreach (var phase in _phases)
+            {
+                phase.IsVisible = true;
+            }
+
+            return;
+        }
+
+        var key = status.Key;
+        foreach (var phase in _phases)
+        {
+            phase.IsVisible = string.Equals(phase.Status, key, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private string BuildSummary()
+    {
+        if (_phases.Count == 0)
+        {
+            return "No milestones captured";
+        }
+
+        var visible = _phases.Count(p => p.IsVisible);
+        var total = _phases.Count;
+        var atRisk = _phases.Count(p => p.IsVisible && p.IsAtRisk);
+
+        if (visible == total)
+        {
+            return atRisk > 0
+                ? $"{total} milestones • {atRisk} flagged" : $"{total} milestones on record";
+        }
+
+        return atRisk > 0
+            ? $"{visible} of {total} milestones shown • {atRisk} flagged"
+            : $"{visible} of {total} milestones shown";
+    }
+
+    private static List<ClubVisionRoadmapStatusViewModel> BuildStatusFilters(
+        IReadOnlyList<ClubVisionRoadmapPhaseViewModel> phases,
+        IReadOnlyList<string> options)
+    {
+        var filters = new List<ClubVisionRoadmapStatusViewModel>
+        {
+            ClubVisionRoadmapStatusViewModel.CreateAll(phases)
+        };
+
+        if (options is { Count: > 0 })
+        {
+            foreach (var option in options.Where(o => !string.IsNullOrWhiteSpace(o)))
+            {
+                filters.Add(ClubVisionRoadmapStatusViewModel.Create(option, phases));
+            }
+        }
+
+        return filters;
+    }
+}
+
+public sealed class ClubVisionRoadmapPhaseViewModel : ObservableObject
+{
+    private bool _isVisible = true;
+
+    private ClubVisionRoadmapPhaseViewModel(
+        string id,
+        string title,
+        string timeline,
+        string status,
+        string? description,
+        string? accent,
+        string? pill,
+        bool isAtRisk)
+    {
+        Id = id;
+        Title = title;
+        Timeline = timeline;
+        Status = status;
+        Description = description;
+        Accent = accent;
+        Pill = pill;
+        IsAtRisk = isAtRisk;
+    }
+
+    public string Id { get; }
+
+    public string Title { get; }
+
+    public string Timeline { get; }
+
+    public string Status { get; }
+
+    public string? Description { get; }
+
+    public string? Accent { get; }
+
+    public string? Pill { get; }
+
+    public bool IsAtRisk { get; }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => SetProperty(ref _isVisible, value);
+    }
+
+    public static ClubVisionRoadmapPhaseViewModel FromDefinition(ClubVisionRoadmapPhaseDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        var isAtRisk = string.Equals(definition.Status, "At Risk", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(definition.Status, "Behind", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(definition.Status, "Off Track", StringComparison.OrdinalIgnoreCase);
+
+        return new ClubVisionRoadmapPhaseViewModel(
+            definition.Id,
+            definition.Title,
+            definition.Timeline,
+            definition.Status,
+            definition.Description,
+            definition.Accent,
+            definition.Pill,
+            isAtRisk);
+    }
+}
+
+public sealed class ClubVisionRoadmapStatusViewModel : ObservableObject
+{
+    private bool _isSelected;
+
+    private ClubVisionRoadmapStatusViewModel(string? key, string label, int count)
+    {
+        Key = key;
+        Label = label;
+        Count = count;
+    }
+
+    public string? Key { get; }
+
+    public string Label { get; }
+
+    public int Count { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+
+    public static ClubVisionRoadmapStatusViewModel CreateAll(IReadOnlyList<ClubVisionRoadmapPhaseViewModel> phases)
+    {
+        var count = phases?.Count ?? 0;
+        return new ClubVisionRoadmapStatusViewModel(null, count == 1 ? "All (1)" : $"All ({count})", count);
+    }
+
+    public static ClubVisionRoadmapStatusViewModel Create(string status, IReadOnlyList<ClubVisionRoadmapPhaseViewModel> phases)
+    {
+        if (phases is null || phases.Count == 0)
+        {
+            return new ClubVisionRoadmapStatusViewModel(status, status, 0);
+        }
+
+        var count = phases.Count(phase => string.Equals(phase.Status, status, StringComparison.OrdinalIgnoreCase));
+        var label = count == 0 ? status : $"{status} ({count})";
+        return new ClubVisionRoadmapStatusViewModel(status, label, count);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/CardEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/CardEditorViewModel.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public abstract class CardEditorViewModel : ObservableObject
+{
+    private readonly AsyncRelayCommand _saveCommand;
+    private readonly RelayCommand _cancelCommand;
+    private bool _isBusy;
+
+    protected CardEditorViewModel(string title, string? subtitle = null)
+    {
+        Title = title ?? throw new ArgumentNullException(nameof(title));
+        Subtitle = subtitle;
+        _saveCommand = new AsyncRelayCommand(SaveAsync, () => CanSave);
+        _cancelCommand = new RelayCommand(_ => RequestClose());
+    }
+
+    public string Title { get; }
+
+    public string? Subtitle { get; }
+
+    public bool HasSubtitle => !string.IsNullOrWhiteSpace(Subtitle);
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set => SetProperty(ref _isBusy, value);
+    }
+
+    public ICommand SaveCommand => _saveCommand;
+
+    public ICommand CancelCommand => _cancelCommand;
+
+    protected virtual bool CanSave => true;
+
+    public event EventHandler? CloseRequested;
+
+    protected void NotifyCanSaveChanged() => _saveCommand.RaiseCanExecuteChanged();
+
+    protected void RequestClose() => CloseRequested?.Invoke(this, EventArgs.Empty);
+
+    private async Task SaveAsync()
+    {
+        if (!CanSave)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await PersistAsync().ConfigureAwait(false);
+            RequestClose();
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    protected abstract Task PersistAsync();
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/ClubVisionExpectationBoardEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/ClubVisionExpectationBoardEditorViewModel.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class ClubVisionExpectationBoardEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<ClubVisionExpectationBoardSnapshot, Task> _persistAsync;
+    private readonly RelayCommand _removeObjectiveCommand;
+    private readonly RelayCommand _moveUpCommand;
+    private readonly RelayCommand _moveDownCommand;
+    private ClubVisionExpectationEditorItemViewModel? _selectedObjective;
+    private string? _validationMessage;
+
+    public ClubVisionExpectationBoardEditorViewModel(
+        string title,
+        string? subtitle,
+        ClubVisionExpectationBoardSnapshot board,
+        Func<ClubVisionExpectationBoardSnapshot, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        Objectives = new ObservableCollection<ClubVisionExpectationEditorItemViewModel>(
+            board.Objectives?.Select(ClubVisionExpectationEditorItemViewModel.FromSnapshot)
+            ?? Enumerable.Empty<ClubVisionExpectationEditorItemViewModel>());
+
+        foreach (var objective in Objectives)
+        {
+            objective.PropertyChanged += OnObjectivePropertyChanged;
+        }
+
+        StatusOptions = new ObservableCollection<string>(board.StatusOptions ?? Array.Empty<string>());
+        PriorityOptions = new ObservableCollection<string>(board.PriorityOptions ?? Array.Empty<string>());
+
+        AddObjectiveCommand = new RelayCommand(_ => AddObjective());
+        _removeObjectiveCommand = new RelayCommand(_ => RemoveSelectedObjective(), _ => SelectedObjective is not null);
+        _moveUpCommand = new RelayCommand(_ => MoveSelected(-1), _ => CanMove(-1));
+        _moveDownCommand = new RelayCommand(_ => MoveSelected(1), _ => CanMove(1));
+
+        if (Objectives.Count > 0)
+        {
+            SelectedObjective = Objectives[0];
+        }
+
+        UpdateValidation();
+    }
+
+    public ObservableCollection<ClubVisionExpectationEditorItemViewModel> Objectives { get; }
+
+    public ObservableCollection<string> StatusOptions { get; }
+
+    public ObservableCollection<string> PriorityOptions { get; }
+
+    public ICommand AddObjectiveCommand { get; }
+
+    public ICommand RemoveObjectiveCommand => _removeObjectiveCommand;
+
+    public ICommand MoveUpCommand => _moveUpCommand;
+
+    public ICommand MoveDownCommand => _moveDownCommand;
+
+    public ClubVisionExpectationEditorItemViewModel? SelectedObjective
+    {
+        get => _selectedObjective;
+        set
+        {
+            if (SetProperty(ref _selectedObjective, value))
+            {
+                _removeObjectiveCommand.RaiseCanExecuteChanged();
+                _moveUpCommand.RaiseCanExecuteChanged();
+                _moveDownCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                OnPropertyChanged(nameof(HasValidationMessage));
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override bool CanSave => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override async Task PersistAsync()
+    {
+        var objectives = Objectives
+            .Select(objective => objective.ToSnapshot())
+            .ToList();
+
+        var statusOptions = StatusOptions
+            .Concat(objectives.Select(objective => objective.Status))
+            .Where(option => !string.IsNullOrWhiteSpace(option))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var priorityOptions = PriorityOptions
+            .Concat(objectives.Select(objective => objective.Priority))
+            .Where(option => !string.IsNullOrWhiteSpace(option))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var snapshot = new ClubVisionExpectationBoardSnapshot(objectives, statusOptions, priorityOptions);
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private void AddObjective()
+    {
+        var priority = PriorityOptions.FirstOrDefault() ?? "Medium";
+        var status = StatusOptions.FirstOrDefault() ?? "On Course";
+
+        var objective = new ClubVisionExpectationEditorItemViewModel(
+            Guid.NewGuid().ToString("N"),
+            "New objective",
+            "Competition",
+            priority,
+            status,
+            "TBD",
+            string.Empty,
+            string.Empty);
+
+        objective.PropertyChanged += OnObjectivePropertyChanged;
+        Objectives.Add(objective);
+        SelectedObjective = objective;
+        UpdateValidation();
+    }
+
+    private void RemoveSelectedObjective()
+    {
+        var objective = SelectedObjective;
+        if (objective is null)
+        {
+            return;
+        }
+
+        objective.PropertyChanged -= OnObjectivePropertyChanged;
+        var index = Objectives.IndexOf(objective);
+        Objectives.Remove(objective);
+
+        if (Objectives.Count > 0)
+        {
+            var target = Math.Clamp(index, 0, Objectives.Count - 1);
+            SelectedObjective = Objectives[target];
+        }
+        else
+        {
+            SelectedObjective = null;
+        }
+
+        UpdateValidation();
+    }
+
+    private bool CanMove(int direction)
+    {
+        if (SelectedObjective is null)
+        {
+            return false;
+        }
+
+        var index = Objectives.IndexOf(SelectedObjective);
+        var target = index + direction;
+        return index >= 0 && target >= 0 && target < Objectives.Count;
+    }
+
+    private void MoveSelected(int direction)
+    {
+        if (SelectedObjective is null)
+        {
+            return;
+        }
+
+        var index = Objectives.IndexOf(SelectedObjective);
+        var target = index + direction;
+        if (index < 0 || target < 0 || target >= Objectives.Count)
+        {
+            return;
+        }
+
+        Objectives.Move(index, target);
+        UpdateValidation();
+    }
+
+    private void OnObjectivePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ClubVisionExpectationEditorItemViewModel.Objective)
+            or nameof(ClubVisionExpectationEditorItemViewModel.Status)
+            or nameof(ClubVisionExpectationEditorItemViewModel.Deadline))
+        {
+            UpdateValidation();
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        if (Objectives.Count == 0)
+        {
+            ValidationMessage = "Add at least one objective.";
+            return;
+        }
+
+        foreach (var objective in Objectives)
+        {
+            if (string.IsNullOrWhiteSpace(objective.Objective))
+            {
+                ValidationMessage = "Objectives require a description.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(objective.Status))
+            {
+                ValidationMessage = "Set a status for each objective.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(objective.Deadline))
+            {
+                ValidationMessage = "Provide a deadline for each objective.";
+                return;
+            }
+        }
+
+        ValidationMessage = null;
+    }
+}
+
+public sealed class ClubVisionExpectationEditorItemViewModel : ObservableObject
+{
+    private string _objective;
+    private string _competition;
+    private string _priority;
+    private string _status;
+    private string _deadline;
+    private string? _notes;
+    private string? _accent;
+
+    public ClubVisionExpectationEditorItemViewModel(
+        string id,
+        string objective,
+        string competition,
+        string priority,
+        string status,
+        string deadline,
+        string? notes,
+        string? accent)
+    {
+        Id = id;
+        _objective = objective;
+        _competition = competition;
+        _priority = priority;
+        _status = status;
+        _deadline = deadline;
+        _notes = notes;
+        _accent = accent;
+    }
+
+    public string Id { get; }
+
+    public string Objective
+    {
+        get => _objective;
+        set => SetProperty(ref _objective, value);
+    }
+
+    public string Competition
+    {
+        get => _competition;
+        set => SetProperty(ref _competition, value);
+    }
+
+    public string Priority
+    {
+        get => _priority;
+        set => SetProperty(ref _priority, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        set => SetProperty(ref _status, value);
+    }
+
+    public string Deadline
+    {
+        get => _deadline;
+        set => SetProperty(ref _deadline, value);
+    }
+
+    public string? Notes
+    {
+        get => _notes;
+        set => SetProperty(ref _notes, value);
+    }
+
+    public string? Accent
+    {
+        get => _accent;
+        set => SetProperty(ref _accent, value);
+    }
+
+    public ClubVisionExpectationSnapshot ToSnapshot() => new(
+        Id,
+        Objective.Trim(),
+        string.IsNullOrWhiteSpace(Competition) ? "" : Competition.Trim(),
+        string.IsNullOrWhiteSpace(Priority) ? "Medium" : Priority.Trim(),
+        Status.Trim(),
+        Deadline.Trim(),
+        string.IsNullOrWhiteSpace(Notes) ? null : Notes.Trim(),
+        string.IsNullOrWhiteSpace(Accent) ? null : Accent.Trim());
+
+    public static ClubVisionExpectationEditorItemViewModel FromSnapshot(ClubVisionExpectationSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        return new ClubVisionExpectationEditorItemViewModel(
+            snapshot.Id,
+            snapshot.Objective,
+            snapshot.Competition,
+            snapshot.Priority,
+            snapshot.Status,
+            snapshot.Deadline,
+            snapshot.Notes,
+            snapshot.Accent);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/ClubVisionRoadmapEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/ClubVisionRoadmapEditorViewModel.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class ClubVisionRoadmapEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<ClubVisionRoadmapSnapshot, Task> _persistAsync;
+    private readonly RelayCommand _removePhaseCommand;
+    private readonly RelayCommand _moveUpCommand;
+    private readonly RelayCommand _moveDownCommand;
+    private ClubVisionRoadmapPhaseEditorViewModel? _selectedPhase;
+    private string? _validationMessage;
+
+    public ClubVisionRoadmapEditorViewModel(
+        string title,
+        string? subtitle,
+        ClubVisionRoadmapSnapshot roadmap,
+        Func<ClubVisionRoadmapSnapshot, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        Phases = new ObservableCollection<ClubVisionRoadmapPhaseEditorViewModel>(
+            roadmap.Phases?.Select(ClubVisionRoadmapPhaseEditorViewModel.FromSnapshot)
+            ?? Enumerable.Empty<ClubVisionRoadmapPhaseEditorViewModel>());
+
+        foreach (var phase in Phases)
+        {
+            phase.PropertyChanged += OnPhasePropertyChanged;
+        }
+
+        StatusOptions = new ObservableCollection<string>(roadmap.StatusOptions ?? Array.Empty<string>());
+        PillOptions = new ObservableCollection<string>(roadmap.PillOptions ?? Array.Empty<string>());
+
+        AddPhaseCommand = new RelayCommand(_ => AddPhase());
+        _removePhaseCommand = new RelayCommand(_ => RemoveSelectedPhase(), _ => SelectedPhase is not null);
+        _moveUpCommand = new RelayCommand(_ => MoveSelected(-1), _ => CanMove(-1));
+        _moveDownCommand = new RelayCommand(_ => MoveSelected(1), _ => CanMove(1));
+
+        if (Phases.Count > 0)
+        {
+            SelectedPhase = Phases[0];
+        }
+
+        UpdateValidation();
+    }
+
+    public ObservableCollection<ClubVisionRoadmapPhaseEditorViewModel> Phases { get; }
+
+    public ObservableCollection<string> StatusOptions { get; }
+
+    public ObservableCollection<string> PillOptions { get; }
+
+    public ICommand AddPhaseCommand { get; }
+
+    public ICommand RemovePhaseCommand => _removePhaseCommand;
+
+    public ICommand MoveUpCommand => _moveUpCommand;
+
+    public ICommand MoveDownCommand => _moveDownCommand;
+
+    public ClubVisionRoadmapPhaseEditorViewModel? SelectedPhase
+    {
+        get => _selectedPhase;
+        set
+        {
+            if (SetProperty(ref _selectedPhase, value))
+            {
+                _removePhaseCommand.RaiseCanExecuteChanged();
+                _moveUpCommand.RaiseCanExecuteChanged();
+                _moveDownCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                OnPropertyChanged(nameof(HasValidationMessage));
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override bool CanSave => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override async Task PersistAsync()
+    {
+        var phases = Phases
+            .Select(phase => phase.ToSnapshot())
+            .ToList();
+
+        var statusOptions = StatusOptions
+            .Concat(phases.Select(phase => phase.Status))
+            .Where(option => !string.IsNullOrWhiteSpace(option))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var pillOptions = PillOptions
+            .Concat(phases.Select(phase => phase.Pill))
+            .Where(option => !string.IsNullOrWhiteSpace(option))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var snapshot = new ClubVisionRoadmapSnapshot(phases, statusOptions, pillOptions);
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private void AddPhase()
+    {
+        var phase = new ClubVisionRoadmapPhaseEditorViewModel(
+            Guid.NewGuid().ToString("N"),
+            "New milestone",
+            "TBD",
+            StatusOptions.FirstOrDefault() ?? "Planned",
+            string.Empty,
+            string.Empty,
+            string.Empty);
+
+        phase.PropertyChanged += OnPhasePropertyChanged;
+        Phases.Add(phase);
+        SelectedPhase = phase;
+        UpdateValidation();
+    }
+
+    private void RemoveSelectedPhase()
+    {
+        var phase = SelectedPhase;
+        if (phase is null)
+        {
+            return;
+        }
+
+        phase.PropertyChanged -= OnPhasePropertyChanged;
+        var index = Phases.IndexOf(phase);
+        Phases.Remove(phase);
+
+        if (Phases.Count > 0)
+        {
+            var target = Math.Clamp(index, 0, Phases.Count - 1);
+            SelectedPhase = Phases[target];
+        }
+        else
+        {
+            SelectedPhase = null;
+        }
+
+        UpdateValidation();
+    }
+
+    private bool CanMove(int direction)
+    {
+        if (SelectedPhase is null)
+        {
+            return false;
+        }
+
+        var index = Phases.IndexOf(SelectedPhase);
+        var target = index + direction;
+        return index >= 0 && target >= 0 && target < Phases.Count;
+    }
+
+    private void MoveSelected(int direction)
+    {
+        if (SelectedPhase is null)
+        {
+            return;
+        }
+
+        var index = Phases.IndexOf(SelectedPhase);
+        var target = index + direction;
+        if (index < 0 || target < 0 || target >= Phases.Count)
+        {
+            return;
+        }
+
+        Phases.Move(index, target);
+        UpdateValidation();
+    }
+
+    private void OnPhasePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ClubVisionRoadmapPhaseEditorViewModel.Title)
+            or nameof(ClubVisionRoadmapPhaseEditorViewModel.Status)
+            or nameof(ClubVisionRoadmapPhaseEditorViewModel.Timeline))
+        {
+            UpdateValidation();
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        if (Phases.Count == 0)
+        {
+            ValidationMessage = "Add at least one milestone to continue.";
+            return;
+        }
+
+        foreach (var phase in Phases)
+        {
+            if (string.IsNullOrWhiteSpace(phase.Title))
+            {
+                ValidationMessage = "Milestones require a title.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(phase.Status))
+            {
+                ValidationMessage = "Select a status for each milestone.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(phase.Timeline))
+            {
+                ValidationMessage = "Provide a timeline for each milestone.";
+                return;
+            }
+        }
+
+        ValidationMessage = null;
+    }
+}
+
+public sealed class ClubVisionRoadmapPhaseEditorViewModel : ObservableObject
+{
+    private string _title;
+    private string _timeline;
+    private string _status;
+    private string? _description;
+    private string? _accent;
+    private string? _pill;
+
+    public ClubVisionRoadmapPhaseEditorViewModel(
+        string id,
+        string title,
+        string timeline,
+        string status,
+        string? description,
+        string? accent,
+        string? pill)
+    {
+        Id = id;
+        _title = title;
+        _timeline = timeline;
+        _status = status;
+        _description = description;
+        _accent = accent;
+        _pill = pill;
+    }
+
+    public string Id { get; }
+
+    public string Title
+    {
+        get => _title;
+        set => SetProperty(ref _title, value);
+    }
+
+    public string Timeline
+    {
+        get => _timeline;
+        set => SetProperty(ref _timeline, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        set => SetProperty(ref _status, value);
+    }
+
+    public string? Description
+    {
+        get => _description;
+        set => SetProperty(ref _description, value);
+    }
+
+    public string? Accent
+    {
+        get => _accent;
+        set => SetProperty(ref _accent, value);
+    }
+
+    public string? Pill
+    {
+        get => _pill;
+        set => SetProperty(ref _pill, value);
+    }
+
+    public ClubVisionRoadmapPhaseSnapshot ToSnapshot() => new(
+        Id,
+        Title.Trim(),
+        Timeline.Trim(),
+        Status.Trim(),
+        string.IsNullOrWhiteSpace(Description) ? null : Description.Trim(),
+        string.IsNullOrWhiteSpace(Accent) ? null : Accent.Trim(),
+        string.IsNullOrWhiteSpace(Pill) ? null : Pill.Trim());
+
+    public static ClubVisionRoadmapPhaseEditorViewModel FromSnapshot(ClubVisionRoadmapPhaseSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        return new ClubVisionRoadmapPhaseEditorViewModel(
+            snapshot.Id,
+            snapshot.Title,
+            snapshot.Timeline,
+            snapshot.Status,
+            snapshot.Description,
+            snapshot.Accent,
+            snapshot.Pill);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/FormationEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/FormationEditorViewModel.cs
@@ -1,0 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class FormationEditorViewModel : CardEditorViewModel
+{
+    private readonly IClubDataService _clubDataService;
+    private readonly ReadOnlyCollection<FormationLineEditorViewModel> _lines;
+    private readonly ReadOnlyCollection<FormationSlotEditorViewModel> _slots;
+    private readonly ReadOnlyCollection<FormationPlayerOptionViewModel> _options;
+    private string? _validationMessage;
+
+    public FormationEditorViewModel(
+        string title,
+        string? subtitle,
+        IReadOnlyList<FormationLineSnapshot> lines,
+        IReadOnlyList<FormationPlayerOptionSnapshot> options,
+        IClubDataService clubDataService)
+        : base(title, subtitle)
+    {
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+
+        if (lines is null)
+        {
+            throw new ArgumentNullException(nameof(lines));
+        }
+
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var optionViewModels = options
+            .Select(option => new FormationPlayerOptionViewModel(option.Id, option.Name, option.Position, option.Detail))
+            .ToList();
+
+        var optionLookup = new HashSet<string>(optionViewModels.Select(option => option.Id), StringComparer.OrdinalIgnoreCase);
+
+        _options = new ReadOnlyCollection<FormationPlayerOptionViewModel>(optionViewModels);
+
+        var slotCollection = new List<FormationSlotEditorViewModel>();
+        var lineCollection = new List<FormationLineEditorViewModel>();
+
+        foreach (var line in lines)
+        {
+            var slots = new List<FormationSlotEditorViewModel>();
+            var index = 1;
+            foreach (var player in line.Players)
+            {
+                if (!optionLookup.Contains(player.Id))
+                {
+                    optionViewModels.Add(new FormationPlayerOptionViewModel(player.Id, player.Name, position: null, detail: null));
+                    optionLookup.Add(player.Id);
+                }
+
+                var slot = new FormationSlotEditorViewModel(
+                    owner: this,
+                    slotId: player.Id,
+                    role: line.Role,
+                    label: line.Players.Count > 1 ? $"{line.Role} {index}" : line.Role,
+                    normalizedX: player.X,
+                    normalizedY: player.Y,
+                    selectedPlayerId: player.Id);
+
+                slots.Add(slot);
+                slotCollection.Add(slot);
+                index++;
+            }
+
+            lineCollection.Add(new FormationLineEditorViewModel(line.Role, slots));
+        }
+
+        _lines = new ReadOnlyCollection<FormationLineEditorViewModel>(lineCollection);
+        _slots = new ReadOnlyCollection<FormationSlotEditorViewModel>(slotCollection);
+
+        UpdateValidationState();
+    }
+
+    public IReadOnlyList<FormationLineEditorViewModel> Lines => _lines;
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                NotifyCanSaveChanged();
+                OnPropertyChanged(nameof(HasValidationMessage));
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override bool CanSave => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    internal IReadOnlyList<FormationPlayerOptionViewModel> GetAvailablePlayers(FormationSlotEditorViewModel requester)
+    {
+        var assigned = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var slot in _slots)
+        {
+            if (ReferenceEquals(slot, requester))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(slot.SelectedPlayerId))
+            {
+                assigned.Add(slot.SelectedPlayerId);
+            }
+        }
+
+        return _options
+            .Where(option => string.Equals(option.Id, requester.SelectedPlayerId, StringComparison.OrdinalIgnoreCase) ||
+                             !assigned.Contains(option.Id))
+            .OrderBy(option => option.DisplayName, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+    }
+
+    internal void HandleSlotSelectionChanged()
+    {
+        foreach (var slot in _slots)
+        {
+            slot.NotifyAvailablePlayersChanged();
+        }
+
+        UpdateValidationState();
+    }
+
+    private void UpdateValidationState()
+    {
+        foreach (var slot in _slots)
+        {
+            if (string.IsNullOrWhiteSpace(slot.SelectedPlayerId))
+            {
+                ValidationMessage = "Assign a player to every position before saving.";
+                return;
+            }
+        }
+
+        var duplicates = _slots
+            .Where(slot => !string.IsNullOrWhiteSpace(slot.SelectedPlayerId))
+            .GroupBy(slot => slot.SelectedPlayerId, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1);
+
+        if (duplicates is not null)
+        {
+            ValidationMessage = "Each player can only occupy a single position.";
+            return;
+        }
+
+        ValidationMessage = null;
+    }
+
+    protected override async Task PersistAsync()
+    {
+        var updatedLines = new List<FormationLineSnapshot>(_lines.Count);
+        foreach (var line in _lines)
+        {
+            var players = new List<FormationPlayerSnapshot>(line.Slots.Count);
+            foreach (var slot in line.Slots)
+            {
+                var option = _options.First(o => string.Equals(o.Id, slot.SelectedPlayerId, StringComparison.OrdinalIgnoreCase));
+                players.Add(new FormationPlayerSnapshot(option.Id, ComposeDisplayName(option), slot.NormalizedX, slot.NormalizedY));
+            }
+
+            updatedLines.Add(new FormationLineSnapshot(line.Role, players));
+        }
+
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var tactics = snapshot.Tactics with { FormationLines = updatedLines };
+            return snapshot with { Tactics = tactics };
+        }).ConfigureAwait(false);
+    }
+
+    private static string ComposeDisplayName(FormationPlayerOptionViewModel option)
+    {
+        if (!string.IsNullOrWhiteSpace(option.Detail))
+        {
+            return option.DisplayName.Contains('(')
+                ? option.DisplayName
+                : $"{option.DisplayName} ({option.Detail})";
+        }
+
+        return option.DisplayName;
+    }
+}
+
+public sealed class FormationLineEditorViewModel
+{
+    public FormationLineEditorViewModel(string role, IReadOnlyList<FormationSlotEditorViewModel> slots)
+    {
+        Role = role ?? throw new ArgumentNullException(nameof(role));
+        Slots = slots ?? throw new ArgumentNullException(nameof(slots));
+    }
+
+    public string Role { get; }
+
+    public IReadOnlyList<FormationSlotEditorViewModel> Slots { get; }
+}
+
+public sealed class FormationSlotEditorViewModel : ObservableObject
+{
+    private readonly FormationEditorViewModel _owner;
+    private string? _selectedPlayerId;
+
+    public FormationSlotEditorViewModel(
+        FormationEditorViewModel owner,
+        string slotId,
+        string role,
+        string label,
+        double normalizedX,
+        double normalizedY,
+        string? selectedPlayerId)
+    {
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        SlotId = slotId ?? throw new ArgumentNullException(nameof(slotId));
+        Role = role ?? throw new ArgumentNullException(nameof(role));
+        Label = label ?? throw new ArgumentNullException(nameof(label));
+        NormalizedX = normalizedX;
+        NormalizedY = normalizedY;
+        _selectedPlayerId = selectedPlayerId;
+    }
+
+    public string SlotId { get; }
+
+    public string Role { get; }
+
+    public string Label { get; }
+
+    public double NormalizedX { get; }
+
+    public double NormalizedY { get; }
+
+    public string? SelectedPlayerId
+    {
+        get => _selectedPlayerId;
+        set
+        {
+            if (SetProperty(ref _selectedPlayerId, value))
+            {
+                _owner.HandleSlotSelectionChanged();
+            }
+        }
+    }
+
+    public IReadOnlyList<FormationPlayerOptionViewModel> AvailablePlayers => _owner.GetAvailablePlayers(this);
+
+    internal void NotifyAvailablePlayersChanged() => OnPropertyChanged(nameof(AvailablePlayers));
+}
+
+public sealed class FormationPlayerOptionViewModel
+{
+    public FormationPlayerOptionViewModel(string id, string displayName, string? position, string? detail)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+        Position = position;
+        Detail = detail;
+    }
+
+    public string Id { get; }
+
+    public string DisplayName { get; }
+
+    public string? Position { get; }
+
+    public string? Detail { get; }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/GaugeEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/GaugeEditorViewModel.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Threading.Tasks;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class GaugeEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<GaugeSnapshot, Task> _persistAsync;
+    private readonly GaugeSnapshot _original;
+    private double _value;
+    private double _target;
+    private string _displayValue;
+    private string _summary;
+    private string? _pill;
+
+    public GaugeEditorViewModel(
+        string title,
+        string? subtitle,
+        GaugeSnapshot gauge,
+        Func<GaugeSnapshot, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        _original = gauge;
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+        _value = gauge.Value;
+        _target = gauge.Target;
+        _displayValue = gauge.Metric.Value;
+        _summary = gauge.Metric.Summary;
+        _pill = gauge.Metric.Pill;
+    }
+
+    public double Minimum => _original.Minimum;
+
+    public double Maximum => _original.Maximum;
+
+    public string Unit => _original.Unit;
+
+    public double Value
+    {
+        get => _value;
+        set
+        {
+            if (SetProperty(ref _value, value))
+            {
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public double Target
+    {
+        get => _target;
+        set
+        {
+            if (SetProperty(ref _target, value))
+            {
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public string DisplayValue
+    {
+        get => _displayValue;
+        set
+        {
+            if (SetProperty(ref _displayValue, value ?? string.Empty))
+            {
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public string Summary
+    {
+        get => _summary;
+        set
+        {
+            if (SetProperty(ref _summary, value ?? string.Empty))
+            {
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public string? Pill
+    {
+        get => _pill;
+        set
+        {
+            if (SetProperty(ref _pill, value))
+            {
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    protected override bool CanSave
+    {
+        get
+        {
+            if (double.IsNaN(Value) || double.IsNaN(Target))
+            {
+                return false;
+            }
+
+            if (Value < Minimum || Value > Maximum)
+            {
+                return false;
+            }
+
+            if (Target < Minimum || Target > Maximum)
+            {
+                return false;
+            }
+
+            return !string.IsNullOrWhiteSpace(DisplayValue);
+        }
+    }
+
+    protected override async Task PersistAsync()
+    {
+        var clampedValue = Math.Clamp(Value, Minimum, Maximum);
+        var clampedTarget = Math.Clamp(Target, Minimum, Maximum);
+        var metric = new MetricSnapshot(
+            string.IsNullOrWhiteSpace(DisplayValue) ? $"{clampedValue:0.#}{Unit}" : DisplayValue.Trim(),
+            Summary?.Trim() ?? string.Empty,
+            string.IsNullOrWhiteSpace(Pill) ? null : Pill.Trim());
+
+        var updated = _original with
+        {
+            Value = clampedValue,
+            Target = clampedTarget,
+            Metric = metric
+        };
+
+        await _persistAsync(updated).ConfigureAwait(false);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/ListCardEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/ListCardEditorViewModel.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class ListCardEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<IReadOnlyList<ListEntrySnapshot>, Task> _persistAsync;
+    private readonly RelayCommand _removeSelectedCommand;
+    private readonly RelayCommand _moveUpCommand;
+    private readonly RelayCommand _moveDownCommand;
+    private EditableListItemViewModel? _selectedItem;
+
+    public ListCardEditorViewModel(
+        string title,
+        string? subtitle,
+        IReadOnlyList<ListEntrySnapshot> items,
+        Func<IReadOnlyList<ListEntrySnapshot>, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+        Items = new ObservableCollection<EditableListItemViewModel>(
+            items?.Select(EditableListItemViewModel.FromSnapshot) ?? Enumerable.Empty<EditableListItemViewModel>());
+        Items.CollectionChanged += OnItemsCollectionChanged;
+
+        foreach (var item in Items)
+        {
+            item.PropertyChanged += OnItemPropertyChanged;
+        }
+
+        _removeSelectedCommand = new RelayCommand(_ => RemoveSelected(), _ => SelectedItem is not null);
+        _moveUpCommand = new RelayCommand(_ => MoveSelected(-1), _ => CanMove(-1));
+        _moveDownCommand = new RelayCommand(_ => MoveSelected(1), _ => CanMove(1));
+        AddItemCommand = new RelayCommand(_ => AddItem());
+
+        if (Items.Count > 0)
+        {
+            SelectedItem = Items[0];
+        }
+
+        NotifyCanSaveChanged();
+    }
+
+    public ObservableCollection<EditableListItemViewModel> Items { get; }
+
+    public EditableListItemViewModel? SelectedItem
+    {
+        get => _selectedItem;
+        set
+        {
+            if (SetProperty(ref _selectedItem, value))
+            {
+                _removeSelectedCommand.RaiseCanExecuteChanged();
+                _moveUpCommand.RaiseCanExecuteChanged();
+                _moveDownCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public ICommand AddItemCommand { get; }
+
+    public ICommand RemoveSelectedCommand => _removeSelectedCommand;
+
+    public ICommand MoveUpCommand => _moveUpCommand;
+
+    public ICommand MoveDownCommand => _moveDownCommand;
+
+    protected override bool CanSave => Items.Count > 0 && Items.All(item => !string.IsNullOrWhiteSpace(item.Primary));
+
+    protected override async Task PersistAsync()
+    {
+        var snapshot = Items
+            .Where(item => !string.IsNullOrWhiteSpace(item.Primary))
+            .Select(item => item.ToSnapshot())
+            .ToList();
+
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private void AddItem()
+    {
+        var item = new EditableListItemViewModel(string.Empty, string.Empty, string.Empty, string.Empty);
+        item.PropertyChanged += OnItemPropertyChanged;
+        Items.Add(item);
+        SelectedItem = item;
+        NotifyCanSaveChanged();
+    }
+
+    private void RemoveSelected()
+    {
+        var item = SelectedItem;
+        if (item is null)
+        {
+            return;
+        }
+
+        item.PropertyChanged -= OnItemPropertyChanged;
+        Items.Remove(item);
+        if (Items.Count > 0)
+        {
+            var index = Math.Min(Items.Count - 1, Items.IndexOf(item));
+            SelectedItem = Items[Math.Max(0, index)];
+        }
+        else
+        {
+            SelectedItem = null;
+        }
+
+        NotifyCanSaveChanged();
+    }
+
+    private bool CanMove(int direction)
+    {
+        if (SelectedItem is null)
+        {
+            return false;
+        }
+
+        var index = Items.IndexOf(SelectedItem);
+        if (index < 0)
+        {
+            return false;
+        }
+
+        var target = index + direction;
+        return target >= 0 && target < Items.Count;
+    }
+
+    private void MoveSelected(int direction)
+    {
+        if (SelectedItem is null)
+        {
+            return;
+        }
+
+        var index = Items.IndexOf(SelectedItem);
+        var target = index + direction;
+        if (index < 0 || target < 0 || target >= Items.Count)
+        {
+            return;
+        }
+
+        Items.Move(index, target);
+        SelectedItem = Items[target];
+        NotifyCanSaveChanged();
+    }
+
+    private void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (EditableListItemViewModel oldItem in e.OldItems)
+            {
+                oldItem.PropertyChanged -= OnItemPropertyChanged;
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (EditableListItemViewModel newItem in e.NewItems)
+            {
+                newItem.PropertyChanged += OnItemPropertyChanged;
+            }
+        }
+
+        NotifyCanSaveChanged();
+    }
+
+    private void OnItemPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        NotifyCanSaveChanged();
+    }
+}
+
+public sealed class EditableListItemViewModel : ObservableObject
+{
+    private string _primary;
+    private string? _secondary;
+    private string? _tertiary;
+    private string? _accent;
+
+    public EditableListItemViewModel(string primary, string? secondary, string? tertiary, string? accent)
+    {
+        _primary = primary;
+        _secondary = secondary;
+        _tertiary = tertiary;
+        _accent = accent;
+    }
+
+    public string Primary
+    {
+        get => _primary;
+        set => SetProperty(ref _primary, value);
+    }
+
+    public string? Secondary
+    {
+        get => _secondary;
+        set => SetProperty(ref _secondary, value);
+    }
+
+    public string? Tertiary
+    {
+        get => _tertiary;
+        set => SetProperty(ref _tertiary, value);
+    }
+
+    public string? Accent
+    {
+        get => _accent;
+        set => SetProperty(ref _accent, value);
+    }
+
+    public static EditableListItemViewModel FromSnapshot(ListEntrySnapshot snapshot)
+    {
+        return new EditableListItemViewModel(snapshot.Primary, snapshot.Secondary, snapshot.Tertiary, snapshot.Accent);
+    }
+
+    public ListEntrySnapshot ToSnapshot()
+    {
+        return new ListEntrySnapshot(
+            Primary.Trim(),
+            string.IsNullOrWhiteSpace(Secondary) ? null : Secondary.Trim(),
+            string.IsNullOrWhiteSpace(Tertiary) ? null : Tertiary.Trim(),
+            string.IsNullOrWhiteSpace(Accent) ? null : Accent.Trim());
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/MoraleHeatmapEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/MoraleHeatmapEditorViewModel.cs
@@ -1,0 +1,366 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class MoraleHeatmapEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<MoraleHeatmapSnapshot, Task> _persistAsync;
+    private string? _legendTitle;
+    private string? _legendSubtitle;
+    private string? _validationMessage;
+    private MoraleHeatmapEditorRowViewModel? _selectedRow;
+
+    public MoraleHeatmapEditorViewModel(
+        string title,
+        string? subtitle,
+        MoraleHeatmapSnapshot snapshot,
+        Func<MoraleHeatmapSnapshot, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        Columns = snapshot.Columns is { Count: > 0 }
+            ? new ReadOnlyCollection<string>(snapshot.Columns.ToList())
+            : Array.Empty<string>();
+
+        IntensityOptions = snapshot.Intensities is { Count: > 0 }
+            ? new ReadOnlyCollection<MoraleIntensityOptionViewModel>(
+                snapshot.Intensities.Select(MoraleIntensityOptionViewModel.FromSnapshot).ToList())
+            : Array.Empty<MoraleIntensityOptionViewModel>();
+
+        _legendTitle = snapshot.LegendTitle;
+        _legendSubtitle = snapshot.LegendSubtitle;
+
+        Rows = new ObservableCollection<MoraleHeatmapEditorRowViewModel>(
+            CreateRows(snapshot.Rows));
+
+        foreach (var row in Rows)
+        {
+            AttachRowHandlers(row);
+        }
+
+        if (Rows.Count > 0)
+        {
+            SelectedRow = Rows[0];
+        }
+
+        UpdateValidation();
+    }
+
+    public ObservableCollection<MoraleHeatmapEditorRowViewModel> Rows { get; }
+
+    public IReadOnlyList<string> Columns { get; }
+
+    public IReadOnlyList<MoraleIntensityOptionViewModel> IntensityOptions { get; }
+
+    public MoraleHeatmapEditorRowViewModel? SelectedRow
+    {
+        get => _selectedRow;
+        set => SetProperty(ref _selectedRow, value);
+    }
+
+    public string? LegendTitle
+    {
+        get => _legendTitle;
+        set => SetProperty(ref _legendTitle, value);
+    }
+
+    public string? LegendSubtitle
+    {
+        get => _legendSubtitle;
+        set => SetProperty(ref _legendSubtitle, value);
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                OnPropertyChanged(nameof(HasValidationMessage));
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override bool CanSave => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override async Task PersistAsync()
+    {
+        var rows = Rows.Select(row => row.ToSnapshot()).ToList();
+        var intensities = IntensityOptions.Select(option => option.ToSnapshot()).ToList();
+        var columns = Columns.ToList();
+
+        var snapshot = new MoraleHeatmapSnapshot(
+            columns,
+            rows,
+            intensities,
+            string.IsNullOrWhiteSpace(LegendTitle) ? null : LegendTitle,
+            string.IsNullOrWhiteSpace(LegendSubtitle) ? null : LegendSubtitle);
+
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private IEnumerable<MoraleHeatmapEditorRowViewModel> CreateRows(IReadOnlyList<MoraleHeatmapRowSnapshot>? rows)
+    {
+        if (rows is { Count: > 0 })
+        {
+            foreach (var row in rows)
+            {
+                yield return MoraleHeatmapEditorRowViewModel.FromSnapshot(row, Columns, IntensityOptions);
+            }
+        }
+    }
+
+    private void AttachRowHandlers(MoraleHeatmapEditorRowViewModel row)
+    {
+        row.PropertyChanged += OnRowPropertyChanged;
+        foreach (var cell in row.Cells)
+        {
+            cell.PropertyChanged += OnCellPropertyChanged;
+        }
+    }
+
+    private void OnRowPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        UpdateValidation();
+    }
+
+    private void OnCellPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (string.Equals(e.PropertyName, nameof(MoraleHeatmapEditorCellViewModel.SelectedIntensity), StringComparison.Ordinal) ||
+            string.Equals(e.PropertyName, nameof(MoraleHeatmapEditorCellViewModel.Label), StringComparison.Ordinal) ||
+            string.Equals(e.PropertyName, nameof(MoraleHeatmapEditorCellViewModel.Detail), StringComparison.Ordinal))
+        {
+            UpdateValidation();
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        if (Rows.Count == 0)
+        {
+            ValidationMessage = "No morale units are available to edit.";
+            return;
+        }
+
+        if (Columns.Count == 0)
+        {
+            ValidationMessage = "Define morale columns before editing values.";
+            return;
+        }
+
+        foreach (var row in Rows)
+        {
+            if (string.IsNullOrWhiteSpace(row.Label))
+            {
+                ValidationMessage = "All morale groups require a name.";
+                return;
+            }
+
+            if (row.Cells.Count != Columns.Count)
+            {
+                ValidationMessage = $"{row.Label} is missing entries for one or more morale columns.";
+                return;
+            }
+
+            foreach (var cell in row.Cells)
+            {
+                if (!cell.HasIntensity)
+                {
+                    ValidationMessage = $"Select an intensity for {row.Label} – {cell.Column}.";
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(cell.Label))
+                {
+                    ValidationMessage = $"Provide a label for the {row.Label} – {cell.Column} morale cell.";
+                    return;
+                }
+            }
+        }
+
+        ValidationMessage = null;
+    }
+}
+
+public sealed class MoraleHeatmapEditorRowViewModel : ObservableObject
+{
+    private string _label;
+
+    private MoraleHeatmapEditorRowViewModel(
+        string label,
+        IReadOnlyList<MoraleHeatmapEditorCellViewModel> cells)
+    {
+        _label = label;
+        Cells = new ObservableCollection<MoraleHeatmapEditorCellViewModel>(cells);
+    }
+
+    public ObservableCollection<MoraleHeatmapEditorCellViewModel> Cells { get; }
+
+    public string Label
+    {
+        get => _label;
+        set => SetProperty(ref _label, value);
+    }
+
+    public MoraleHeatmapRowSnapshot ToSnapshot()
+    {
+        return new MoraleHeatmapRowSnapshot(
+            Label,
+            Cells.Select(cell => cell.ToSnapshot()).ToList());
+    }
+
+    public static MoraleHeatmapEditorRowViewModel FromSnapshot(
+        MoraleHeatmapRowSnapshot snapshot,
+        IReadOnlyList<string> columns,
+        IReadOnlyList<MoraleIntensityOptionViewModel> intensities)
+    {
+        var lookup = snapshot.Cells?.ToDictionary(cell => cell.Column, StringComparer.OrdinalIgnoreCase)
+                     ?? new Dictionary<string, MoraleHeatmapCellSnapshot>(StringComparer.OrdinalIgnoreCase);
+
+        var cells = new List<MoraleHeatmapEditorCellViewModel>(columns.Count);
+        foreach (var column in columns)
+        {
+            lookup.TryGetValue(column, out var cell);
+            cells.Add(MoraleHeatmapEditorCellViewModel.FromSnapshot(column, cell, intensities));
+        }
+
+        return new MoraleHeatmapEditorRowViewModel(snapshot.Label, cells);
+    }
+}
+
+public sealed class MoraleHeatmapEditorCellViewModel : ObservableObject
+{
+    private MoraleIntensityOptionViewModel? _selectedIntensity;
+    private string _label;
+    private string? _detail;
+
+    private MoraleHeatmapEditorCellViewModel(
+        string column,
+        string label,
+        string? detail,
+        MoraleIntensityOptionViewModel? selected,
+        IReadOnlyList<MoraleIntensityOptionViewModel> options)
+    {
+        Column = column;
+        _label = label;
+        _detail = detail;
+        _selectedIntensity = selected;
+        IntensityOptions = options;
+    }
+
+    public string Column { get; }
+
+    public IReadOnlyList<MoraleIntensityOptionViewModel> IntensityOptions { get; }
+
+    public string Label
+    {
+        get => _label;
+        set => SetProperty(ref _label, value);
+    }
+
+    public string? Detail
+    {
+        get => _detail;
+        set => SetProperty(ref _detail, value);
+    }
+
+    public MoraleIntensityOptionViewModel? SelectedIntensity
+    {
+        get => _selectedIntensity;
+        set => SetProperty(ref _selectedIntensity, value);
+    }
+
+    public bool HasIntensity => SelectedIntensity is not null;
+
+    public MoraleHeatmapCellSnapshot ToSnapshot()
+    {
+        var key = SelectedIntensity?.Key ?? string.Empty;
+        return new MoraleHeatmapCellSnapshot(
+            Column,
+            key,
+            string.IsNullOrWhiteSpace(Label) ? "—" : Label,
+            string.IsNullOrWhiteSpace(Detail) ? null : Detail);
+    }
+
+    public static MoraleHeatmapEditorCellViewModel FromSnapshot(
+        string column,
+        MoraleHeatmapCellSnapshot? snapshot,
+        IReadOnlyList<MoraleIntensityOptionViewModel> options)
+    {
+        MoraleIntensityOptionViewModel? selected = null;
+
+        if (snapshot is not null && !string.IsNullOrWhiteSpace(snapshot.IntensityKey))
+        {
+            selected = options.FirstOrDefault(option =>
+                string.Equals(option.Key, snapshot.IntensityKey, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return new MoraleHeatmapEditorCellViewModel(
+            column,
+            snapshot?.Label ?? string.Empty,
+            snapshot?.Detail,
+            selected,
+            options);
+    }
+}
+
+public sealed class MoraleIntensityOptionViewModel : ObservableObject
+{
+    private string _displayName;
+    private string _color;
+    private string? _description;
+
+    private MoraleIntensityOptionViewModel(string key, string displayName, string color, string? description)
+    {
+        Key = key;
+        _displayName = displayName;
+        _color = color;
+        _description = description;
+    }
+
+    public string Key { get; }
+
+    public string DisplayName
+    {
+        get => _displayName;
+        set => SetProperty(ref _displayName, value);
+    }
+
+    public string Color
+    {
+        get => _color;
+        set => SetProperty(ref _color, value);
+    }
+
+    public string? Description
+    {
+        get => _description;
+        set => SetProperty(ref _description, value);
+    }
+
+    public MoraleIntensitySnapshot ToSnapshot()
+    {
+        return new MoraleIntensitySnapshot(
+            Key,
+            DisplayName,
+            Color,
+            string.IsNullOrWhiteSpace(Description) ? null : Description);
+    }
+
+    public static MoraleIntensityOptionViewModel FromSnapshot(MoraleIntensitySnapshot snapshot)
+    {
+        return new MoraleIntensityOptionViewModel(snapshot.Key, snapshot.DisplayName, snapshot.Color, snapshot.Description);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/ScoutAssignmentEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/ScoutAssignmentEditorViewModel.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class ScoutAssignmentEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<IReadOnlyList<ScoutAssignmentSnapshot>, Task> _persistAsync;
+    private readonly ReadOnlyCollection<string> _stageOptions;
+    private readonly ReadOnlyCollection<string> _priorityOptions;
+    private readonly ReadOnlyCollection<ScoutAssignmentEditorScoutOptionViewModel> _scoutOptions;
+    private readonly RelayCommand _addAssignmentCommand;
+    private readonly RelayCommand _removeAssignmentCommand;
+    private readonly RelayCommand _moveUpCommand;
+    private readonly RelayCommand _moveDownCommand;
+    private ScoutAssignmentEditorItemViewModel? _selectedAssignment;
+
+    public ScoutAssignmentEditorViewModel(
+        IReadOnlyList<ScoutAssignmentSnapshot>? assignments,
+        IReadOnlyList<ScoutOptionSnapshot>? scoutOptions,
+        IReadOnlyList<string>? stageOptions,
+        IReadOnlyList<string>? priorityOptions,
+        Func<IReadOnlyList<ScoutAssignmentSnapshot>, Task> persistAsync)
+        : base("Manage Scout Assignments", "Reassign coverage and adjust delivery expectations.")
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        _stageOptions = new ReadOnlyCollection<string>((stageOptions ?? Array.Empty<string>())
+            .Where(static option => !string.IsNullOrWhiteSpace(option))
+            .Select(static option => option.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList());
+
+        _priorityOptions = new ReadOnlyCollection<string>((priorityOptions ?? Array.Empty<string>())
+            .Where(static option => !string.IsNullOrWhiteSpace(option))
+            .Select(static option => option.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList());
+
+        var scoutOptionViewModels = (scoutOptions ?? Array.Empty<ScoutOptionSnapshot>())
+            .Where(static option => !string.IsNullOrWhiteSpace(option.Name))
+            .Select(static option => new ScoutAssignmentEditorScoutOptionViewModel(option))
+            .ToList();
+        _scoutOptions = new ReadOnlyCollection<ScoutAssignmentEditorScoutOptionViewModel>(scoutOptionViewModels);
+
+        Assignments = new ObservableCollection<ScoutAssignmentEditorItemViewModel>(
+            assignments?.Select(assignment => ScoutAssignmentEditorItemViewModel.FromSnapshot(
+                assignment,
+                GetDefaultStage(),
+                GetDefaultPriority()))
+            ?? Enumerable.Empty<ScoutAssignmentEditorItemViewModel>());
+        Assignments.CollectionChanged += OnAssignmentsCollectionChanged;
+
+        foreach (var assignment in Assignments)
+        {
+            assignment.PropertyChanged += OnAssignmentPropertyChanged;
+        }
+
+        if (Assignments.Count > 0)
+        {
+            SelectedAssignment = Assignments[0];
+        }
+
+        _addAssignmentCommand = new RelayCommand(_ => AddAssignment());
+        _removeAssignmentCommand = new RelayCommand(_ => RemoveSelected(), _ => SelectedAssignment is not null);
+        _moveUpCommand = new RelayCommand(_ => MoveSelected(-1), _ => CanMove(-1));
+        _moveDownCommand = new RelayCommand(_ => MoveSelected(1), _ => CanMove(1));
+
+        NotifyCanSaveChanged();
+    }
+
+    public ObservableCollection<ScoutAssignmentEditorItemViewModel> Assignments { get; }
+
+    public ScoutAssignmentEditorItemViewModel? SelectedAssignment
+    {
+        get => _selectedAssignment;
+        set
+        {
+            if (SetProperty(ref _selectedAssignment, value))
+            {
+                _removeAssignmentCommand.RaiseCanExecuteChanged();
+                _moveUpCommand.RaiseCanExecuteChanged();
+                _moveDownCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public IReadOnlyList<string> StageOptions => _stageOptions;
+
+    public IReadOnlyList<string> PriorityOptions => _priorityOptions;
+
+    public IReadOnlyList<ScoutAssignmentEditorScoutOptionViewModel> ScoutOptions => _scoutOptions;
+
+    public ICommand AddAssignmentCommand => _addAssignmentCommand;
+
+    public ICommand RemoveAssignmentCommand => _removeAssignmentCommand;
+
+    public ICommand MoveUpCommand => _moveUpCommand;
+
+    public ICommand MoveDownCommand => _moveDownCommand;
+
+    protected override bool CanSave => Assignments.Count > 0 && Assignments.All(static assignment => assignment.IsValid);
+
+    protected override async Task PersistAsync()
+    {
+        var snapshot = Assignments
+            .Select(assignment => assignment.ToSnapshot())
+            .ToList();
+
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private void AddAssignment()
+    {
+        var assignment = new ScoutAssignmentEditorItemViewModel(
+            Guid.NewGuid().ToString("N"),
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            GetDefaultPriority(),
+            GetDefaultStage(),
+            "Due in 4 weeks",
+            _scoutOptions.FirstOrDefault()?.Name ?? string.Empty,
+            string.Empty);
+
+        assignment.PropertyChanged += OnAssignmentPropertyChanged;
+        Assignments.Add(assignment);
+        SelectedAssignment = assignment;
+        NotifyCanSaveChanged();
+    }
+
+    private void RemoveSelected()
+    {
+        var target = SelectedAssignment;
+        if (target is null)
+        {
+            return;
+        }
+
+        target.PropertyChanged -= OnAssignmentPropertyChanged;
+        var index = Assignments.IndexOf(target);
+        Assignments.Remove(target);
+
+        if (Assignments.Count == 0)
+        {
+            SelectedAssignment = null;
+        }
+        else if (index >= Assignments.Count)
+        {
+            SelectedAssignment = Assignments[^1];
+        }
+        else
+        {
+            SelectedAssignment = Assignments[index];
+        }
+
+        NotifyCanSaveChanged();
+    }
+
+    private bool CanMove(int direction)
+    {
+        if (SelectedAssignment is null)
+        {
+            return false;
+        }
+
+        var index = Assignments.IndexOf(SelectedAssignment);
+        var targetIndex = index + direction;
+        return index >= 0 && targetIndex >= 0 && targetIndex < Assignments.Count;
+    }
+
+    private void MoveSelected(int direction)
+    {
+        if (!CanMove(direction))
+        {
+            return;
+        }
+
+        var index = Assignments.IndexOf(SelectedAssignment!);
+        var target = index + direction;
+        Assignments.Move(index, target);
+        SelectedAssignment = Assignments[target];
+    }
+
+    private void OnAssignmentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (ScoutAssignmentEditorItemViewModel assignment in e.OldItems)
+            {
+                assignment.PropertyChanged -= OnAssignmentPropertyChanged;
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (ScoutAssignmentEditorItemViewModel assignment in e.NewItems)
+            {
+                assignment.PropertyChanged += OnAssignmentPropertyChanged;
+            }
+        }
+
+        NotifyCanSaveChanged();
+    }
+
+    private void OnAssignmentPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        NotifyCanSaveChanged();
+    }
+
+    private string GetDefaultStage() => _stageOptions.Count > 0 ? _stageOptions[0] : "In Progress";
+
+    private string GetDefaultPriority() => _priorityOptions.Count > 0 ? _priorityOptions[0] : "Medium";
+}
+
+public sealed class ScoutAssignmentEditorItemViewModel : ObservableObject
+{
+    private string _focus;
+    private string _role;
+    private string _region;
+    private string _priority;
+    private string _stage;
+    private string _deadline;
+    private string _scout;
+    private string? _notes;
+
+    public ScoutAssignmentEditorItemViewModel(
+        string id,
+        string focus,
+        string role,
+        string region,
+        string priority,
+        string stage,
+        string deadline,
+        string scout,
+        string? notes)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        _focus = focus;
+        _role = role;
+        _region = region;
+        _priority = priority;
+        _stage = stage;
+        _deadline = deadline;
+        _scout = scout;
+        _notes = notes;
+    }
+
+    public string Id { get; }
+
+    public string Focus
+    {
+        get => _focus;
+        set => SetProperty(ref _focus, value);
+    }
+
+    public string Role
+    {
+        get => _role;
+        set => SetProperty(ref _role, value);
+    }
+
+    public string Region
+    {
+        get => _region;
+        set => SetProperty(ref _region, value);
+    }
+
+    public string Priority
+    {
+        get => _priority;
+        set => SetProperty(ref _priority, value);
+    }
+
+    public string Stage
+    {
+        get => _stage;
+        set => SetProperty(ref _stage, value);
+    }
+
+    public string Deadline
+    {
+        get => _deadline;
+        set => SetProperty(ref _deadline, value);
+    }
+
+    public string Scout
+    {
+        get => _scout;
+        set => SetProperty(ref _scout, value);
+    }
+
+    public string? Notes
+    {
+        get => _notes;
+        set => SetProperty(ref _notes, value);
+    }
+
+    public bool IsValid => !string.IsNullOrWhiteSpace(Focus)
+        && !string.IsNullOrWhiteSpace(Role)
+        && !string.IsNullOrWhiteSpace(Priority)
+        && !string.IsNullOrWhiteSpace(Stage)
+        && !string.IsNullOrWhiteSpace(Scout)
+        && !string.IsNullOrWhiteSpace(Deadline);
+
+    public ScoutAssignmentSnapshot ToSnapshot()
+    {
+        return new ScoutAssignmentSnapshot(
+            Id,
+            Focus.Trim(),
+            Role.Trim(),
+            Region.Trim(),
+            Priority.Trim(),
+            Stage.Trim(),
+            Deadline.Trim(),
+            Scout.Trim(),
+            string.IsNullOrWhiteSpace(Notes) ? null : Notes.Trim());
+    }
+
+    public static ScoutAssignmentEditorItemViewModel FromSnapshot(
+        ScoutAssignmentSnapshot snapshot,
+        string defaultStage,
+        string defaultPriority)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        return new ScoutAssignmentEditorItemViewModel(
+            snapshot.Id,
+            snapshot.Focus,
+            snapshot.Role,
+            snapshot.Region,
+            string.IsNullOrWhiteSpace(snapshot.Priority) ? defaultPriority : snapshot.Priority,
+            string.IsNullOrWhiteSpace(snapshot.Stage) ? defaultStage : snapshot.Stage,
+            snapshot.Deadline,
+            snapshot.Scout,
+            snapshot.Notes);
+    }
+}
+
+public sealed class ScoutAssignmentEditorScoutOptionViewModel
+{
+    private readonly ScoutOptionSnapshot _snapshot;
+
+    public ScoutAssignmentEditorScoutOptionViewModel(ScoutOptionSnapshot snapshot)
+    {
+        _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+    }
+
+    public string Id => _snapshot.Id;
+
+    public string Name => _snapshot.Name;
+
+    public string Region => _snapshot.Region;
+
+    public string Availability => _snapshot.Availability;
+
+    public string Display => string.IsNullOrWhiteSpace(Availability)
+        ? $"{Name} — {Region}"
+        : $"{Name} — {Region} ({Availability})";
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/ShortlistEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/ShortlistEditorViewModel.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class ShortlistEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<IReadOnlyList<ShortlistPlayerSnapshot>, Task> _persistAsync;
+    private readonly ReadOnlyCollection<string> _statusOptions;
+    private readonly ReadOnlyCollection<string> _actionOptions;
+    private readonly RelayCommand _addPlayerCommand;
+    private readonly RelayCommand _removePlayerCommand;
+    private readonly RelayCommand _moveUpCommand;
+    private readonly RelayCommand _moveDownCommand;
+    private ShortlistEditorItemViewModel? _selectedPlayer;
+
+    public ShortlistEditorViewModel(
+        IReadOnlyList<ShortlistPlayerSnapshot>? players,
+        IReadOnlyList<string>? statusOptions,
+        IReadOnlyList<string>? actionOptions,
+        Func<IReadOnlyList<ShortlistPlayerSnapshot>, Task> persistAsync)
+        : base("Curate Shortlist", "Organise targets, priorities, and next actions for the recruitment team.")
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        _statusOptions = new ReadOnlyCollection<string>((statusOptions ?? Array.Empty<string>())
+            .Where(static option => !string.IsNullOrWhiteSpace(option))
+            .Select(static option => option.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList());
+
+        _actionOptions = new ReadOnlyCollection<string>((actionOptions ?? Array.Empty<string>())
+            .Where(static option => !string.IsNullOrWhiteSpace(option))
+            .Select(static option => option.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList());
+
+        Players = new ObservableCollection<ShortlistEditorItemViewModel>(
+            players?.Select(player => ShortlistEditorItemViewModel.FromSnapshot(
+                player,
+                GetDefaultStatus(),
+                GetDefaultAction()))
+            ?? Enumerable.Empty<ShortlistEditorItemViewModel>());
+
+        Players.CollectionChanged += OnPlayersCollectionChanged;
+
+        foreach (var player in Players)
+        {
+            player.PropertyChanged += OnPlayerPropertyChanged;
+        }
+
+        if (Players.Count > 0)
+        {
+            SelectedPlayer = Players[0];
+        }
+
+        _addPlayerCommand = new RelayCommand(_ => AddPlayer());
+        _removePlayerCommand = new RelayCommand(_ => RemoveSelected(), _ => SelectedPlayer is not null);
+        _moveUpCommand = new RelayCommand(_ => MoveSelected(-1), _ => CanMove(-1));
+        _moveDownCommand = new RelayCommand(_ => MoveSelected(1), _ => CanMove(1));
+
+        NotifyCanSaveChanged();
+    }
+
+    public ObservableCollection<ShortlistEditorItemViewModel> Players { get; }
+
+    public ShortlistEditorItemViewModel? SelectedPlayer
+    {
+        get => _selectedPlayer;
+        set
+        {
+            if (SetProperty(ref _selectedPlayer, value))
+            {
+                _removePlayerCommand.RaiseCanExecuteChanged();
+                _moveUpCommand.RaiseCanExecuteChanged();
+                _moveDownCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public IReadOnlyList<string> StatusOptions => _statusOptions;
+
+    public IReadOnlyList<string> ActionOptions => _actionOptions;
+
+    public ICommand AddPlayerCommand => _addPlayerCommand;
+
+    public ICommand RemovePlayerCommand => _removePlayerCommand;
+
+    public ICommand MoveUpCommand => _moveUpCommand;
+
+    public ICommand MoveDownCommand => _moveDownCommand;
+
+    protected override bool CanSave => Players.Count > 0 && Players.All(static player => player.IsValid);
+
+    protected override async Task PersistAsync()
+    {
+        var snapshot = Players.Select(player => player.ToSnapshot()).ToList();
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private void AddPlayer()
+    {
+        var player = new ShortlistEditorItemViewModel(
+            Guid.NewGuid().ToString("N"),
+            string.Empty,
+            string.Empty,
+            GetDefaultStatus(),
+            GetDefaultAction(),
+            string.Empty,
+            string.Empty);
+
+        player.PropertyChanged += OnPlayerPropertyChanged;
+        Players.Add(player);
+        SelectedPlayer = player;
+        NotifyCanSaveChanged();
+    }
+
+    private void RemoveSelected()
+    {
+        var target = SelectedPlayer;
+        if (target is null)
+        {
+            return;
+        }
+
+        target.PropertyChanged -= OnPlayerPropertyChanged;
+        var index = Players.IndexOf(target);
+        Players.Remove(target);
+
+        if (Players.Count == 0)
+        {
+            SelectedPlayer = null;
+        }
+        else if (index >= Players.Count)
+        {
+            SelectedPlayer = Players[^1];
+        }
+        else
+        {
+            SelectedPlayer = Players[index];
+        }
+
+        NotifyCanSaveChanged();
+    }
+
+    private bool CanMove(int direction)
+    {
+        if (SelectedPlayer is null)
+        {
+            return false;
+        }
+
+        var index = Players.IndexOf(SelectedPlayer);
+        var targetIndex = index + direction;
+        return index >= 0 && targetIndex >= 0 && targetIndex < Players.Count;
+    }
+
+    private void MoveSelected(int direction)
+    {
+        if (!CanMove(direction))
+        {
+            return;
+        }
+
+        var index = Players.IndexOf(SelectedPlayer!);
+        var target = index + direction;
+        Players.Move(index, target);
+        SelectedPlayer = Players[target];
+    }
+
+    private void OnPlayersCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (ShortlistEditorItemViewModel player in e.OldItems)
+            {
+                player.PropertyChanged -= OnPlayerPropertyChanged;
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (ShortlistEditorItemViewModel player in e.NewItems)
+            {
+                player.PropertyChanged += OnPlayerPropertyChanged;
+            }
+        }
+
+        NotifyCanSaveChanged();
+    }
+
+    private void OnPlayerPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        NotifyCanSaveChanged();
+    }
+
+    private string GetDefaultStatus() => _statusOptions.Count > 0 ? _statusOptions[0] : "Monitor";
+
+    private string GetDefaultAction() => _actionOptions.Count > 0 ? _actionOptions[0] : "Hold";
+}
+
+public sealed class ShortlistEditorItemViewModel : ObservableObject
+{
+    private string _name;
+    private string _position;
+    private string _status;
+    private string _action;
+    private string? _priority;
+    private string? _notes;
+
+    public ShortlistEditorItemViewModel(
+        string id,
+        string name,
+        string position,
+        string status,
+        string action,
+        string? priority,
+        string? notes)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        _name = name;
+        _position = position;
+        _status = status;
+        _action = action;
+        _priority = priority;
+        _notes = notes;
+    }
+
+    public string Id { get; }
+
+    public string Name
+    {
+        get => _name;
+        set => SetProperty(ref _name, value);
+    }
+
+    public string Position
+    {
+        get => _position;
+        set => SetProperty(ref _position, value);
+    }
+
+    public string Status
+    {
+        get => _status;
+        set => SetProperty(ref _status, value);
+    }
+
+    public string Action
+    {
+        get => _action;
+        set => SetProperty(ref _action, value);
+    }
+
+    public string? Priority
+    {
+        get => _priority;
+        set => SetProperty(ref _priority, value);
+    }
+
+    public string? Notes
+    {
+        get => _notes;
+        set => SetProperty(ref _notes, value);
+    }
+
+    public bool IsValid => !string.IsNullOrWhiteSpace(Name)
+        && !string.IsNullOrWhiteSpace(Position)
+        && !string.IsNullOrWhiteSpace(Status)
+        && !string.IsNullOrWhiteSpace(Action);
+
+    public ShortlistPlayerSnapshot ToSnapshot()
+    {
+        return new ShortlistPlayerSnapshot(
+            Id,
+            Name.Trim(),
+            Position.Trim(),
+            Status.Trim(),
+            Action.Trim(),
+            string.IsNullOrWhiteSpace(Priority) ? null : Priority.Trim(),
+            string.IsNullOrWhiteSpace(Notes) ? null : Notes.Trim());
+    }
+
+    public static ShortlistEditorItemViewModel FromSnapshot(
+        ShortlistPlayerSnapshot snapshot,
+        string defaultStatus,
+        string defaultAction)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        return new ShortlistEditorItemViewModel(
+            snapshot.Id,
+            snapshot.Name,
+            snapshot.Position,
+            string.IsNullOrWhiteSpace(snapshot.Status) ? defaultStatus : snapshot.Status,
+            string.IsNullOrWhiteSpace(snapshot.Action) ? defaultAction : snapshot.Action,
+            snapshot.Priority,
+            snapshot.Notes);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/TrainingProgressionEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/TrainingProgressionEditorViewModel.cs
@@ -1,0 +1,964 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class TrainingProgressionEditorViewModel : CardEditorViewModel
+{
+    private readonly IClubDataService _clubDataService;
+    private static readonly IReadOnlyList<string> DefaultColourOptions = Array.AsReadOnly(new[]
+    {
+        "#3E8EF7",
+        "#53D769",
+        "#FFB545",
+        "#F95B78",
+        "#8B6CFF",
+        "#40C4FF",
+        "#32C766",
+        "#FF6F61",
+        "#6BD5E1",
+        "#A970FF"
+    });
+
+    private readonly ObservableCollection<string> _periods;
+    private readonly ObservableCollection<TrainingProgressionPeriodEditorViewModel> _periodEntries;
+    private string _metricValue;
+    private string _metricLabel;
+    private string _summary;
+    private double _minimum;
+    private double _maximum;
+    private TrainingProgressionSeriesEditorViewModel? _selectedSeries;
+    private string? _validationMessage;
+    private readonly RelayCommand _removePeriodCommand;
+    private readonly RelayCommand _addPeriodCommand;
+    private bool _synchronisingPeriods;
+
+    public TrainingProgressionEditorViewModel(
+        TrainingProgressionSnapshot snapshot,
+        IClubDataService clubDataService)
+        : base("Adjust Training Progression", "Update development trends, highlights, and scenario ranges.")
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+        _metricValue = snapshot.MetricValue;
+        _metricLabel = snapshot.MetricLabel;
+        _summary = snapshot.Summary;
+        _minimum = snapshot.Minimum;
+        _maximum = snapshot.Maximum;
+        _periods = new ObservableCollection<string>(snapshot.Periods?.ToList() ?? new List<string>());
+        _periodEntries = new ObservableCollection<TrainingProgressionPeriodEditorViewModel>();
+        Periods = new ReadOnlyObservableCollection<string>(_periods);
+        PeriodEntries = new ReadOnlyObservableCollection<TrainingProgressionPeriodEditorViewModel>(_periodEntries);
+        ColourOptions = DefaultColourOptions;
+
+        Series = new ObservableCollection<TrainingProgressionSeriesEditorViewModel>(
+            snapshot.Series?.Select(series => new TrainingProgressionSeriesEditorViewModel(series, OnSeriesChanged, OnSeriesPointsChanged))
+            ?? new List<TrainingProgressionSeriesEditorViewModel>());
+        Series.CollectionChanged += OnSeriesCollectionChanged;
+
+        Highlights = new ObservableCollection<TrainingProgressionHighlightEditorViewModel>(
+            snapshot.Highlights?.Select(item => new TrainingProgressionHighlightEditorViewModel(item, UpdateValidationState))
+            ?? new List<TrainingProgressionHighlightEditorViewModel>());
+        Highlights.CollectionChanged += OnHighlightsCollectionChanged;
+
+        foreach (var series in Series)
+        {
+            series.Points.CollectionChanged += OnPointsCollectionChanged;
+        }
+
+        AddSeriesCommand = new RelayCommand(_ => AddSeries());
+        RemoveSeriesCommand = new RelayCommand(param => RemoveSeries(param as TrainingProgressionSeriesEditorViewModel), param => param is TrainingProgressionSeriesEditorViewModel);
+        AddHighlightCommand = new RelayCommand(_ => AddHighlight());
+        RemoveHighlightCommand = new RelayCommand(param => RemoveHighlight(param as TrainingProgressionHighlightEditorViewModel), param => param is TrainingProgressionHighlightEditorViewModel);
+        _addPeriodCommand = new RelayCommand(_ => AddPeriod());
+        _removePeriodCommand = new RelayCommand(param => RemovePeriod(param as TrainingProgressionPeriodEditorViewModel), param => param is TrainingProgressionPeriodEditorViewModel && CanRemovePeriods);
+
+        SynchronisePeriodEditors();
+        NotifyPeriodStateChanged();
+        UpdateValidationState();
+    }
+
+    public ObservableCollection<TrainingProgressionSeriesEditorViewModel> Series { get; }
+
+    public ObservableCollection<TrainingProgressionHighlightEditorViewModel> Highlights { get; }
+
+    public ReadOnlyObservableCollection<string> Periods { get; }
+
+    public ReadOnlyObservableCollection<TrainingProgressionPeriodEditorViewModel> PeriodEntries { get; }
+
+    public IReadOnlyList<string> ColourOptions { get; }
+
+    public ICommand AddSeriesCommand { get; }
+
+    public ICommand RemoveSeriesCommand { get; }
+
+    public ICommand AddHighlightCommand { get; }
+
+    public ICommand RemoveHighlightCommand { get; }
+
+    public ICommand AddPeriodCommand => _addPeriodCommand;
+
+    public ICommand RemovePeriodCommand => _removePeriodCommand;
+
+    public TrainingProgressionSeriesEditorViewModel? SelectedSeries
+    {
+        get => _selectedSeries;
+        set => SetProperty(ref _selectedSeries, value);
+    }
+
+    public string MetricValue
+    {
+        get => _metricValue;
+        set
+        {
+            if (SetProperty(ref _metricValue, value))
+            {
+                UpdateValidationState();
+            }
+        }
+    }
+
+    public string MetricLabel
+    {
+        get => _metricLabel;
+        set
+        {
+            if (SetProperty(ref _metricLabel, value))
+            {
+                UpdateValidationState();
+            }
+        }
+    }
+
+    public string Summary
+    {
+        get => _summary;
+        set
+        {
+            if (SetProperty(ref _summary, value))
+            {
+                UpdateValidationState();
+            }
+        }
+    }
+
+    public double Minimum
+    {
+        get => _minimum;
+        set
+        {
+            if (SetProperty(ref _minimum, value))
+            {
+                UpdateValidationState();
+            }
+        }
+    }
+
+    public double Maximum
+    {
+        get => _maximum;
+        set
+        {
+            if (SetProperty(ref _maximum, value))
+            {
+                UpdateValidationState();
+            }
+        }
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    protected override bool CanSave => string.IsNullOrEmpty(ValidationMessage);
+
+    protected override async Task PersistAsync()
+    {
+        var progression = new TrainingProgressionSnapshot(
+            MetricValue,
+            MetricLabel,
+            Summary,
+            _periods.ToList(),
+            Minimum,
+            Maximum,
+            Series.Select(series => series.ToSnapshot()).ToList(),
+            Highlights.Select(highlight => highlight.ToSnapshot()).ToList());
+
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var overview = snapshot.Training.Overview with { Progression = progression };
+            var training = snapshot.Training with { Overview = overview };
+            return snapshot with { Training = training };
+        }).ConfigureAwait(false);
+    }
+
+    private void AddSeries()
+    {
+        var newSeries = new TrainingProgressionSeriesEditorViewModel(
+            new TrainingProgressionSeriesSnapshot(
+                Guid.NewGuid().ToString("N"),
+                "New Trajectory",
+                "#3E8EF7",
+                null,
+                false,
+                CreateDefaultPoints()),
+            OnSeriesChanged,
+            OnSeriesPointsChanged);
+
+        newSeries.Points.CollectionChanged += OnPointsCollectionChanged;
+        Series.Add(newSeries);
+        SelectedSeries = newSeries;
+        UpdateValidationState();
+    }
+
+    private void AddPeriod()
+    {
+        var baseLabel = $"Week {_periods.Count + 1}";
+        var label = CreateUniquePeriodName(baseLabel);
+
+        _periods.Add(label);
+        foreach (var series in Series)
+        {
+            series.EnsurePointForPeriod(label, Minimum);
+        }
+
+        SynchronisePeriodEditors();
+        NotifyPeriodStateChanged();
+        UpdateValidationState();
+    }
+
+    private string CreateUniquePeriodName(string baseLabel)
+    {
+        var attempt = 1;
+        var candidate = baseLabel;
+        while (_periods.Any(period => string.Equals(period, candidate, StringComparison.OrdinalIgnoreCase)))
+        {
+            attempt++;
+            candidate = $"{baseLabel} {attempt}";
+        }
+
+        return candidate;
+    }
+
+    private void RemovePeriod(TrainingProgressionPeriodEditorViewModel? period)
+    {
+        if (period is null || _periods.Count <= 1)
+        {
+            return;
+        }
+
+        var index = _periodEntries.IndexOf(period);
+        if (index < 0 || index >= _periods.Count)
+        {
+            return;
+        }
+
+        var removedLabel = _periods[index];
+        _periods.RemoveAt(index);
+
+        foreach (var series in Series)
+        {
+            series.RemovePointsForPeriod(removedLabel);
+        }
+
+        SynchronisePeriodEditors();
+        NotifyPeriodStateChanged();
+        RecalculatePeriods();
+        UpdateValidationState();
+    }
+
+    private IReadOnlyList<TrainingProgressionPointSnapshot> CreateDefaultPoints()
+    {
+        if (_periods.Count == 0)
+        {
+            _periods.Add("Week 1");
+        }
+
+        var snapshots = new List<TrainingProgressionPointSnapshot>();
+        foreach (var period in _periods)
+        {
+            snapshots.Add(new TrainingProgressionPointSnapshot(period, Minimum, null));
+        }
+
+        return snapshots;
+    }
+
+    private void RemoveSeries(TrainingProgressionSeriesEditorViewModel? series)
+    {
+        if (series is null)
+        {
+            return;
+        }
+
+        series.Points.CollectionChanged -= OnPointsCollectionChanged;
+        Series.Remove(series);
+        if (ReferenceEquals(SelectedSeries, series))
+        {
+            SelectedSeries = Series.FirstOrDefault();
+        }
+
+        UpdateValidationState();
+        RecalculatePeriods();
+    }
+
+    private void AddHighlight()
+    {
+        var highlight = new TrainingProgressionHighlightEditorViewModel(new ListEntrySnapshot("New highlight", null, null, null), UpdateValidationState);
+        Highlights.Add(highlight);
+        UpdateValidationState();
+    }
+
+    private void RemoveHighlight(TrainingProgressionHighlightEditorViewModel? highlight)
+    {
+        if (highlight is null)
+        {
+            return;
+        }
+
+        Highlights.Remove(highlight);
+        UpdateValidationState();
+    }
+
+    private void OnSeriesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewItems is not null)
+        {
+            foreach (TrainingProgressionSeriesEditorViewModel series in e.NewItems)
+            {
+                series.Points.CollectionChanged += OnPointsCollectionChanged;
+            }
+        }
+
+        if (e.OldItems is not null)
+        {
+            foreach (TrainingProgressionSeriesEditorViewModel series in e.OldItems)
+            {
+                series.Points.CollectionChanged -= OnPointsCollectionChanged;
+            }
+        }
+
+        UpdateValidationState();
+        RecalculatePeriods();
+    }
+
+    private void OnHighlightsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        UpdateValidationState();
+    }
+
+    private void OnPointsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RecalculatePeriods();
+        UpdateValidationState();
+    }
+
+    private void OnSeriesChanged()
+    {
+        UpdateValidationState();
+    }
+
+    private void OnSeriesPointsChanged()
+    {
+        RecalculatePeriods();
+        UpdateValidationState();
+    }
+
+    private void RecalculatePeriods()
+    {
+        var ordered = new List<string>(_periods);
+        var observed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+
+        foreach (var period in ordered)
+        {
+            if (observed.Add(period))
+            {
+                result.Add(period);
+            }
+        }
+
+        foreach (var point in Series.SelectMany(series => series.Points))
+        {
+            if (string.IsNullOrWhiteSpace(point.Period))
+            {
+                continue;
+            }
+
+            if (observed.Add(point.Period))
+            {
+                result.Add(point.Period);
+            }
+        }
+
+        _periods.Clear();
+        foreach (var period in result)
+        {
+            _periods.Add(period);
+        }
+
+        SynchronisePeriodEditors();
+        NotifyPeriodStateChanged();
+    }
+
+    private void UpdateValidationState()
+    {
+        if (string.IsNullOrWhiteSpace(MetricLabel))
+        {
+            ValidationMessage = "Metric label is required.";
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(MetricValue))
+        {
+            ValidationMessage = "Metric value is required.";
+            return;
+        }
+
+        if (Maximum <= Minimum)
+        {
+            ValidationMessage = "Maximum must be greater than minimum.";
+            return;
+        }
+
+        if (_periods.Count == 0)
+        {
+            ValidationMessage = "At least one timeline period is required.";
+            return;
+        }
+
+        if (_periods.Any(string.IsNullOrWhiteSpace))
+        {
+            ValidationMessage = "Timeline periods cannot be empty.";
+            return;
+        }
+
+        var duplicatePeriod = _periods
+            .GroupBy(period => period, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicatePeriod is not null)
+        {
+            ValidationMessage = $"Timeline period '{duplicatePeriod.Key}' is defined more than once.";
+            return;
+        }
+
+        if (Series.Count == 0)
+        {
+            ValidationMessage = "At least one progression series is required.";
+            return;
+        }
+
+        foreach (var series in Series)
+        {
+            if (string.IsNullOrWhiteSpace(series.Name))
+            {
+                ValidationMessage = "Series names cannot be empty.";
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(series.Color))
+            {
+                ValidationMessage = "Series colours cannot be empty.";
+                return;
+            }
+
+            if (!IsValidHexColour(series.Color))
+            {
+                ValidationMessage = $"Series '{series.Name}' has an invalid colour. Use #RRGGBB or #AARRGGBB.";
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(series.Accent) && !IsValidHexColour(series.Accent))
+            {
+                ValidationMessage = $"Series '{series.Name}' has an invalid accent colour.";
+                return;
+            }
+
+            if (series.Points.Count == 0)
+            {
+                ValidationMessage = $"Series '{series.Name}' must contain at least one data point.";
+                return;
+            }
+
+            foreach (var point in series.Points)
+            {
+                if (string.IsNullOrWhiteSpace(point.Period))
+                {
+                    ValidationMessage = $"Series '{series.Name}' has a point without a period label.";
+                    return;
+                }
+            }
+        }
+
+        ValidationMessage = null;
+    }
+
+    private void SynchronisePeriodEditors()
+    {
+        _synchronisingPeriods = true;
+        try
+        {
+            while (_periodEntries.Count > _periods.Count)
+            {
+                _periodEntries.RemoveAt(_periodEntries.Count - 1);
+            }
+
+            while (_periodEntries.Count < _periods.Count)
+            {
+                var periodViewModel = new TrainingProgressionPeriodEditorViewModel(
+                    _periods[_periodEntries.Count],
+                    OnPeriodRenamed);
+                _periodEntries.Add(periodViewModel);
+            }
+
+            for (var index = 0; index < _periods.Count; index++)
+            {
+                _periodEntries[index].UpdateFromOwner(_periods[index]);
+            }
+        }
+        finally
+        {
+            _synchronisingPeriods = false;
+        }
+    }
+
+    private void OnPeriodRenamed(TrainingProgressionPeriodEditorViewModel period, string previous, string current)
+    {
+        if (_synchronisingPeriods)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(current))
+        {
+            period.UpdateFromOwner(previous);
+            UpdateValidationState();
+            return;
+        }
+
+        var index = _periodEntries.IndexOf(period);
+        if (index < 0)
+        {
+            return;
+        }
+
+        _periods[index] = current;
+
+        foreach (var series in Series)
+        {
+            series.RenamePeriod(previous, current);
+        }
+
+        UpdateValidationState();
+    }
+
+    private void NotifyPeriodStateChanged()
+    {
+        OnPropertyChanged(nameof(CanRemovePeriods));
+        _removePeriodCommand.RaiseCanExecuteChanged();
+    }
+
+    public bool CanRemovePeriods => _periods.Count > 1;
+
+    private static bool IsValidHexColour(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var span = value.AsSpan().Trim();
+        if (span.Length != 7 && span.Length != 9)
+        {
+            return false;
+        }
+
+        if (span[0] != '#')
+        {
+            return false;
+        }
+
+        for (var index = 1; index < span.Length; index++)
+        {
+            if (!Uri.IsHexDigit(span[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+public sealed class TrainingProgressionSeriesEditorViewModel : ObservableObject
+{
+    private readonly Action _requestValidation;
+    private readonly Action _pointsChanged;
+    private readonly RelayCommand _addPointCommand;
+    private readonly RelayCommand _removePointCommand;
+    private string _name;
+    private string _color;
+    private string? _accent;
+    private bool _isHighlighted;
+
+    public TrainingProgressionSeriesEditorViewModel(
+        TrainingProgressionSeriesSnapshot snapshot,
+        Action requestValidation,
+        Action pointsChanged)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        _requestValidation = requestValidation ?? throw new ArgumentNullException(nameof(requestValidation));
+        _pointsChanged = pointsChanged ?? throw new ArgumentNullException(nameof(pointsChanged));
+        Id = snapshot.Id;
+        _name = snapshot.Name;
+        _color = snapshot.Color;
+        _accent = snapshot.Accent;
+        _isHighlighted = snapshot.IsHighlighted;
+        Points = new ObservableCollection<TrainingProgressionPointEditorViewModel>(
+            snapshot.Points?.Select(point => new TrainingProgressionPointEditorViewModel(point, OnPointChanged))
+            ?? new List<TrainingProgressionPointEditorViewModel>());
+        _addPointCommand = new RelayCommand(_ => AddPoint());
+        _removePointCommand = new RelayCommand(param => RemovePoint(param as TrainingProgressionPointEditorViewModel), param => param is TrainingProgressionPointEditorViewModel);
+    }
+
+    public string Id { get; }
+
+    public ObservableCollection<TrainingProgressionPointEditorViewModel> Points { get; }
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            if (SetProperty(ref _name, value))
+            {
+                _requestValidation();
+            }
+        }
+    }
+
+    public string Color
+    {
+        get => _color;
+        set
+        {
+            if (SetProperty(ref _color, value))
+            {
+                _requestValidation();
+            }
+        }
+    }
+
+    public string? Accent
+    {
+        get => _accent;
+        set
+        {
+            if (SetProperty(ref _accent, value))
+            {
+                _requestValidation();
+            }
+        }
+    }
+
+    public bool IsHighlighted
+    {
+        get => _isHighlighted;
+        set
+        {
+            if (SetProperty(ref _isHighlighted, value))
+            {
+                _requestValidation();
+            }
+        }
+    }
+
+    public ICommand AddPointCommand => _addPointCommand;
+
+    public ICommand RemovePointCommand => _removePointCommand;
+
+    public TrainingProgressionSeriesSnapshot ToSnapshot()
+    {
+        return new TrainingProgressionSeriesSnapshot(
+            Id,
+            Name,
+            Color,
+            Accent,
+            IsHighlighted,
+            Points.Select(point => point.ToSnapshot()).ToList());
+    }
+
+    public void EnsurePointForPeriod(string period, double defaultValue)
+    {
+        if (Points.Any(point => string.Equals(point.Period, period, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        Points.Add(new TrainingProgressionPointEditorViewModel(
+            new TrainingProgressionPointSnapshot(period, defaultValue, null),
+            OnPointChanged));
+        _pointsChanged();
+    }
+
+    public void RemovePointsForPeriod(string period)
+    {
+        for (var index = Points.Count - 1; index >= 0; index--)
+        {
+            if (string.Equals(Points[index].Period, period, StringComparison.OrdinalIgnoreCase))
+            {
+                Points.RemoveAt(index);
+            }
+        }
+
+        _pointsChanged();
+    }
+
+    public void RenamePeriod(string previous, string current)
+    {
+        foreach (var point in Points)
+        {
+            if (string.Equals(point.Period, previous, StringComparison.OrdinalIgnoreCase))
+            {
+                point.Period = current;
+            }
+        }
+    }
+
+    private void AddPoint()
+    {
+        var nextIndex = Points.Count + 1;
+        var point = new TrainingProgressionPointEditorViewModel(
+            new TrainingProgressionPointSnapshot($"Week {nextIndex}", 0, null),
+            OnPointChanged);
+        Points.Add(point);
+        _pointsChanged();
+    }
+
+    private void RemovePoint(TrainingProgressionPointEditorViewModel? point)
+    {
+        if (point is null)
+        {
+            return;
+        }
+
+        Points.Remove(point);
+        _pointsChanged();
+    }
+
+    private void OnPointChanged()
+    {
+        _pointsChanged();
+    }
+}
+
+public sealed class TrainingProgressionPeriodEditorViewModel : ObservableObject
+{
+    private readonly Action<TrainingProgressionPeriodEditorViewModel, string, string> _onRenamed;
+    private bool _suppressNotification;
+    private string _name;
+
+    internal TrainingProgressionPeriodEditorViewModel(
+        string name,
+        Action<TrainingProgressionPeriodEditorViewModel, string, string> onRenamed)
+    {
+        _name = name ?? throw new ArgumentNullException(nameof(name));
+        _onRenamed = onRenamed ?? throw new ArgumentNullException(nameof(onRenamed));
+    }
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            var newValue = value ?? string.Empty;
+            if (string.Equals(_name, newValue, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var previous = _name;
+            _name = newValue;
+            OnPropertyChanged();
+
+            if (!_suppressNotification)
+            {
+                _onRenamed(this, previous, newValue);
+            }
+        }
+    }
+
+    internal void UpdateFromOwner(string name)
+    {
+        try
+        {
+            _suppressNotification = true;
+            Name = name;
+        }
+        finally
+        {
+            _suppressNotification = false;
+        }
+    }
+}
+
+public sealed class TrainingProgressionPointEditorViewModel : ObservableObject
+{
+    private readonly Action _onChanged;
+    private string _period;
+    private double _value;
+    private string? _detail;
+
+    public TrainingProgressionPointEditorViewModel(TrainingProgressionPointSnapshot snapshot, Action onChanged)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        _onChanged = onChanged ?? throw new ArgumentNullException(nameof(onChanged));
+        _period = snapshot.Period;
+        _value = snapshot.Value;
+        _detail = snapshot.Detail;
+    }
+
+    public string Period
+    {
+        get => _period;
+        set
+        {
+            if (SetProperty(ref _period, value))
+            {
+                _onChanged();
+            }
+        }
+    }
+
+    public double Value
+    {
+        get => _value;
+        set
+        {
+            if (SetProperty(ref _value, value))
+            {
+                _onChanged();
+            }
+        }
+    }
+
+    public string? Detail
+    {
+        get => _detail;
+        set
+        {
+            if (SetProperty(ref _detail, value))
+            {
+                _onChanged();
+            }
+        }
+    }
+
+    public TrainingProgressionPointSnapshot ToSnapshot()
+    {
+        return new TrainingProgressionPointSnapshot(Period, Value, Detail);
+    }
+}
+
+public sealed class TrainingProgressionHighlightEditorViewModel : ObservableObject
+{
+    private readonly Action _onChanged;
+    private string _primary;
+    private string? _secondary;
+    private string? _tertiary;
+    private string? _accent;
+
+    public TrainingProgressionHighlightEditorViewModel(ListEntrySnapshot snapshot, Action onChanged)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        _onChanged = onChanged ?? throw new ArgumentNullException(nameof(onChanged));
+        _primary = snapshot.Primary;
+        _secondary = snapshot.Secondary;
+        _tertiary = snapshot.Tertiary;
+        _accent = snapshot.Accent;
+    }
+
+    public string Primary
+    {
+        get => _primary;
+        set
+        {
+            if (SetProperty(ref _primary, value))
+            {
+                _onChanged();
+            }
+        }
+    }
+
+    public string? Secondary
+    {
+        get => _secondary;
+        set
+        {
+            if (SetProperty(ref _secondary, value))
+            {
+                _onChanged();
+            }
+        }
+    }
+
+    public string? Tertiary
+    {
+        get => _tertiary;
+        set
+        {
+            if (SetProperty(ref _tertiary, value))
+            {
+                _onChanged();
+            }
+        }
+    }
+
+    public string? Accent
+    {
+        get => _accent;
+        set
+        {
+            if (SetProperty(ref _accent, value))
+            {
+                _onChanged();
+            }
+        }
+    }
+
+    public ListEntrySnapshot ToSnapshot()
+    {
+        return new ListEntrySnapshot(Primary, Secondary, Tertiary, Accent);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/TrainingSessionEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/TrainingSessionEditorViewModel.cs
@@ -1,0 +1,374 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class TrainingSessionEditorViewModel : CardEditorViewModel
+{
+    private static readonly string[] DefaultDays =
+    {
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+    };
+
+    private static readonly string[] DefaultSlots =
+    {
+        "Morning",
+        "Afternoon",
+        "Evening"
+    };
+
+    private readonly Func<IReadOnlyList<TrainingSessionDetailSnapshot>, Task> _persistAsync;
+    private readonly RelayCommand _removeSessionCommand;
+    private readonly RelayCommand _moveUpCommand;
+    private readonly RelayCommand _moveDownCommand;
+    private TrainingSessionEditorItemViewModel? _selectedSession;
+    private string? _validationMessage;
+
+    public TrainingSessionEditorViewModel(
+        string title,
+        string? subtitle,
+        IReadOnlyList<TrainingSessionDetailSnapshot>? sessions,
+        Func<IReadOnlyList<TrainingSessionDetailSnapshot>, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        Sessions = new ObservableCollection<TrainingSessionEditorItemViewModel>(
+            sessions?.Select(TrainingSessionEditorItemViewModel.FromSnapshot)
+            ?? Enumerable.Empty<TrainingSessionEditorItemViewModel>());
+        Sessions.CollectionChanged += OnSessionsCollectionChanged;
+
+        foreach (var session in Sessions)
+        {
+            session.PropertyChanged += OnSessionPropertyChanged;
+        }
+
+        DayOptions = Array.AsReadOnly(DefaultDays);
+        SlotOptions = Array.AsReadOnly(DefaultSlots);
+
+        _removeSessionCommand = new RelayCommand(_ => RemoveSelectedSession(), _ => SelectedSession is not null);
+        _moveUpCommand = new RelayCommand(_ => MoveSelected(-1), _ => CanMove(-1));
+        _moveDownCommand = new RelayCommand(_ => MoveSelected(1), _ => CanMove(1));
+        AddSessionCommand = new RelayCommand(_ => AddSession());
+
+        if (Sessions.Count > 0)
+        {
+            SelectedSession = Sessions[0];
+        }
+
+        UpdateValidation();
+    }
+
+    public ObservableCollection<TrainingSessionEditorItemViewModel> Sessions { get; }
+
+    public IReadOnlyList<string> DayOptions { get; }
+
+    public IReadOnlyList<string> SlotOptions { get; }
+
+    public TrainingSessionEditorItemViewModel? SelectedSession
+    {
+        get => _selectedSession;
+        set
+        {
+            if (SetProperty(ref _selectedSession, value))
+            {
+                _removeSessionCommand.RaiseCanExecuteChanged();
+                _moveUpCommand.RaiseCanExecuteChanged();
+                _moveDownCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public ICommand AddSessionCommand { get; }
+
+    public ICommand RemoveSessionCommand => _removeSessionCommand;
+
+    public ICommand MoveUpCommand => _moveUpCommand;
+
+    public ICommand MoveDownCommand => _moveDownCommand;
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                OnPropertyChanged(nameof(HasValidationMessage));
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override bool CanSave => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override async Task PersistAsync()
+    {
+        var snapshot = Sessions
+            .Select(session => session.ToSnapshot())
+            .ToList();
+
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private void AddSession()
+    {
+        var baseDay = SelectedSession?.Day;
+        var day = !string.IsNullOrWhiteSpace(baseDay) ? baseDay! : DayOptions[0];
+        var slot = GetAvailableSlot(day) ?? SlotOptions[0];
+
+        var session = new TrainingSessionEditorItemViewModel(
+            Guid.NewGuid().ToString("N"),
+            day,
+            slot,
+            string.Empty,
+            string.Empty,
+            string.Empty);
+
+        session.PropertyChanged += OnSessionPropertyChanged;
+        Sessions.Add(session);
+        SelectedSession = session;
+        UpdateValidation();
+    }
+
+    private void RemoveSelectedSession()
+    {
+        var session = SelectedSession;
+        if (session is null)
+        {
+            return;
+        }
+
+        session.PropertyChanged -= OnSessionPropertyChanged;
+        var index = Sessions.IndexOf(session);
+        Sessions.Remove(session);
+
+        if (Sessions.Count > 0)
+        {
+            var target = Math.Clamp(index, 0, Sessions.Count - 1);
+            SelectedSession = Sessions[target];
+        }
+        else
+        {
+            SelectedSession = null;
+        }
+
+        UpdateValidation();
+    }
+
+    private bool CanMove(int direction)
+    {
+        if (SelectedSession is null)
+        {
+            return false;
+        }
+
+        var index = Sessions.IndexOf(SelectedSession);
+        if (index < 0)
+        {
+            return false;
+        }
+
+        var target = index + direction;
+        return target >= 0 && target < Sessions.Count;
+    }
+
+    private void MoveSelected(int direction)
+    {
+        if (SelectedSession is null)
+        {
+            return;
+        }
+
+        var index = Sessions.IndexOf(SelectedSession);
+        var target = index + direction;
+        if (index < 0 || target < 0 || target >= Sessions.Count)
+        {
+            return;
+        }
+
+        Sessions.Move(index, target);
+        SelectedSession = Sessions[target];
+        UpdateValidation();
+    }
+
+    private void OnSessionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (TrainingSessionEditorItemViewModel item in e.OldItems)
+            {
+                item.PropertyChanged -= OnSessionPropertyChanged;
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (TrainingSessionEditorItemViewModel item in e.NewItems)
+            {
+                item.PropertyChanged += OnSessionPropertyChanged;
+            }
+        }
+
+        UpdateValidation();
+    }
+
+    private void OnSessionPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        UpdateValidation();
+    }
+
+    private void UpdateValidation()
+    {
+        if (Sessions.Count == 0)
+        {
+            ValidationMessage = "Add at least one training session before saving.";
+            NotifyCanSaveChanged();
+            return;
+        }
+
+        if (Sessions.Any(session => string.IsNullOrWhiteSpace(session.Day) || string.IsNullOrWhiteSpace(session.Slot)))
+        {
+            ValidationMessage = "Assign a day and slot to every session.";
+            NotifyCanSaveChanged();
+            return;
+        }
+
+        if (Sessions.Any(session => string.IsNullOrWhiteSpace(session.Activity)))
+        {
+            ValidationMessage = "Provide an activity for every session.";
+            NotifyCanSaveChanged();
+            return;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var session in Sessions)
+        {
+            var key = $"{session.Day.Trim()}::{session.Slot.Trim()}";
+            if (!seen.Add(key))
+            {
+                ValidationMessage = "Each day and slot combination can only be scheduled once.";
+                NotifyCanSaveChanged();
+                return;
+            }
+        }
+
+        ValidationMessage = null;
+        NotifyCanSaveChanged();
+    }
+
+    private string? GetAvailableSlot(string day)
+    {
+        foreach (var slot in SlotOptions)
+        {
+            var exists = Sessions.Any(session =>
+                string.Equals(session.Day, day, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(session.Slot, slot, StringComparison.OrdinalIgnoreCase));
+
+            if (!exists)
+            {
+                return slot;
+            }
+        }
+
+        return null;
+    }
+}
+
+public sealed class TrainingSessionEditorItemViewModel : ObservableObject
+{
+    private string _day;
+    private string _slot;
+    private string _activity;
+    private string? _focus;
+    private string? _intensity;
+
+    public TrainingSessionEditorItemViewModel(
+        string id,
+        string day,
+        string slot,
+        string activity,
+        string? focus,
+        string? intensity)
+    {
+        Id = id ?? throw new ArgumentNullException(nameof(id));
+        _day = day ?? string.Empty;
+        _slot = slot ?? string.Empty;
+        _activity = activity ?? string.Empty;
+        _focus = focus;
+        _intensity = intensity;
+    }
+
+    public string Id { get; }
+
+    public string Day
+    {
+        get => _day;
+        set => SetProperty(ref _day, value);
+    }
+
+    public string Slot
+    {
+        get => _slot;
+        set => SetProperty(ref _slot, value);
+    }
+
+    public string Activity
+    {
+        get => _activity;
+        set => SetProperty(ref _activity, value);
+    }
+
+    public string? Focus
+    {
+        get => _focus;
+        set => SetProperty(ref _focus, value);
+    }
+
+    public string? Intensity
+    {
+        get => _intensity;
+        set => SetProperty(ref _intensity, value);
+    }
+
+    public static TrainingSessionEditorItemViewModel FromSnapshot(TrainingSessionDetailSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        return new TrainingSessionEditorItemViewModel(
+            snapshot.Id,
+            snapshot.Day,
+            snapshot.Slot,
+            snapshot.Activity,
+            snapshot.Focus,
+            snapshot.Intensity);
+    }
+
+    public TrainingSessionDetailSnapshot ToSnapshot()
+    {
+        return new TrainingSessionDetailSnapshot(
+            Id,
+            Day,
+            Slot,
+            Activity,
+            string.IsNullOrWhiteSpace(Focus) ? null : Focus,
+            string.IsNullOrWhiteSpace(Intensity) ? null : Intensity);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/TrainingUnitBoardEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/TrainingUnitBoardEditorViewModel.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class TrainingUnitBoardEditorViewModel : CardEditorViewModel
+{
+    private const string AvailableUnitId = "available";
+
+    private readonly Func<TrainingUnitsBoardSnapshot, Task> _persistAsync;
+    private readonly ObservableCollection<TrainingUnitAssignmentRowViewModel> _players;
+    private readonly ObservableCollection<TrainingUnitCoachAssignmentViewModel> _units;
+    private string? _validationMessage;
+    private TrainingUnitAssignmentRowViewModel? _selectedPlayer;
+
+    public TrainingUnitBoardEditorViewModel(
+        string title,
+        string? subtitle,
+        TrainingUnitsBoardSnapshot board,
+        Func<TrainingUnitsBoardSnapshot, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        if (board is null)
+        {
+            throw new ArgumentNullException(nameof(board));
+        }
+
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        var unitOptions = board.Units
+            .Select(unit => new TrainingUnitUnitOption(unit.Id, unit.Name))
+            .ToList();
+        unitOptions.Add(new TrainingUnitUnitOption(AvailableUnitId, "Available Pool"));
+        UnitOptions = new ReadOnlyCollection<TrainingUnitUnitOption>(unitOptions);
+
+        _units = new ObservableCollection<TrainingUnitCoachAssignmentViewModel>(
+            board.Units.Select(TrainingUnitCoachAssignmentViewModel.FromSnapshot));
+        Units = new ReadOnlyCollection<TrainingUnitCoachAssignmentViewModel>(_units);
+
+        foreach (var unit in _units)
+        {
+            unit.PropertyChanged += OnUnitPropertyChanged;
+        }
+
+        var playerRows = new List<TrainingUnitAssignmentRowViewModel>();
+        foreach (var unit in board.Units)
+        {
+            foreach (var member in unit.Members)
+            {
+                var row = TrainingUnitAssignmentRowViewModel.FromSnapshot(
+                    member,
+                    unit.Id,
+                    UnitOptions);
+                row.PropertyChanged += OnPlayerPropertyChanged;
+                playerRows.Add(row);
+            }
+        }
+
+        foreach (var member in board.AvailablePlayers)
+        {
+            var row = TrainingUnitAssignmentRowViewModel.FromSnapshot(
+                member,
+                AvailableUnitId,
+                UnitOptions);
+            row.PropertyChanged += OnPlayerPropertyChanged;
+            playerRows.Add(row);
+        }
+
+        _players = new ObservableCollection<TrainingUnitAssignmentRowViewModel>(playerRows.OrderBy(p => p.Name));
+        Players = new ReadOnlyCollection<TrainingUnitAssignmentRowViewModel>(_players);
+
+        if (_players.Count > 0)
+        {
+            SelectedPlayer = _players[0];
+        }
+
+        UpdateValidation();
+    }
+
+    public IReadOnlyList<TrainingUnitCoachAssignmentViewModel> Units { get; }
+
+    public IReadOnlyList<TrainingUnitAssignmentRowViewModel> Players { get; }
+
+    public IReadOnlyList<TrainingUnitUnitOption> UnitOptions { get; }
+
+    public TrainingUnitAssignmentRowViewModel? SelectedPlayer
+    {
+        get => _selectedPlayer;
+        set => SetProperty(ref _selectedPlayer, value);
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                OnPropertyChanged(nameof(HasValidationMessage));
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override bool CanSave => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override async Task PersistAsync()
+    {
+        var grouped = _players
+            .GroupBy(player => player.SelectedUnitId)
+            .ToDictionary(group => group.Key ?? AvailableUnitId, group => group.ToList());
+
+        var updatedUnits = new List<TrainingUnitGroupSnapshot>(_units.Count);
+        foreach (var unit in _units)
+        {
+            var members = grouped.TryGetValue(unit.Id, out var assigned)
+                ? assigned
+                    .Select(row => row.ToSnapshot())
+                    .ToList()
+                : new List<TrainingUnitMemberSnapshot>();
+
+            var snapshot = unit.ToSnapshot(members);
+            updatedUnits.Add(snapshot);
+        }
+
+        var availablePlayers = grouped.TryGetValue(AvailableUnitId, out var available)
+            ? available.Select(row => row.ToSnapshot()).ToList()
+            : new List<TrainingUnitMemberSnapshot>();
+
+        var board = new TrainingUnitsBoardSnapshot(updatedUnits, availablePlayers);
+        await _persistAsync(board).ConfigureAwait(false);
+    }
+
+    private void OnPlayerPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(TrainingUnitAssignmentRowViewModel.SelectedUnitId))
+        {
+            UpdateValidation();
+        }
+    }
+
+    private void OnUnitPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(TrainingUnitCoachAssignmentViewModel.SelectedCoachId))
+        {
+            UpdateValidation();
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        if (_players.Any(player => string.IsNullOrWhiteSpace(player.SelectedUnitId)))
+        {
+            ValidationMessage = "Assign every player to a unit before saving.";
+            return;
+        }
+
+        ValidationMessage = null;
+    }
+}
+
+public sealed class TrainingUnitCoachAssignmentViewModel : ObservableObject
+{
+    private string? _selectedCoachId;
+
+    private TrainingUnitCoachAssignmentViewModel(
+        string id,
+        string name,
+        string? coachId,
+        IReadOnlyList<TrainingUnitCoachSnapshot> coachOptions)
+    {
+        Id = id;
+        Name = name;
+        _selectedCoachId = coachId;
+        CoachOptions = new ReadOnlyCollection<TrainingUnitCoachSnapshot>(coachOptions);
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public IReadOnlyList<TrainingUnitCoachSnapshot> CoachOptions { get; }
+
+    public string? SelectedCoachId
+    {
+        get => _selectedCoachId;
+        set => SetProperty(ref _selectedCoachId, value);
+    }
+
+    public static TrainingUnitCoachAssignmentViewModel FromSnapshot(TrainingUnitGroupSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        return new TrainingUnitCoachAssignmentViewModel(
+            snapshot.Id,
+            snapshot.Name,
+            snapshot.CoachId,
+            snapshot.CoachOptions);
+    }
+
+    public TrainingUnitGroupSnapshot ToSnapshot(IReadOnlyList<TrainingUnitMemberSnapshot> members)
+    {
+        return new TrainingUnitGroupSnapshot(
+            Id,
+            Name,
+            SelectedCoachId,
+            CoachOptions,
+            members);
+    }
+}
+
+public sealed class TrainingUnitAssignmentRowViewModel : ObservableObject
+{
+    private string? _selectedUnitId;
+
+    private TrainingUnitAssignmentRowViewModel(
+        string id,
+        string name,
+        string position,
+        string role,
+        string status,
+        string? accent,
+        string? detail,
+        string? unitId,
+        IReadOnlyList<TrainingUnitUnitOption> unitOptions)
+    {
+        Id = id;
+        Name = name;
+        Position = position;
+        Role = role;
+        Status = status;
+        Accent = accent;
+        Detail = detail;
+        UnitOptions = unitOptions;
+        _selectedUnitId = unitId;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string Position { get; }
+
+    public string Role { get; }
+
+    public string Status { get; }
+
+    public string? Accent { get; }
+
+    public string? Detail { get; }
+
+    public IReadOnlyList<TrainingUnitUnitOption> UnitOptions { get; }
+
+    public string? SelectedUnitId
+    {
+        get => _selectedUnitId;
+        set => SetProperty(ref _selectedUnitId, value);
+    }
+
+    public static TrainingUnitAssignmentRowViewModel FromSnapshot(
+        TrainingUnitMemberSnapshot snapshot,
+        string? unitId,
+        IReadOnlyList<TrainingUnitUnitOption> unitOptions)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        return new TrainingUnitAssignmentRowViewModel(
+            snapshot.Id,
+            snapshot.Name,
+            snapshot.Position,
+            snapshot.Role,
+            snapshot.Status,
+            snapshot.Accent,
+            snapshot.Detail,
+            unitId,
+            unitOptions);
+    }
+
+    public TrainingUnitMemberSnapshot ToSnapshot()
+    {
+        return new TrainingUnitMemberSnapshot(
+            Id,
+            Name,
+            Position,
+            Role,
+            Status,
+            Accent,
+            Detail);
+    }
+}
+
+public sealed record TrainingUnitUnitOption(string Id, string Name);

--- a/WPF/FMUI.Wpf/ViewModels/Editors/TrainingWorkloadEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/TrainingWorkloadEditorViewModel.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class TrainingWorkloadEditorViewModel : CardEditorViewModel
+{
+    private readonly Func<TrainingWorkloadHeatmapSnapshot, Task> _persistAsync;
+    private string? _legendTitle;
+    private string? _legendSubtitle;
+    private string? _validationMessage;
+    private TrainingWorkloadEditorRowViewModel? _selectedRow;
+
+    public TrainingWorkloadEditorViewModel(
+        string title,
+        string? subtitle,
+        TrainingWorkloadHeatmapSnapshot? snapshot,
+        Func<TrainingWorkloadHeatmapSnapshot, Task> persistAsync)
+        : base(title, subtitle)
+    {
+        _persistAsync = persistAsync ?? throw new ArgumentNullException(nameof(persistAsync));
+
+        Columns = snapshot?.Columns is { Count: > 0 }
+            ? new ReadOnlyCollection<string>(snapshot.Columns.ToList())
+            : Array.Empty<string>();
+
+        IntensityOptions = snapshot?.Intensities is { Count: > 0 }
+            ? new ReadOnlyCollection<TrainingIntensityLevelOptionViewModel>(
+                snapshot.Intensities.Select(TrainingIntensityLevelOptionViewModel.FromSnapshot).ToList())
+            : Array.Empty<TrainingIntensityLevelOptionViewModel>();
+
+        _legendTitle = snapshot?.LegendTitle;
+        _legendSubtitle = snapshot?.LegendSubtitle;
+
+        Rows = new ObservableCollection<TrainingWorkloadEditorRowViewModel>(
+            CreateRows(snapshot?.Units));
+
+        foreach (var row in Rows)
+        {
+            AttachRowHandlers(row);
+        }
+
+        if (Rows.Count > 0)
+        {
+            SelectedRow = Rows[0];
+        }
+
+        UpdateValidation();
+    }
+
+    public ObservableCollection<TrainingWorkloadEditorRowViewModel> Rows { get; }
+
+    public IReadOnlyList<string> Columns { get; }
+
+    public IReadOnlyList<TrainingIntensityLevelOptionViewModel> IntensityOptions { get; }
+
+    public TrainingWorkloadEditorRowViewModel? SelectedRow
+    {
+        get => _selectedRow;
+        set => SetProperty(ref _selectedRow, value);
+    }
+
+    public double MinimumLoad => 0;
+
+    public double MaximumLoad => 120;
+
+    public double LoadStep => 5;
+
+    public string? LegendTitle
+    {
+        get => _legendTitle;
+        set => SetProperty(ref _legendTitle, value);
+    }
+
+    public string? LegendSubtitle
+    {
+        get => _legendSubtitle;
+        set => SetProperty(ref _legendSubtitle, value);
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                OnPropertyChanged(nameof(HasValidationMessage));
+                NotifyCanSaveChanged();
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override bool CanSave => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    protected override async Task PersistAsync()
+    {
+        var rows = Rows.Select(row => row.ToSnapshot()).ToList();
+        var intensities = IntensityOptions.Select(option => option.ToSnapshot()).ToList();
+        var columns = Columns.ToList();
+
+        var snapshot = new TrainingWorkloadHeatmapSnapshot(
+            columns,
+            rows,
+            intensities,
+            string.IsNullOrWhiteSpace(LegendTitle) ? null : LegendTitle,
+            string.IsNullOrWhiteSpace(LegendSubtitle) ? null : LegendSubtitle);
+
+        await _persistAsync(snapshot).ConfigureAwait(false);
+    }
+
+    private IEnumerable<TrainingWorkloadEditorRowViewModel> CreateRows(IReadOnlyList<TrainingWorkloadUnitSnapshot>? units)
+    {
+        if (units is { Count: > 0 })
+        {
+            foreach (var unit in units)
+            {
+                yield return TrainingWorkloadEditorRowViewModel.FromSnapshot(unit, Columns, IntensityOptions);
+            }
+        }
+    }
+
+    private void AttachRowHandlers(TrainingWorkloadEditorRowViewModel row)
+    {
+        row.PropertyChanged += OnRowPropertyChanged;
+        foreach (var cell in row.Cells)
+        {
+            cell.PropertyChanged += OnCellPropertyChanged;
+        }
+    }
+
+    private void DetachRowHandlers(TrainingWorkloadEditorRowViewModel row)
+    {
+        row.PropertyChanged -= OnRowPropertyChanged;
+        foreach (var cell in row.Cells)
+        {
+            cell.PropertyChanged -= OnCellPropertyChanged;
+        }
+    }
+
+    private void OnRowPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        UpdateValidation();
+    }
+
+    private void OnCellPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (string.Equals(e.PropertyName, nameof(TrainingWorkloadEditorCellViewModel.SelectedIntensity), StringComparison.Ordinal) ||
+            string.Equals(e.PropertyName, nameof(TrainingWorkloadEditorCellViewModel.Load), StringComparison.Ordinal) ||
+            string.Equals(e.PropertyName, nameof(TrainingWorkloadEditorCellViewModel.Detail), StringComparison.Ordinal))
+        {
+            UpdateValidation();
+        }
+    }
+
+    private void UpdateValidation()
+    {
+        if (Rows.Count == 0)
+        {
+            ValidationMessage = "No training units are available to edit.";
+            return;
+        }
+
+        if (Columns.Count == 0)
+        {
+            ValidationMessage = "Define schedule columns before editing workload.";
+            return;
+        }
+
+        foreach (var row in Rows)
+        {
+            if (string.IsNullOrWhiteSpace(row.Label))
+            {
+                ValidationMessage = "All training units require a name.";
+                return;
+            }
+
+            if (row.Cells.Count != Columns.Count)
+            {
+                ValidationMessage = $"{row.Label} is missing workload entries for one or more slots.";
+                return;
+            }
+
+            foreach (var cell in row.Cells)
+            {
+                if (!cell.HasIntensity)
+                {
+                    ValidationMessage = $"Select an intensity for {row.Label} – {cell.Column}.";
+                    return;
+                }
+
+                if (cell.Load < MinimumLoad || cell.Load > MaximumLoad)
+                {
+                    ValidationMessage = $"{row.Label} – {cell.Column} load must be between {MinimumLoad:0} and {MaximumLoad:0}.";
+                    return;
+                }
+            }
+        }
+
+        ValidationMessage = null;
+    }
+}
+
+public sealed class TrainingWorkloadEditorRowViewModel : ObservableObject
+{
+    private string _label;
+
+    private TrainingWorkloadEditorRowViewModel(
+        string label,
+        IReadOnlyList<TrainingWorkloadEditorCellViewModel> cells)
+    {
+        _label = label;
+        Cells = new ObservableCollection<TrainingWorkloadEditorCellViewModel>(cells);
+    }
+
+    public ObservableCollection<TrainingWorkloadEditorCellViewModel> Cells { get; }
+
+    public string Label
+    {
+        get => _label;
+        set => SetProperty(ref _label, value);
+    }
+
+    public static TrainingWorkloadEditorRowViewModel FromSnapshot(
+        TrainingWorkloadUnitSnapshot snapshot,
+        IReadOnlyList<string> columns,
+        IReadOnlyList<TrainingIntensityLevelOptionViewModel> intensityOptions)
+    {
+        var lookup = snapshot.Cells?.ToDictionary(cell => cell.Column, StringComparer.OrdinalIgnoreCase)
+                     ?? new Dictionary<string, TrainingWorkloadCellSnapshot>(StringComparer.OrdinalIgnoreCase);
+
+        var cells = new List<TrainingWorkloadEditorCellViewModel>(columns.Count);
+        foreach (var column in columns)
+        {
+            lookup.TryGetValue(column, out var cellSnapshot);
+            cells.Add(new TrainingWorkloadEditorCellViewModel(column, cellSnapshot, intensityOptions));
+        }
+
+        return new TrainingWorkloadEditorRowViewModel(snapshot.Label, cells);
+    }
+
+    public TrainingWorkloadUnitSnapshot ToSnapshot()
+    {
+        var cells = Cells.Select(cell => cell.ToSnapshot()).ToList();
+        return new TrainingWorkloadUnitSnapshot(Label, cells);
+    }
+}
+
+public sealed class TrainingWorkloadEditorCellViewModel : ObservableObject
+{
+    private TrainingIntensityLevelOptionViewModel? _selectedIntensity;
+    private double _load;
+    private string? _detail;
+
+    public TrainingWorkloadEditorCellViewModel(
+        string column,
+        TrainingWorkloadCellSnapshot? snapshot,
+        IReadOnlyList<TrainingIntensityLevelOptionViewModel> options)
+    {
+        Column = column;
+        IntensityOptions = options;
+
+        if (snapshot is not null)
+        {
+            _selectedIntensity = options.FirstOrDefault(option => option.Matches(snapshot.IntensityKey));
+            _load = snapshot.Load;
+            _detail = snapshot.Detail;
+        }
+        else if (options.Count > 0)
+        {
+            _selectedIntensity = options[0];
+            _load = options[0].LoadValue;
+        }
+    }
+
+    public string Column { get; }
+
+    public IReadOnlyList<TrainingIntensityLevelOptionViewModel> IntensityOptions { get; }
+
+    public TrainingIntensityLevelOptionViewModel? SelectedIntensity
+    {
+        get => _selectedIntensity;
+        set
+        {
+            if (SetProperty(ref _selectedIntensity, value))
+            {
+                OnPropertyChanged(nameof(HasIntensity));
+            }
+        }
+    }
+
+    public bool HasIntensity => SelectedIntensity is not null;
+
+    public double Load
+    {
+        get => _load;
+        set => SetProperty(ref _load, value);
+    }
+
+    public string? Detail
+    {
+        get => _detail;
+        set => SetProperty(ref _detail, value);
+    }
+
+    public TrainingWorkloadCellSnapshot ToSnapshot()
+    {
+        var intensityKey = SelectedIntensity?.Key ?? string.Empty;
+        var detail = string.IsNullOrWhiteSpace(Detail) ? null : Detail;
+        return new TrainingWorkloadCellSnapshot(Column, intensityKey, Load, detail);
+    }
+}
+
+public sealed class TrainingIntensityLevelOptionViewModel
+{
+    private readonly TrainingIntensityLevelSnapshot _snapshot;
+
+    private TrainingIntensityLevelOptionViewModel(TrainingIntensityLevelSnapshot snapshot)
+    {
+        _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+    }
+
+    public string Key => _snapshot.Key;
+
+    public string DisplayName => _snapshot.DisplayName;
+
+    public string Color => _snapshot.Color;
+
+    public double LoadValue => _snapshot.LoadValue;
+
+    public bool Matches(string? key) => string.Equals(Key, key, StringComparison.OrdinalIgnoreCase);
+
+    public TrainingIntensityLevelSnapshot ToSnapshot() => new(Key, DisplayName, Color, LoadValue);
+
+    public static TrainingIntensityLevelOptionViewModel FromSnapshot(TrainingIntensityLevelSnapshot snapshot) => new(snapshot);
+}

--- a/WPF/FMUI.Wpf/ViewModels/Editors/TransferNegotiationEditorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/Editors/TransferNegotiationEditorViewModel.cs
@@ -1,0 +1,919 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels.Editors;
+
+public sealed class TransferNegotiationEditorViewModel : CardEditorViewModel
+{
+    private static readonly string[] DefaultStageOptions =
+    {
+        "Initial Talks",
+        "Negotiating",
+        "Finalising Terms",
+        "Awaiting Response"
+    };
+
+    private static readonly string[] DefaultStatusOptions =
+    {
+        "Monitoring",
+        "Negotiating",
+        "Awaiting Response",
+        "Accepted"
+    };
+
+    private readonly IClubDataService _clubDataService;
+    private readonly ObservableCollection<TransferNegotiationDealEditorViewModel> _deals;
+    private readonly RelayCommand _addDealCommand;
+    private readonly RelayCommand _removeDealCommand;
+    private TransferNegotiationDealEditorViewModel? _selectedDeal;
+    private string? _validationMessage;
+    private bool _hasCollectionChanges;
+
+    public TransferNegotiationEditorViewModel(
+        IReadOnlyList<TransferNegotiationDealSnapshot> deals,
+        IReadOnlyList<ListEntrySnapshot> summaries,
+        IClubDataService clubDataService)
+        : base(
+            "Manage Active Deals",
+            "Tune offers, stages, and feedback across ongoing transfer negotiations.")
+    {
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+
+        _deals = new ObservableCollection<TransferNegotiationDealEditorViewModel>(
+            (deals ?? Array.Empty<TransferNegotiationDealSnapshot>())
+                .Select(TransferNegotiationDealEditorViewModel.FromSnapshot));
+
+        _deals.CollectionChanged += OnDealsCollectionChanged;
+
+        foreach (var deal in _deals)
+        {
+            AttachDeal(deal);
+        }
+
+        if (_deals.Count > 0)
+        {
+            SelectedDeal = _deals[0];
+        }
+
+        _addDealCommand = new RelayCommand(_ => AddDeal());
+        _removeDealCommand = new RelayCommand(_ => RemoveSelectedDeal(), () => SelectedDeal is not null);
+
+        NotifyCanSaveChanged();
+    }
+
+    public ObservableCollection<TransferNegotiationDealEditorViewModel> Deals => _deals;
+
+    public TransferNegotiationDealEditorViewModel? SelectedDeal
+    {
+        get => _selectedDeal;
+        set
+        {
+            if (SetProperty(ref _selectedDeal, value))
+            {
+                _removeDealCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string? ValidationMessage
+    {
+        get => _validationMessage;
+        private set
+        {
+            if (SetProperty(ref _validationMessage, value))
+            {
+                OnPropertyChanged(nameof(HasValidationMessage));
+            }
+        }
+    }
+
+    public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
+
+    public ICommand AddDealCommand => _addDealCommand;
+
+    public ICommand RemoveSelectedDealCommand => _removeDealCommand;
+
+    protected override bool CanSave
+    {
+        get
+        {
+            var isDirty = _hasCollectionChanges || Deals.Any(deal => deal.IsDirty);
+            ValidationMessage = Validate();
+            return isDirty && string.IsNullOrWhiteSpace(ValidationMessage);
+        }
+    }
+
+    protected override async Task PersistAsync()
+    {
+        var dealSnapshots = Deals.Select(deal => deal.ToSnapshot()).ToList();
+        var summaries = dealSnapshots.Select(CreateSummary).ToList();
+
+        await _clubDataService.UpdateAsync(snapshot =>
+        {
+            var centre = snapshot.Transfers.Centre with
+            {
+                Negotiations = dealSnapshots,
+                ActiveDeals = summaries
+            };
+
+            var transfers = snapshot.Transfers with { Centre = centre };
+            return snapshot with { Transfers = transfers };
+        }).ConfigureAwait(false);
+
+        foreach (var deal in Deals)
+        {
+            deal.AcceptChanges();
+        }
+
+        _hasCollectionChanges = false;
+    }
+
+    private void AddDeal()
+    {
+        var stageOptions = BuildOptionSet(
+            DefaultStageOptions,
+            deal => deal.StageOptions.Concat(new[] { deal.Stage }));
+        var statusOptions = BuildOptionSet(
+            DefaultStatusOptions,
+            deal => deal.StatusOptions.Concat(new[] { deal.Status }));
+
+        var template = SelectedDeal ?? _deals.FirstOrDefault();
+        var termTemplates = template is not null
+            ? template.Terms.Select(term => term.ToSnapshot()).ToList()
+            : CreateDefaultTerms();
+
+        var newDeal = TransferNegotiationDealEditorViewModel.CreateNew(
+            stageOptions,
+            statusOptions,
+            termTemplates);
+
+        _deals.Add(newDeal);
+        SelectedDeal = newDeal;
+    }
+
+    private void RemoveSelectedDeal()
+    {
+        if (SelectedDeal is null)
+        {
+            return;
+        }
+
+        var index = _deals.IndexOf(SelectedDeal);
+        if (index < 0)
+        {
+            return;
+        }
+
+        _deals.RemoveAt(index);
+
+        if (_deals.Count == 0)
+        {
+            SelectedDeal = null;
+            return;
+        }
+
+        var nextIndex = Math.Clamp(index, 0, _deals.Count - 1);
+        SelectedDeal = _deals[nextIndex];
+    }
+
+    private void OnDealsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Reset)
+        {
+            foreach (var deal in _deals)
+            {
+                AttachDeal(deal);
+            }
+
+            NotifyCanSaveChanged();
+            return;
+        }
+
+        if (e.OldItems is not null)
+        {
+            foreach (TransferNegotiationDealEditorViewModel deal in e.OldItems)
+            {
+                DetachDeal(deal);
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (TransferNegotiationDealEditorViewModel deal in e.NewItems)
+            {
+                AttachDeal(deal);
+            }
+        }
+
+        _hasCollectionChanges = IsCollectionDifferentFromSnapshot();
+        NotifyCanSaveChanged();
+    }
+
+    private void AttachDeal(TransferNegotiationDealEditorViewModel deal)
+    {
+        deal.PropertyChanged += OnDealPropertyChanged;
+    }
+
+    private void DetachDeal(TransferNegotiationDealEditorViewModel deal)
+    {
+        deal.PropertyChanged -= OnDealPropertyChanged;
+    }
+
+    private string? Validate()
+    {
+        if (_deals.Count == 0)
+        {
+            return null;
+        }
+
+        foreach (var deal in _deals)
+        {
+            if (string.IsNullOrWhiteSpace(deal.Player))
+            {
+                return "Player name is required for every negotiation.";
+            }
+
+            if (string.IsNullOrWhiteSpace(deal.Position))
+            {
+                return "Add a position so recruitment can stay aligned.";
+            }
+
+            if (string.IsNullOrWhiteSpace(deal.Club))
+            {
+                return "Club name is required for every negotiation.";
+            }
+
+            if (string.IsNullOrWhiteSpace(deal.Stage))
+            {
+                return "Specify a stage for every negotiation.";
+            }
+
+            if (string.IsNullOrWhiteSpace(deal.Status))
+            {
+                return "Specify a status for every negotiation.";
+            }
+        }
+
+        return null;
+    }
+
+    private IReadOnlyList<string> BuildOptionSet(
+        IReadOnlyList<string> defaults,
+        Func<TransferNegotiationDealEditorViewModel, IEnumerable<string>> selector)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ordered = new List<string>();
+
+        void AppendRange(IEnumerable<string> values)
+        {
+            if (values is null)
+            {
+                return;
+            }
+
+            foreach (var value in values)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                if (set.Add(value))
+                {
+                    ordered.Add(value);
+                }
+            }
+        }
+
+        if (defaults is not null)
+        {
+            AppendRange(defaults);
+        }
+
+        foreach (var deal in _deals)
+        {
+            AppendRange(selector(deal));
+        }
+
+        return ordered;
+    }
+
+    private bool IsCollectionDifferentFromSnapshot()
+    {
+        var baseline = _clubDataService.Current.Transfers.Centre.Negotiations
+            ?? Array.Empty<TransferNegotiationDealSnapshot>();
+
+        if (baseline.Count != _deals.Count)
+        {
+            return true;
+        }
+
+        var baselineIds = baseline
+            .Select(deal => deal.Id)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        var currentIds = _deals
+            .Select(deal => deal.Id)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        return !baselineIds.SequenceEqual(currentIds, StringComparer.Ordinal);
+    }
+
+    private static IReadOnlyList<TransferNegotiationTermSnapshot> CreateDefaultTerms()
+    {
+        return new List<TransferNegotiationTermSnapshot>
+        {
+            new(
+                "fee",
+                "Transfer Fee",
+                "£{0:0.0}M",
+                5d,
+                100d,
+                0.5d,
+                15d,
+                20d,
+                "Guaranteed fee offered to the selling club."),
+            new(
+                "wage",
+                "Weekly Wages",
+                "£{0:0}K p/w",
+                10d,
+                400d,
+                5d,
+                80d,
+                100d,
+                "Weekly salary for the player."),
+            new(
+                "bonus",
+                "Signing Bonus",
+                "£{0:0.0}M",
+                0d,
+                20d,
+                0.25d,
+                1d,
+                2d,
+                "Upfront bonus requested by the agent.")
+        };
+    }
+
+    private void OnDealPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TransferNegotiationDealEditorViewModel.IsDirty) ||
+            e.PropertyName == nameof(TransferNegotiationDealEditorViewModel.Player) ||
+            e.PropertyName == nameof(TransferNegotiationDealEditorViewModel.Club) ||
+            e.PropertyName == nameof(TransferNegotiationDealEditorViewModel.Stage) ||
+            e.PropertyName == nameof(TransferNegotiationDealEditorViewModel.Status))
+        {
+            NotifyCanSaveChanged();
+        }
+    }
+
+    private static ListEntrySnapshot CreateSummary(TransferNegotiationDealSnapshot deal)
+    {
+        var feeTerm = deal.Terms?.FirstOrDefault(term =>
+            string.Equals(term.Id, "fee", StringComparison.OrdinalIgnoreCase));
+
+        var secondary = feeTerm is not null
+            ? string.Format(CultureInfo.InvariantCulture, feeTerm.Format, feeTerm.Value)
+            : deal.Stage;
+
+        return new ListEntrySnapshot(deal.Player, secondary, deal.Status, deal.Accent);
+    }
+}
+
+public sealed class TransferNegotiationDealEditorViewModel : ObservableObject
+{
+    private string _initialPlayer;
+    private string _initialPosition;
+    private string _initialClub;
+    private string? _initialAccent;
+    private string _initialStage;
+    private string _initialStatus;
+    private string _initialDeadline;
+    private string _initialSummary;
+    private string _initialAgent;
+    private string _initialResponse;
+    private readonly ObservableCollection<string> _stageOptions;
+    private readonly ObservableCollection<string> _statusOptions;
+    private readonly ObservableCollection<TransferNegotiationTermEditorViewModel> _terms;
+    private readonly RelayCommand _resetCommand;
+
+    private string _player;
+    private string _position;
+    private string _club;
+    private string? _accent;
+    private string _stage;
+    private string _status;
+    private string _deadline;
+    private string _summary;
+    private string _agent;
+    private string _response;
+    private bool _isNew;
+
+    private TransferNegotiationDealEditorViewModel(TransferNegotiationDealSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        Id = snapshot.Id;
+        _initialPlayer = snapshot.Player;
+        _initialPosition = snapshot.Position;
+        _initialClub = snapshot.Club;
+        _initialAccent = snapshot.Accent;
+
+        _player = snapshot.Player;
+        _position = snapshot.Position;
+        _club = snapshot.Club;
+        _accent = snapshot.Accent;
+
+        _initialStage = snapshot.Stage;
+        _initialStatus = snapshot.Status;
+        _initialDeadline = snapshot.Deadline;
+        _initialSummary = snapshot.Summary;
+        _initialAgent = snapshot.Agent;
+        _initialResponse = snapshot.Response;
+
+        _stage = snapshot.Stage;
+        _status = snapshot.Status;
+        _deadline = snapshot.Deadline;
+        _summary = snapshot.Summary;
+        _agent = snapshot.Agent;
+        _response = snapshot.Response;
+
+        _stageOptions = CreateOptionList(snapshot.StageOptions, snapshot.Stage);
+        _statusOptions = CreateOptionList(snapshot.StatusOptions, snapshot.Status);
+
+        _terms = new ObservableCollection<TransferNegotiationTermEditorViewModel>(
+            (snapshot.Terms ?? Array.Empty<TransferNegotiationTermSnapshot>())
+                .Select(TransferNegotiationTermEditorViewModel.FromSnapshot));
+
+        foreach (var term in _terms)
+        {
+            term.PropertyChanged += OnTermPropertyChanged;
+        }
+
+        _resetCommand = new RelayCommand(_ => Reset(), () => IsDirty);
+    }
+
+    public string Id { get; }
+
+    public string Player
+    {
+        get => _player;
+        set
+        {
+            if (SetProperty(ref _player, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Position
+    {
+        get => _position;
+        set
+        {
+            if (SetProperty(ref _position, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Club
+    {
+        get => _club;
+        set
+        {
+            if (SetProperty(ref _club, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string? Accent
+    {
+        get => _accent;
+        set
+        {
+            if (SetProperty(ref _accent, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Stage
+    {
+        get => _stage;
+        set
+        {
+            if (SetProperty(ref _stage, value))
+            {
+                EnsureOption(_stageOptions, value);
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Status
+    {
+        get => _status;
+        set
+        {
+            if (SetProperty(ref _status, value))
+            {
+                EnsureOption(_statusOptions, value);
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Deadline
+    {
+        get => _deadline;
+        set
+        {
+            if (SetProperty(ref _deadline, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Summary
+    {
+        get => _summary;
+        set
+        {
+            if (SetProperty(ref _summary, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Agent
+    {
+        get => _agent;
+        set
+        {
+            if (SetProperty(ref _agent, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public string Response
+    {
+        get => _response;
+        set
+        {
+            if (SetProperty(ref _response, value))
+            {
+                OnDirtyChanged();
+            }
+        }
+    }
+
+    public ObservableCollection<string> StageOptions => _stageOptions;
+
+    public ObservableCollection<string> StatusOptions => _statusOptions;
+
+    public ObservableCollection<TransferNegotiationTermEditorViewModel> Terms => _terms;
+
+    public bool HasStageOptions => _stageOptions.Count > 0;
+
+    public bool HasStatusOptions => _statusOptions.Count > 0;
+
+    public bool IsDirty =>
+        _isNew ||
+        !string.Equals(_player, _initialPlayer, StringComparison.Ordinal) ||
+        !string.Equals(_position, _initialPosition, StringComparison.Ordinal) ||
+        !string.Equals(_club, _initialClub, StringComparison.Ordinal) ||
+        !string.Equals(_accent ?? string.Empty, _initialAccent ?? string.Empty, StringComparison.Ordinal) ||
+        !string.Equals(_stage, _initialStage, StringComparison.Ordinal) ||
+        !string.Equals(_status, _initialStatus, StringComparison.Ordinal) ||
+        !string.Equals(_deadline, _initialDeadline, StringComparison.Ordinal) ||
+        !string.Equals(_summary, _initialSummary, StringComparison.Ordinal) ||
+        !string.Equals(_agent, _initialAgent, StringComparison.Ordinal) ||
+        !string.Equals(_response, _initialResponse, StringComparison.Ordinal) ||
+        _terms.Any(term => term.IsDirty);
+
+    public ICommand ResetCommand => _resetCommand;
+
+    public static TransferNegotiationDealEditorViewModel CreateNew(
+        IReadOnlyList<string> stageOptions,
+        IReadOnlyList<string> statusOptions,
+        IReadOnlyList<TransferNegotiationTermSnapshot> terms)
+    {
+        var stageList = stageOptions?.ToList() ?? new List<string>();
+        var statusList = statusOptions?.ToList() ?? new List<string>();
+        var termSnapshots = terms?.Select(term => term with { }).ToList() ?? new List<TransferNegotiationTermSnapshot>();
+
+        var snapshot = new TransferNegotiationDealSnapshot(
+            Guid.NewGuid().ToString("N"),
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            stageList.FirstOrDefault() ?? string.Empty,
+            statusList.FirstOrDefault() ?? string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            null,
+            stageList,
+            statusList,
+            termSnapshots);
+
+        var viewModel = new TransferNegotiationDealEditorViewModel(snapshot)
+        {
+            _isNew = true
+        };
+
+        viewModel._initialPlayer = string.Empty;
+        viewModel._initialPosition = string.Empty;
+        viewModel._initialClub = string.Empty;
+        viewModel._initialAccent = null;
+        viewModel._initialDeadline = string.Empty;
+        viewModel._initialSummary = string.Empty;
+        viewModel._initialAgent = string.Empty;
+        viewModel._initialResponse = string.Empty;
+
+        viewModel._resetCommand.RaiseCanExecuteChanged();
+        viewModel.OnPropertyChanged(nameof(IsDirty));
+
+        return viewModel;
+    }
+
+    public static TransferNegotiationDealEditorViewModel FromSnapshot(TransferNegotiationDealSnapshot snapshot)
+        => new(snapshot);
+
+    public TransferNegotiationDealSnapshot ToSnapshot()
+    {
+        var termSnapshots = _terms.Select(term => term.ToSnapshot()).ToList();
+
+        return new TransferNegotiationDealSnapshot(
+            Id,
+            _player,
+            _position,
+            _club,
+            Stage,
+            Status,
+            Deadline,
+            Summary,
+            Agent,
+            Response,
+            Accent,
+            _stageOptions.ToList(),
+            _statusOptions.ToList(),
+            termSnapshots);
+    }
+
+    public void AcceptChanges()
+    {
+        _initialPlayer = _player;
+        _initialPosition = _position;
+        _initialClub = _club;
+        _initialAccent = _accent;
+        _initialStage = _stage;
+        _initialStatus = _status;
+        _initialDeadline = _deadline;
+        _initialSummary = _summary;
+        _initialAgent = _agent;
+        _initialResponse = _response;
+        _isNew = false;
+
+        foreach (var term in _terms)
+        {
+            term.AcceptChanges();
+        }
+
+        _resetCommand.RaiseCanExecuteChanged();
+        OnPropertyChanged(nameof(IsDirty));
+    }
+
+    private void Reset()
+    {
+        Player = _initialPlayer;
+        Position = _initialPosition;
+        Club = _initialClub;
+        Accent = _initialAccent;
+        Stage = _initialStage;
+        Status = _initialStatus;
+        Deadline = _initialDeadline;
+        Summary = _initialSummary;
+        Agent = _initialAgent;
+        Response = _initialResponse;
+
+        foreach (var term in _terms)
+        {
+            term.Reset();
+        }
+
+        OnDirtyChanged();
+    }
+
+    private void OnDirtyChanged()
+    {
+        _resetCommand.RaiseCanExecuteChanged();
+        OnPropertyChanged(nameof(IsDirty));
+    }
+
+    private void OnTermPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TransferNegotiationTermEditorViewModel.IsDirty))
+        {
+            OnDirtyChanged();
+        }
+    }
+
+    private static ObservableCollection<string> CreateOptionList(IReadOnlyList<string>? options, string value)
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (options is { Count: > 0 })
+        {
+            foreach (var option in options)
+            {
+                if (!string.IsNullOrWhiteSpace(option))
+                {
+                    set.Add(option);
+                }
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            set.Add(value);
+        }
+
+        return new ObservableCollection<string>(set);
+    }
+
+    private static void EnsureOption(ObservableCollection<string> list, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        if (!list.Any(item => string.Equals(item, value, StringComparison.OrdinalIgnoreCase)))
+        {
+            list.Add(value);
+        }
+    }
+}
+
+public sealed class TransferNegotiationTermEditorViewModel : ObservableObject
+{
+    private readonly string _id;
+    private readonly string _label;
+    private readonly string _format;
+    private readonly double _minimum;
+    private readonly double _maximum;
+    private readonly double _step;
+    private readonly double _target;
+    private readonly string? _tooltip;
+    private double _baseline;
+    private double _value;
+    private readonly RelayCommand _resetCommand;
+
+    private TransferNegotiationTermEditorViewModel(TransferNegotiationTermSnapshot snapshot)
+    {
+        _id = snapshot.Id;
+        _label = snapshot.Label;
+        _format = snapshot.Format;
+        _minimum = snapshot.Minimum;
+        _maximum = snapshot.Maximum;
+        _step = snapshot.Step;
+        _target = snapshot.Target;
+        _tooltip = snapshot.Tooltip;
+        _baseline = snapshot.Value;
+        _value = snapshot.Value;
+        _resetCommand = new RelayCommand(_ => Reset(), () => IsDirty);
+    }
+
+    public string Label => _label;
+
+    public string? Tooltip => _tooltip;
+
+    public double Minimum => _minimum;
+
+    public double Maximum => _maximum;
+
+    public double Target => _target;
+
+    public double Value
+    {
+        get => _value;
+        set
+        {
+            var clamped = Math.Clamp(value, _minimum, _maximum <= _minimum ? value : _maximum);
+            if (SetProperty(ref _value, clamped))
+            {
+                OnPropertyChanged(nameof(DisplayValue));
+                OnPropertyChanged(nameof(DeltaDisplay));
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(Progress));
+                OnPropertyChanged(nameof(MeetsTarget));
+                _resetCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string DisplayValue => string.Format(CultureInfo.InvariantCulture, _format, Value);
+
+    public string TargetDisplay => string.Format(CultureInfo.InvariantCulture, _format, _target);
+
+    public string DeltaDisplay => string.Format(CultureInfo.InvariantCulture, _format, Value - _target);
+
+    public double Progress
+    {
+        get
+        {
+            if (_target > 0)
+            {
+                var ratio = Value / _target;
+                return Math.Clamp(ratio, 0d, 1d);
+            }
+
+            var range = _maximum - _minimum;
+            if (range <= 0)
+            {
+                return 0d;
+            }
+
+            var relative = (Value - _minimum) / range;
+            return Math.Clamp(relative, 0d, 1d);
+        }
+    }
+
+    public bool MeetsTarget => Value >= _target;
+
+    public double TickFrequency
+    {
+        get
+        {
+            if (_step > 0)
+            {
+                return _step;
+            }
+
+            var range = _maximum - _minimum;
+            return range <= 0 ? 1d : Math.Max(range / 20d, 0.5d);
+        }
+    }
+
+    public bool IsDirty => Math.Abs(Value - _baseline) > 0.0001;
+
+    public ICommand ResetCommand => _resetCommand;
+
+    public static TransferNegotiationTermEditorViewModel FromSnapshot(TransferNegotiationTermSnapshot snapshot)
+        => new(snapshot);
+
+    public TransferNegotiationTermSnapshot ToSnapshot()
+    {
+        return new TransferNegotiationTermSnapshot(
+            _id,
+            _label,
+            _format,
+            _minimum,
+            _maximum,
+            _step,
+            Value,
+            _target,
+            _tooltip);
+    }
+
+    public void AcceptChanges()
+    {
+        _baseline = Value;
+        _resetCommand.RaiseCanExecuteChanged();
+        OnPropertyChanged(nameof(IsDirty));
+    }
+
+    public void Reset()
+    {
+        Value = _baseline;
+        OnPropertyChanged(nameof(IsDirty));
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/FinanceBudgetAllocatorViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/FinanceBudgetAllocatorViewModel.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class FinanceBudgetAllocatorViewModel : ObservableObject
+{
+    private readonly IClubDataService _clubDataService;
+    private FinanceBudgetAllocatorDefinition _definition;
+    private readonly ReadOnlyCollection<FinanceBudgetAllocationLineViewModel> _lines;
+    private readonly AsyncRelayCommand _saveCommand;
+    private readonly RelayCommand _resetCommand;
+    private bool _isSaving;
+    private string? _statusMessage;
+
+    public FinanceBudgetAllocatorViewModel(FinanceBudgetAllocatorDefinition definition, IClubDataService clubDataService)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+
+        var lines = definition.Lines
+            ?.Select(line => new FinanceBudgetAllocationLineViewModel(line, OnLineChanged))
+            .ToList() ?? new List<FinanceBudgetAllocationLineViewModel>();
+
+        _lines = new ReadOnlyCollection<FinanceBudgetAllocationLineViewModel>(lines);
+        _saveCommand = new AsyncRelayCommand(SaveAsync, () => IsDirty && !IsSaving);
+        _resetCommand = new RelayCommand(_ => Reset(), _ => IsDirty && !IsSaving);
+    }
+
+    public IReadOnlyList<FinanceBudgetAllocationLineViewModel> Lines => _lines;
+
+    public string SummaryText => string.Format(
+        CultureInfo.InvariantCulture,
+        _definition.SummaryFormat,
+        Remaining,
+        TotalBaseline);
+
+    public string CommitLabel => _definition.CommitLabel;
+
+    public string ResetLabel => _definition.ResetLabel;
+
+    public double TotalBaseline => _lines.Sum(line => line.Baseline);
+
+    public double TotalValue => _lines.Sum(line => line.Value);
+
+    public double Remaining => TotalBaseline - TotalValue;
+
+    public bool IsDirty => _lines.Any(line => line.IsDirty);
+
+    public bool IsSaving
+    {
+        get => _isSaving;
+        private set
+        {
+            if (SetProperty(ref _isSaving, value))
+            {
+                _saveCommand.RaiseCanExecuteChanged();
+                _resetCommand.RaiseCanExecuteChanged();
+                OnPropertyChanged(nameof(CanSave));
+            }
+        }
+    }
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (SetProperty(ref _statusMessage, value))
+            {
+                OnPropertyChanged(nameof(HasStatusMessage));
+            }
+        }
+    }
+
+    public bool HasStatusMessage => !string.IsNullOrWhiteSpace(StatusMessage);
+
+    public ICommand SaveCommand => _saveCommand;
+
+    public ICommand ResetCommand => _resetCommand;
+
+    public bool CanSave => IsDirty && !IsSaving;
+
+    private void OnLineChanged()
+    {
+        OnPropertyChanged(nameof(SummaryText));
+        OnPropertyChanged(nameof(TotalValue));
+        OnPropertyChanged(nameof(Remaining));
+        OnPropertyChanged(nameof(IsDirty));
+        _saveCommand.RaiseCanExecuteChanged();
+        _resetCommand.RaiseCanExecuteChanged();
+        StatusMessage = null;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!IsDirty)
+        {
+            return;
+        }
+
+        try
+        {
+            IsSaving = true;
+            StatusMessage = "Saving budget allocations...";
+
+            var updatedLines = _lines
+                .Select(line => line.CreateSnapshot())
+                .ToList();
+
+            await _clubDataService.UpdateAsync(snapshot =>
+            {
+                var finance = snapshot.Finance;
+                var summary = finance.Summary;
+                var allocator = summary.BudgetAllocator with { Lines = updatedLines };
+                var updatedSummary = summary with { BudgetAllocator = allocator };
+                var updatedFinance = finance with { Summary = updatedSummary };
+                return snapshot with { Finance = updatedFinance };
+            }).ConfigureAwait(true);
+
+            foreach (var line in _lines)
+            {
+                line.Commit();
+            }
+
+            _definition = _definition with { Lines = updatedLines.Select(MapDefinition).ToList() };
+
+            StatusMessage = "Budget allocation saved";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Unable to save budget allocation: {ex.Message}";
+        }
+        finally
+        {
+            IsSaving = false;
+        }
+
+        OnPropertyChanged(nameof(IsDirty));
+        OnPropertyChanged(nameof(SummaryText));
+        OnPropertyChanged(nameof(Remaining));
+        OnPropertyChanged(nameof(TotalValue));
+        _saveCommand.RaiseCanExecuteChanged();
+        _resetCommand.RaiseCanExecuteChanged();
+    }
+
+    private void Reset()
+    {
+        foreach (var line in _lines)
+        {
+            line.Reset();
+        }
+
+        StatusMessage = "Changes reverted";
+        OnPropertyChanged(nameof(SummaryText));
+        OnPropertyChanged(nameof(Remaining));
+        OnPropertyChanged(nameof(TotalValue));
+        OnPropertyChanged(nameof(IsDirty));
+        _saveCommand.RaiseCanExecuteChanged();
+        _resetCommand.RaiseCanExecuteChanged();
+    }
+
+    private static FinanceBudgetAllocationLineDefinition MapDefinition(FinanceBudgetAllocationLineSnapshot snapshot)
+    {
+        return new FinanceBudgetAllocationLineDefinition(
+            snapshot.Id,
+            snapshot.Label,
+            snapshot.Description,
+            snapshot.Minimum,
+            snapshot.Maximum,
+            snapshot.Step,
+            snapshot.Value,
+            snapshot.Baseline,
+            snapshot.Format,
+            snapshot.Accent);
+    }
+}
+
+public sealed class FinanceBudgetAllocationLineViewModel : ObservableObject
+{
+    private readonly Action _changed;
+    private double _value;
+    private double _baseline;
+
+    internal FinanceBudgetAllocationLineViewModel(FinanceBudgetAllocationLineDefinition definition, Action changed)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        _changed = changed ?? throw new ArgumentNullException(nameof(changed));
+        Id = definition.Id;
+        Label = definition.Label;
+        Description = definition.Description;
+        Minimum = definition.Minimum;
+        Maximum = definition.Maximum;
+        Step = definition.Step;
+        _value = definition.Value;
+        _baseline = definition.Baseline;
+        Format = definition.Format;
+        Accent = definition.Accent;
+    }
+
+    public string Id { get; }
+
+    public string Label { get; }
+
+    public string? Description { get; }
+
+    public double Minimum { get; }
+
+    public double Maximum { get; }
+
+    public double Step { get; }
+
+    public double TickFrequency
+    {
+        get
+        {
+            if (Step > 0)
+            {
+                return Step;
+            }
+
+            var range = Maximum - Minimum;
+            return range <= 0 ? 1 : Math.Max(range / 20d, 1d);
+        }
+    }
+
+    public bool UseTicks => Step > 0;
+
+    public string Format { get; }
+
+    public string? Accent { get; }
+
+    public double Baseline => _baseline;
+
+    public double Value
+    {
+        get => _value;
+        set
+        {
+            var clamped = Math.Clamp(value, Minimum, Maximum);
+            if (SetProperty(ref _value, clamped))
+            {
+                OnPropertyChanged(nameof(DisplayValue));
+                OnPropertyChanged(nameof(IsDirty));
+                _changed();
+            }
+        }
+    }
+
+    public string DisplayValue => string.Format(CultureInfo.InvariantCulture, Format, Value);
+
+    public string RangeDisplay => string.Format(
+        CultureInfo.InvariantCulture,
+        "{0} – {1}",
+        string.Format(CultureInfo.InvariantCulture, Format, Minimum),
+        string.Format(CultureInfo.InvariantCulture, Format, Maximum));
+
+    public bool IsDirty => !AreClose(Value, _baseline);
+
+    public void Reset()
+    {
+        Value = _baseline;
+    }
+
+    public void Commit()
+    {
+        _baseline = _value;
+        OnPropertyChanged(nameof(IsDirty));
+    }
+
+    public FinanceBudgetAllocationLineSnapshot CreateSnapshot()
+    {
+        return new FinanceBudgetAllocationLineSnapshot(
+            Id,
+            Label,
+            Description,
+            Minimum,
+            Maximum,
+            Step,
+            Value,
+            _baseline,
+            Format,
+            Accent);
+    }
+
+    private static bool AreClose(double x, double y) => Math.Abs(x - y) < 0.0001;
+}

--- a/WPF/FMUI.Wpf/ViewModels/FinanceCashflowViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/FinanceCashflowViewModel.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class FinanceCashflowViewModel : ObservableObject
+{
+    private readonly FinanceCashflowDefinition _definition;
+    private readonly ReadOnlyCollection<FinanceCashflowCategoryViewModel> _categories;
+    private FinanceCashflowCategoryViewModel? _selectedCategory;
+    private IReadOnlyList<FinanceCashflowItemViewModel> _activeItems;
+
+    public FinanceCashflowViewModel(FinanceCashflowDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        var categories = definition.Categories
+            ?.Select(category => new FinanceCashflowCategoryViewModel(category))
+            .ToList() ?? new List<FinanceCashflowCategoryViewModel>();
+
+        _categories = new ReadOnlyCollection<FinanceCashflowCategoryViewModel>(categories);
+        _activeItems = Array.Empty<FinanceCashflowItemViewModel>();
+
+        if (_categories.Count > 0)
+        {
+            SelectedCategory = _categories[0];
+        }
+    }
+
+    public string SummaryLabel => _definition.SummaryLabel;
+
+    public string SummaryValue
+    {
+        get
+        {
+            var selectedAmount = SelectedCategory?.Amount ?? TotalAmount;
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                _definition.SummaryFormat,
+                selectedAmount,
+                TotalAmount);
+        }
+    }
+
+    public IReadOnlyList<FinanceCashflowCategoryViewModel> Categories => _categories;
+
+    public FinanceCashflowCategoryViewModel? SelectedCategory
+    {
+        get => _selectedCategory;
+        set
+        {
+            if (SetProperty(ref _selectedCategory, value))
+            {
+                _activeItems = value?.Items ?? Array.Empty<FinanceCashflowItemViewModel>();
+                OnPropertyChanged(nameof(Items));
+                OnPropertyChanged(nameof(SummaryValue));
+                OnPropertyChanged(nameof(SelectedCategoryName));
+                OnPropertyChanged(nameof(SelectedCategoryDescription));
+                OnPropertyChanged(nameof(HasSelectedCategoryDescription));
+            }
+        }
+    }
+
+    public string SelectedCategoryName => SelectedCategory?.Name ?? "Cash flow";
+
+    public string? SelectedCategoryDescription => SelectedCategory?.Description;
+
+    public bool HasSelectedCategoryDescription => !string.IsNullOrWhiteSpace(SelectedCategoryDescription);
+
+    public IReadOnlyList<FinanceCashflowItemViewModel> Items => _activeItems;
+
+    private double TotalAmount => _categories.Sum(category => category.Amount);
+}
+
+public sealed class FinanceCashflowCategoryViewModel
+{
+    internal FinanceCashflowCategoryViewModel(FinanceCashflowCategoryDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Name = definition.Name;
+        Description = definition.Description;
+        Amount = definition.Amount;
+        Format = definition.Format;
+        Accent = definition.Accent;
+        Items = new ReadOnlyCollection<FinanceCashflowItemViewModel>(
+            definition.Items?.Select(item => new FinanceCashflowItemViewModel(item)).ToList()
+            ?? new List<FinanceCashflowItemViewModel>());
+    }
+
+    public string Name { get; }
+
+    public string? Description { get; }
+
+    public double Amount { get; }
+
+    public string Format { get; }
+
+    public string? Accent { get; }
+
+    public IReadOnlyList<FinanceCashflowItemViewModel> Items { get; }
+
+    public string DisplayAmount => string.Format(CultureInfo.InvariantCulture, Format, Amount);
+}
+
+public sealed class FinanceCashflowItemViewModel
+{
+    internal FinanceCashflowItemViewModel(FinanceCashflowItemDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Id = definition.Id;
+        Name = definition.Name;
+        Amount = definition.Amount;
+        Format = definition.Format;
+        Accent = definition.Accent;
+        Detail = definition.Detail;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public double Amount { get; }
+
+    public string Format { get; }
+
+    public string? Accent { get; }
+
+    public string? Detail { get; }
+
+    public string DisplayAmount => string.Format(CultureInfo.InvariantCulture, Format, Amount);
+}

--- a/WPF/FMUI.Wpf/ViewModels/FinanceForecastViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/FinanceForecastViewModel.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class FinanceForecastViewModel : ObservableObject
+{
+    private readonly IClubDataService _clubDataService;
+    private FinanceForecastDefinition _definition;
+    private readonly ReadOnlyCollection<FinanceForecastImpactItemViewModel> _impacts;
+    private readonly AsyncRelayCommand _saveCommand;
+    private double _value;
+    private double _baseline;
+    private bool _isSaving;
+    private string? _statusMessage;
+
+    public FinanceForecastViewModel(FinanceForecastDefinition definition, IClubDataService clubDataService)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+        _value = definition.Value;
+        _baseline = definition.Value;
+        var impacts = new List<FinanceForecastImpactItemViewModel>(definition.Impacts.Count);
+        foreach (var impact in definition.Impacts)
+        {
+            impacts.Add(new FinanceForecastImpactItemViewModel(impact, _baseline));
+        }
+
+        _impacts = new ReadOnlyCollection<FinanceForecastImpactItemViewModel>(impacts);
+        UpdateImpacts();
+        _saveCommand = new AsyncRelayCommand(SaveAsync, () => IsDirty && !_isSaving);
+    }
+
+    public string SliderLabel => _definition.SliderLabel;
+
+    public double Minimum => _definition.Minimum;
+
+    public double Maximum => _definition.Maximum;
+
+    public double Step => _definition.Step;
+
+    public bool UseTicks => Step > 0;
+
+    public double TickFrequency
+    {
+        get
+        {
+            if (Step > 0)
+            {
+                return Step;
+            }
+
+            var range = Maximum - Minimum;
+            return range <= 0 ? 1 : Math.Max(range / 20d, 1d);
+        }
+    }
+
+    public double Value
+    {
+        get => _value;
+        set
+        {
+            if (value < Minimum)
+            {
+                value = Minimum;
+            }
+            else if (value > Maximum)
+            {
+                value = Maximum;
+            }
+
+            if (SetProperty(ref _value, value))
+            {
+                UpdateImpacts();
+                OnPropertyChanged(nameof(ValueDisplay));
+                OnPropertyChanged(nameof(IsDirty));
+                OnPropertyChanged(nameof(SummaryValue));
+                StatusMessage = null;
+                _saveCommand.RaiseCanExecuteChanged();
+                OnPropertyChanged(nameof(CanSave));
+            }
+        }
+    }
+
+    public string ValueDisplay => string.Format(CultureInfo.InvariantCulture, _definition.ValueDisplayFormat, Value);
+
+    public string SummaryLabel => _definition.SummaryLabel;
+
+    public string SummaryValue => _impacts.Count > 0 ? _impacts[0].DisplayValue : string.Empty;
+
+    public IReadOnlyList<FinanceForecastImpactItemViewModel> Impacts => _impacts;
+
+    public bool IsDirty => !AreClose(_value, _baseline);
+
+    public bool IsSaving
+    {
+        get => _isSaving;
+        private set
+        {
+            if (SetProperty(ref _isSaving, value))
+            {
+                OnPropertyChanged(nameof(CanSave));
+            }
+        }
+    }
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (SetProperty(ref _statusMessage, value))
+            {
+                OnPropertyChanged(nameof(HasStatusMessage));
+            }
+        }
+    }
+
+    public bool HasStatusMessage => !string.IsNullOrWhiteSpace(StatusMessage);
+
+    public ICommand SaveCommand => _saveCommand;
+
+    public bool CanSave => IsDirty && !IsSaving;
+
+    private static bool AreClose(double x, double y) => Math.Abs(x - y) < 0.0001;
+
+    private void UpdateImpacts()
+    {
+        foreach (var impact in _impacts)
+        {
+            impact.Update(Value, _baseline);
+        }
+
+        OnPropertyChanged(nameof(SummaryValue));
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!IsDirty)
+        {
+            return;
+        }
+
+        try
+        {
+            IsSaving = true;
+            StatusMessage = "Saving forecast...";
+
+            var updatedImpacts = _impacts
+                .Select(impact => impact.CreateSnapshot())
+                .ToList();
+
+            var newValue = Value;
+
+            await _clubDataService.UpdateAsync(snapshot =>
+            {
+                var finance = snapshot.Finance;
+                var summary = finance.Summary;
+                var forecast = summary.Forecast;
+                var updatedForecast = forecast with
+                {
+                    CurrentPercentage = newValue,
+                    Impacts = updatedImpacts
+                };
+
+                var updatedSummary = summary with { Forecast = updatedForecast };
+                var updatedFinance = finance with { Summary = updatedSummary };
+                return snapshot with { Finance = updatedFinance };
+            }).ConfigureAwait(true);
+
+            foreach (var impact in _impacts)
+            {
+                impact.Commit();
+            }
+
+            _definition = _definition with { Value = newValue };
+            _baseline = newValue;
+
+            OnPropertyChanged(nameof(IsDirty));
+            OnPropertyChanged(nameof(CanSave));
+            _saveCommand.RaiseCanExecuteChanged();
+            StatusMessage = "Forecast saved";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Unable to save forecast: {ex.Message}";
+        }
+        finally
+        {
+            IsSaving = false;
+            _saveCommand.RaiseCanExecuteChanged();
+            OnPropertyChanged(nameof(CanSave));
+        }
+    }
+}
+
+public sealed class FinanceForecastImpactItemViewModel : ObservableObject
+{
+    private readonly FinanceForecastImpactDefinition _definition;
+    private double _baseValue;
+    private double _currentValue;
+    private string _displayValue = string.Empty;
+
+    public FinanceForecastImpactItemViewModel(FinanceForecastImpactDefinition definition, double baseline)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        _baseValue = definition.BaseValue;
+        Update(baseline, baseline);
+    }
+
+    public string Label => _definition.Label;
+
+    public string DisplayValue
+    {
+        get => _displayValue;
+        private set => SetProperty(ref _displayValue, value);
+    }
+
+    public double CurrentValue
+    {
+        get => _currentValue;
+        private set => SetProperty(ref _currentValue, value);
+    }
+
+    public void Update(double sliderValue, double baseline)
+    {
+        var delta = sliderValue - baseline;
+        var value = _baseValue + (delta * _definition.Sensitivity);
+        CurrentValue = value;
+        DisplayValue = string.Format(CultureInfo.InvariantCulture, _definition.Format, value);
+    }
+
+    public FinanceForecastImpactSnapshot CreateSnapshot()
+    {
+        return new FinanceForecastImpactSnapshot(
+            _definition.Label,
+            _definition.Format,
+            CurrentValue,
+            _definition.Sensitivity);
+    }
+
+    public void Commit()
+    {
+        _baseValue = CurrentValue;
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/FinanceScenarioBoardViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/FinanceScenarioBoardViewModel.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class FinanceScenarioBoardViewModel : ObservableObject
+{
+    private readonly IClubDataService _clubDataService;
+    private FinanceScenarioDefinition _definition;
+    private readonly ReadOnlyCollection<FinanceScenarioOptionViewModel> _options;
+    private readonly AsyncRelayCommand _saveCommand;
+    private readonly RelayCommand _resetCommand;
+    private bool _isSaving;
+    private string? _statusMessage;
+
+    public FinanceScenarioBoardViewModel(FinanceScenarioDefinition definition, IClubDataService clubDataService)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+
+        var options = definition.Options
+            ?.Select(option => new FinanceScenarioOptionViewModel(option, OnOptionChanged))
+            .ToList() ?? new List<FinanceScenarioOptionViewModel>();
+
+        _options = new ReadOnlyCollection<FinanceScenarioOptionViewModel>(options);
+        _saveCommand = new AsyncRelayCommand(SaveAsync, () => IsDirty && !IsSaving);
+        _resetCommand = new RelayCommand(_ => Reset(), _ => IsDirty && !IsSaving);
+    }
+
+    public IReadOnlyList<FinanceScenarioOptionViewModel> Options => _options;
+
+    public string SummaryLabel => _definition.SummaryLabel;
+
+    public string SummaryValue => string.Format(
+        CultureInfo.InvariantCulture,
+        _definition.SummaryFormat,
+        TotalImpact,
+        SelectedCount);
+
+    public string CommitLabel => _definition.CommitLabel;
+
+    public string ResetLabel => _definition.ResetLabel;
+
+    public double TotalImpact => _options.Sum(option => option.IsSelected ? option.Impact : 0d);
+
+    public int SelectedCount => _options.Count(option => option.IsSelected);
+
+    public bool IsDirty => _options.Any(option => option.IsDirty);
+
+    public bool IsSaving
+    {
+        get => _isSaving;
+        private set
+        {
+            if (SetProperty(ref _isSaving, value))
+            {
+                _saveCommand.RaiseCanExecuteChanged();
+                _resetCommand.RaiseCanExecuteChanged();
+                OnPropertyChanged(nameof(CanSave));
+            }
+        }
+    }
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (SetProperty(ref _statusMessage, value))
+            {
+                OnPropertyChanged(nameof(HasStatusMessage));
+            }
+        }
+    }
+
+    public bool HasStatusMessage => !string.IsNullOrWhiteSpace(StatusMessage);
+
+    public ICommand SaveCommand => _saveCommand;
+
+    public ICommand ResetCommand => _resetCommand;
+
+    public bool CanSave => IsDirty && !IsSaving;
+
+    private void OnOptionChanged()
+    {
+        OnPropertyChanged(nameof(TotalImpact));
+        OnPropertyChanged(nameof(SelectedCount));
+        OnPropertyChanged(nameof(SummaryValue));
+        OnPropertyChanged(nameof(IsDirty));
+        _saveCommand.RaiseCanExecuteChanged();
+        _resetCommand.RaiseCanExecuteChanged();
+        StatusMessage = null;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!IsDirty)
+        {
+            return;
+        }
+
+        try
+        {
+            IsSaving = true;
+            StatusMessage = "Saving scenarios...";
+
+            var snapshotOptions = _options.Select(option => option.CreateSnapshot()).ToList();
+
+            await _clubDataService.UpdateAsync(snapshot =>
+            {
+                var finance = snapshot.Finance;
+                var summary = finance.Summary;
+                var scenario = summary.ScenarioBoard with { Options = snapshotOptions };
+                var updatedSummary = summary with { ScenarioBoard = scenario };
+                var updatedFinance = finance with { Summary = updatedSummary };
+                return snapshot with { Finance = updatedFinance };
+            }).ConfigureAwait(true);
+
+            foreach (var option in _options)
+            {
+                option.Commit();
+            }
+
+            _definition = _definition with { Options = snapshotOptions.Select(MapDefinition).ToList() };
+            StatusMessage = "Scenario saved";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Unable to save scenarios: {ex.Message}";
+        }
+        finally
+        {
+            IsSaving = false;
+        }
+
+        OnPropertyChanged(nameof(IsDirty));
+        _saveCommand.RaiseCanExecuteChanged();
+        _resetCommand.RaiseCanExecuteChanged();
+    }
+
+    private void Reset()
+    {
+        foreach (var option in _options)
+        {
+            option.Reset();
+        }
+
+        StatusMessage = "Changes reverted";
+        OnPropertyChanged(nameof(TotalImpact));
+        OnPropertyChanged(nameof(SelectedCount));
+        OnPropertyChanged(nameof(SummaryValue));
+        OnPropertyChanged(nameof(IsDirty));
+        _saveCommand.RaiseCanExecuteChanged();
+        _resetCommand.RaiseCanExecuteChanged();
+    }
+
+    private static FinanceScenarioOptionDefinition MapDefinition(FinanceScenarioOptionSnapshot snapshot)
+    {
+        return new FinanceScenarioOptionDefinition(
+            snapshot.Id,
+            snapshot.Title,
+            snapshot.Detail,
+            snapshot.Impact,
+            snapshot.Format,
+            snapshot.IsSelected,
+            snapshot.Accent);
+    }
+}
+
+public sealed class FinanceScenarioOptionViewModel : ObservableObject
+{
+    private readonly Action _changed;
+    private bool _isSelected;
+    private bool _baselineSelected;
+
+    internal FinanceScenarioOptionViewModel(FinanceScenarioOptionDefinition definition, Action changed)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        _changed = changed ?? throw new ArgumentNullException(nameof(changed));
+        Id = definition.Id;
+        Title = definition.Title;
+        Detail = definition.Detail;
+        Impact = definition.Impact;
+        Format = definition.Format;
+        Accent = definition.Accent;
+        _isSelected = definition.IsSelected;
+        _baselineSelected = definition.IsSelected;
+    }
+
+    public string Id { get; }
+
+    public string Title { get; }
+
+    public string Detail { get; }
+
+    public double Impact { get; }
+
+    public string Format { get; }
+
+    public string? Accent { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (SetProperty(ref _isSelected, value))
+            {
+                OnPropertyChanged(nameof(DisplayImpact));
+                OnPropertyChanged(nameof(IsDirty));
+                _changed();
+            }
+        }
+    }
+
+    public string DisplayImpact => string.Format(CultureInfo.InvariantCulture, Format, Impact);
+
+    public bool IsDirty => _isSelected != _baselineSelected;
+
+    public void Reset()
+    {
+        IsSelected = _baselineSelected;
+    }
+
+    public void Commit()
+    {
+        _baselineSelected = _isSelected;
+        OnPropertyChanged(nameof(IsDirty));
+    }
+
+    public FinanceScenarioOptionSnapshot CreateSnapshot()
+    {
+        return new FinanceScenarioOptionSnapshot(
+            Id,
+            Title,
+            Detail,
+            Impact,
+            Format,
+            IsSelected,
+            Accent);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/FixtureCalendarViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/FixtureCalendarViewModel.cs
@@ -1,0 +1,537 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class FixtureCalendarViewModel : ObservableObject
+{
+    private readonly IClubDataService _clubDataService;
+    private readonly Dictionary<string, FixtureCalendarMatchViewModel> _matchLookup;
+    private FixtureMatchDetailViewModel? _activeDetail;
+    private bool _isDetailOpen;
+
+    public FixtureCalendarViewModel(FixtureCalendarDefinition definition, IClubDataService clubDataService)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+        _matchLookup = new Dictionary<string, FixtureCalendarMatchViewModel>(StringComparer.OrdinalIgnoreCase);
+
+        Filters = new ObservableCollection<FixtureCalendarFilterViewModel>();
+        Weeks = new ObservableCollection<FixtureCalendarWeekViewModel>();
+
+        if (definition.Filters is { Count: > 0 })
+        {
+            foreach (var filter in definition.Filters)
+            {
+                var filterViewModel = new FixtureCalendarFilterViewModel(this, filter);
+                Filters.Add(filterViewModel);
+            }
+        }
+
+        if (definition.Weeks is { Count: > 0 })
+        {
+            foreach (var week in definition.Weeks)
+            {
+                var weekViewModel = new FixtureCalendarWeekViewModel(week);
+                foreach (var day in weekViewModel.Days)
+                {
+                    foreach (var match in day.Matches)
+                    {
+                        match.ShowDetailRequested += OnMatchDetailRequested;
+                        _matchLookup[match.Id] = match;
+                    }
+                }
+
+                Weeks.Add(weekViewModel);
+            }
+        }
+
+        ApplyFilters();
+    }
+
+    public ObservableCollection<FixtureCalendarFilterViewModel> Filters { get; }
+
+    public ObservableCollection<FixtureCalendarWeekViewModel> Weeks { get; }
+
+    public FixtureMatchDetailViewModel? ActiveDetail
+    {
+        get => _activeDetail;
+        private set => SetProperty(ref _activeDetail, value);
+    }
+
+    public bool IsDetailOpen
+    {
+        get => _isDetailOpen;
+        private set => SetProperty(ref _isDetailOpen, value);
+    }
+
+    internal void ToggleFilter(FixtureCalendarFilterViewModel filter)
+    {
+        if (filter is null)
+        {
+            return;
+        }
+
+        if (!Filters.Contains(filter))
+        {
+            return;
+        }
+
+        if (filter.IsCatchAll && !filter.IsActive)
+        {
+            foreach (var other in Filters)
+            {
+                other.SetIsActive(ReferenceEquals(other, filter));
+            }
+        }
+        else
+        {
+            var catchAll = Filters.FirstOrDefault(f => f.IsCatchAll);
+            if (catchAll is not null && catchAll.IsActive)
+            {
+                catchAll.SetIsActive(false);
+            }
+
+            filter.SetIsActive(!filter.IsActive);
+        }
+
+        if (Filters.All(f => !f.IsActive))
+        {
+            foreach (var filterViewModel in Filters)
+            {
+                if (filterViewModel.IsCatchAll)
+                {
+                    filterViewModel.SetIsActive(true);
+                }
+            }
+        }
+
+        ApplyFilters();
+    }
+
+    internal void ShowDetail(FixtureCalendarMatchViewModel match)
+    {
+        if (match is null)
+        {
+            return;
+        }
+
+        var detail = new FixtureMatchDetailViewModel(match, this);
+        ActiveDetail = detail;
+        IsDetailOpen = true;
+    }
+
+    internal void CloseDetail()
+    {
+        if (ActiveDetail is null)
+        {
+            return;
+        }
+
+        ActiveDetail.Dispose();
+        ActiveDetail = null;
+        IsDetailOpen = false;
+    }
+
+    internal async Task SaveMatchDetailAsync(FixtureMatchDetailViewModel detail)
+    {
+        if (detail is null)
+        {
+            throw new ArgumentNullException(nameof(detail));
+        }
+
+        detail.IsBusy = true;
+        detail.StatusMessage = "Saving fixture update...";
+
+        try
+        {
+            await _clubDataService.UpdateAsync(snapshot =>
+            {
+                var fixtures = snapshot.Fixtures;
+                var calendar = fixtures.Calendar;
+
+                var updatedWeeks = calendar.Weeks
+                    .Select(week => week with
+                    {
+                        Days = week.Days
+                            .Select(day => day with
+                            {
+                                Matches = day.Matches
+                                    .Select(match => match.Id.Equals(detail.Id, StringComparison.OrdinalIgnoreCase)
+                                        ? match with
+                                        {
+                                            PreparationNote = detail.PreparationNote,
+                                            TravelNote = detail.TravelNote,
+                                            Status = detail.Status
+                                        }
+                                        : match)
+                                    .ToList()
+                            })
+                            .ToList()
+                    })
+                    .ToList();
+
+                var updatedCalendar = calendar with { Weeks = updatedWeeks };
+                var updatedFixtures = fixtures with { Calendar = updatedCalendar };
+                return snapshot with { Fixtures = updatedFixtures };
+            }).ConfigureAwait(true);
+
+            if (_matchLookup.TryGetValue(detail.Id, out var match))
+            {
+                match.ApplyDetail(detail);
+            }
+
+            detail.StatusMessage = "Fixture updated.";
+            CloseDetail();
+        }
+        catch (Exception ex)
+        {
+            detail.StatusMessage = $"Unable to save fixture: {ex.Message}";
+        }
+        finally
+        {
+            detail.IsBusy = false;
+        }
+    }
+
+    private void OnMatchDetailRequested(object? sender, EventArgs e)
+    {
+        if (sender is FixtureCalendarMatchViewModel match)
+        {
+            ShowDetail(match);
+        }
+    }
+
+    private void ApplyFilters()
+    {
+        var activeCompetitions = Filters
+            .Where(f => f.IsActive)
+            .SelectMany(f => f.Competitions)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var hasSpecificFilters = activeCompetitions.Count > 0;
+
+        foreach (var match in _matchLookup.Values)
+        {
+            if (!hasSpecificFilters)
+            {
+                match.IsVisible = true;
+                continue;
+            }
+
+            match.IsVisible = activeCompetitions.Contains(match.CompetitionKey, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}
+
+public sealed class FixtureCalendarFilterViewModel : ObservableObject
+{
+    private readonly FixtureCalendarViewModel _owner;
+    private bool _isActive;
+
+    internal FixtureCalendarFilterViewModel(FixtureCalendarViewModel owner, FixtureCalendarFilterDefinition definition)
+    {
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Id = definition.Id;
+        DisplayName = definition.DisplayName;
+        Competitions = definition.Competitions ?? Array.Empty<string>();
+        _isActive = definition.IsDefault;
+        ToggleCommand = new RelayCommand(_ => _owner.ToggleFilter(this));
+    }
+
+    public string Id { get; }
+
+    public string DisplayName { get; }
+
+    public IReadOnlyList<string> Competitions { get; }
+
+    public ICommand ToggleCommand { get; }
+
+    public bool IsActive
+    {
+        get => _isActive;
+        private set => SetProperty(ref _isActive, value);
+    }
+
+    internal bool IsCatchAll => Competitions.Count == 0;
+
+    internal void SetIsActive(bool isActive)
+    {
+        IsActive = isActive;
+    }
+}
+
+public sealed class FixtureCalendarWeekViewModel
+{
+    public FixtureCalendarWeekViewModel(FixtureCalendarWeekDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Label = definition.Label;
+        Days = new ObservableCollection<FixtureCalendarDayViewModel>();
+
+        if (definition.Days is { Count: > 0 })
+        {
+            foreach (var day in definition.Days)
+            {
+                Days.Add(new FixtureCalendarDayViewModel(day));
+            }
+        }
+    }
+
+    public string Label { get; }
+
+    public ObservableCollection<FixtureCalendarDayViewModel> Days { get; }
+}
+
+public sealed class FixtureCalendarDayViewModel
+{
+    public FixtureCalendarDayViewModel(FixtureCalendarDayDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Label = definition.Label;
+        Date = definition.Date;
+        Matches = new ObservableCollection<FixtureCalendarMatchViewModel>();
+
+        if (definition.Matches is { Count: > 0 })
+        {
+            foreach (var match in definition.Matches)
+            {
+                Matches.Add(new FixtureCalendarMatchViewModel(match));
+            }
+        }
+    }
+
+    public string Label { get; }
+
+    public string Date { get; }
+
+    public ObservableCollection<FixtureCalendarMatchViewModel> Matches { get; }
+}
+
+public sealed class FixtureCalendarMatchViewModel : ObservableObject
+{
+    private bool _isVisible = true;
+
+    internal FixtureCalendarMatchViewModel(FixtureCalendarMatchDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Id = definition.Id;
+        Day = definition.Day;
+        KickOff = definition.KickOff;
+        Competition = definition.Competition;
+        CompetitionKey = string.IsNullOrWhiteSpace(definition.Competition) ? "all" : definition.Competition;
+        Opponent = definition.Opponent;
+        Venue = definition.Venue;
+        IsHome = definition.IsHome;
+        Importance = definition.Importance;
+        Result = definition.Result;
+        Broadcast = definition.Broadcast;
+        TravelNote = definition.TravelNote;
+        PreparationNote = definition.PreparationNote;
+        Status = definition.Status;
+        CompetitionAccent = definition.CompetitionAccent;
+        KeyPeople = definition.KeyPeople is { Count: > 0 }
+            ? definition.KeyPeople.Select(item => new CardListItemViewModel(item)).ToList()
+            : Array.Empty<CardListItemViewModel>();
+        Preparation = definition.Preparation is { Count: > 0 }
+            ? definition.Preparation.Select(item => new CardListItemViewModel(item)).ToList()
+            : Array.Empty<CardListItemViewModel>();
+
+        ShowDetailCommand = new RelayCommand(_ => ShowDetailRequested?.Invoke(this, EventArgs.Empty));
+    }
+
+    public event EventHandler? ShowDetailRequested;
+
+    public string Id { get; }
+
+    public string Day { get; }
+
+    public string KickOff { get; }
+
+    public string Competition { get; }
+
+    public string CompetitionKey { get; }
+
+    public string Opponent { get; }
+
+    public string Venue { get; }
+
+    public bool IsHome { get; }
+
+    public string Importance { get; }
+
+    public string? Result { get; private set; }
+
+    public string? Broadcast { get; private set; }
+
+    public string? TravelNote { get; private set; }
+
+    public string? PreparationNote { get; private set; }
+
+    public string? Status { get; private set; }
+
+    public string? CompetitionAccent { get; }
+
+    public IReadOnlyList<CardListItemViewModel> KeyPeople { get; }
+
+    public IReadOnlyList<CardListItemViewModel> Preparation { get; }
+
+    public ICommand ShowDetailCommand { get; }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        internal set => SetProperty(ref _isVisible, value);
+    }
+
+    internal void ApplyDetail(FixtureMatchDetailViewModel detail)
+    {
+        Result = detail.Result;
+        TravelNote = detail.TravelNote;
+        PreparationNote = detail.PreparationNote;
+        Status = detail.Status;
+        OnPropertyChanged(nameof(Result));
+        OnPropertyChanged(nameof(TravelNote));
+        OnPropertyChanged(nameof(PreparationNote));
+        OnPropertyChanged(nameof(Status));
+    }
+}
+
+public sealed class FixtureMatchDetailViewModel : ObservableObject, IDisposable
+{
+    private readonly FixtureCalendarMatchViewModel _match;
+    private readonly FixtureCalendarViewModel _owner;
+    private readonly AsyncRelayCommand _saveCommand;
+    private readonly RelayCommand _closeCommand;
+    private bool _isBusy;
+    private string? _statusMessage;
+    private string _preparationNote;
+    private string? _travelNote;
+    private string? _status;
+
+    internal FixtureMatchDetailViewModel(FixtureCalendarMatchViewModel match, FixtureCalendarViewModel owner)
+    {
+        _match = match ?? throw new ArgumentNullException(nameof(match));
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+
+        _preparationNote = match.PreparationNote ?? string.Empty;
+        _travelNote = match.TravelNote;
+        _status = match.Status;
+
+        Id = match.Id;
+        Opponent = match.Opponent;
+        Competition = match.Competition;
+        KickOff = match.KickOff;
+        Venue = match.Venue;
+        IsHome = match.IsHome;
+        Importance = match.Importance;
+        Result = match.Result;
+        Broadcast = match.Broadcast;
+        KeyPeople = match.KeyPeople;
+        Preparation = match.Preparation;
+
+        _saveCommand = new AsyncRelayCommand(SaveAsync, () => !IsBusy);
+        _closeCommand = new RelayCommand(_ => _owner.CloseDetail());
+    }
+
+    public string Id { get; }
+
+    public string Opponent { get; }
+
+    public string Competition { get; }
+
+    public string KickOff { get; }
+
+    public string Venue { get; }
+
+    public bool IsHome { get; }
+
+    public string Importance { get; }
+
+    public string? Result { get; }
+
+    public string? Broadcast { get; }
+
+    public IReadOnlyList<CardListItemViewModel> KeyPeople { get; }
+
+    public IReadOnlyList<CardListItemViewModel> Preparation { get; }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                _saveCommand.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        set => SetProperty(ref _statusMessage, value);
+    }
+
+    public string PreparationNote
+    {
+        get => _preparationNote;
+        set => SetProperty(ref _preparationNote, value);
+    }
+
+    public string? TravelNote
+    {
+        get => _travelNote;
+        set => SetProperty(ref _travelNote, value);
+    }
+
+    public string? Status
+    {
+        get => _status;
+        set => SetProperty(ref _status, value);
+    }
+
+    public ICommand SaveCommand => _saveCommand;
+
+    public ICommand CloseCommand => _closeCommand;
+
+    internal async Task SaveAsync()
+    {
+        await _owner.SaveMatchDetailAsync(this).ConfigureAwait(true);
+    }
+
+    public void Dispose()
+    {
+        _saveCommand.Dispose();
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/MainViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/MainViewModel.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class MainViewModel : ObservableObject
+{
+    private NavigationTabViewModel? _selectedTab;
+    private bool _isCompactHeader;
+    private bool _useCompactNavigation;
+
+    public MainViewModel(
+        INavigationCatalog navigationCatalog,
+        Func<NavigationTab, NavigationTabViewModel> tabFactory,
+        CardSurfaceViewModel cardSurface)
+    {
+        CardSurface = cardSurface;
+
+        var tabs = navigationCatalog
+            .GetTabs()
+            .Select(tabFactory)
+            .ToList();
+
+        Tabs = new ObservableCollection<NavigationTabViewModel>(tabs);
+
+        foreach (var tab in Tabs)
+        {
+            tab.PropertyChanged += OnTabPropertyChanged;
+        }
+
+        SelectTabCommand = new RelayCommand(param =>
+        {
+            if (param is NavigationTabViewModel tab)
+            {
+                SelectTab(tab);
+            }
+        });
+
+        EnsureSelectedTabAvailability();
+    }
+
+    public ObservableCollection<NavigationTabViewModel> Tabs { get; }
+
+    public NavigationTabViewModel? SelectedTab
+    {
+        get => _selectedTab;
+        private set => SetProperty(ref _selectedTab, value);
+    }
+
+    public CardSurfaceViewModel CardSurface { get; }
+
+    public ICommand SelectTabCommand { get; }
+
+    public bool IsCompactHeader
+    {
+        get => _isCompactHeader;
+        private set => SetProperty(ref _isCompactHeader, value);
+    }
+
+    public bool UseCompactNavigation
+    {
+        get => _useCompactNavigation;
+        private set => SetProperty(ref _useCompactNavigation, value);
+    }
+
+    public void UpdateViewport(double width)
+    {
+        const double compactHeaderThreshold = 1500;
+        const double compactNavigationThreshold = 1320;
+
+        IsCompactHeader = width < compactHeaderThreshold;
+        UseCompactNavigation = width < compactNavigationThreshold;
+    }
+
+    private void SelectTab(NavigationTabViewModel tab)
+    {
+        if (!tab.IsVisible || !tab.HasVisibleSubItems)
+        {
+            EnsureSelectedTabAvailability();
+            return;
+        }
+
+        if (SelectedTab == tab)
+        {
+            tab.EnsureActiveSectionBroadcast();
+            return;
+        }
+
+        var active = tab.ActiveSubItem;
+        if (active is null || !active.IsVisible)
+        {
+            var fallback = tab.SubItems.FirstOrDefault(item => item.IsVisible);
+            if (fallback is not null)
+            {
+                tab.ActivateSubItem(fallback);
+            }
+        }
+
+        foreach (var t in Tabs)
+        {
+            t.IsSelected = ReferenceEquals(t, tab);
+        }
+
+        SelectedTab = tab;
+        tab.EnsureActiveSectionBroadcast();
+    }
+
+    private void EnsureSelectedTabAvailability()
+    {
+        if (SelectedTab is not null && (!SelectedTab.IsVisible || !SelectedTab.HasVisibleSubItems))
+        {
+            SelectedTab.IsSelected = false;
+            SelectedTab = null;
+        }
+
+        if (SelectedTab is null)
+        {
+            var next = Tabs.FirstOrDefault(tab => tab.IsVisible && tab.HasVisibleSubItems);
+            if (next is null)
+            {
+                foreach (var tab in Tabs)
+                {
+                    tab.IsSelected = false;
+                }
+
+                return;
+            }
+
+            foreach (var tab in Tabs)
+            {
+                tab.IsSelected = ReferenceEquals(tab, next);
+            }
+
+            SelectedTab = next;
+            next.EnsureActiveSectionBroadcast();
+        }
+    }
+
+    private void OnTabPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(NavigationTabViewModel.IsVisible)
+            or nameof(NavigationTabViewModel.HasVisibleSubItems))
+        {
+            EnsureSelectedTabAvailability();
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/MedicalTimelineViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/MedicalTimelineViewModel.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Media;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class MedicalTimelineViewModel
+{
+    private readonly ReadOnlyCollection<MedicalTimelineEntryViewModel> _entries;
+
+    public MedicalTimelineViewModel(MedicalTimelineDefinition definition)
+    {
+        _entries = new ReadOnlyCollection<MedicalTimelineEntryViewModel>(CreateEntries(definition.Entries));
+        Summary = _entries.Count == 0
+            ? "No active injuries"
+            : $"{_entries.Count} active cases";
+    }
+
+    public IReadOnlyList<MedicalTimelineEntryViewModel> Entries => _entries;
+
+    public string Summary { get; }
+
+    public bool HasEntries => _entries.Count > 0;
+
+    private static List<MedicalTimelineEntryViewModel> CreateEntries(IReadOnlyList<MedicalTimelineEntryDefinition> definitions)
+    {
+        if (definitions is null || definitions.Count == 0)
+        {
+            return new List<MedicalTimelineEntryViewModel>();
+        }
+
+        var list = new List<MedicalTimelineEntryViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            list.Add(new MedicalTimelineEntryViewModel(definition));
+        }
+
+        return list;
+    }
+}
+
+public sealed class MedicalTimelineEntryViewModel
+{
+    private readonly MedicalTimelineEntryDefinition _definition;
+    private readonly ReadOnlyCollection<TimelineEntryViewModel> _phases;
+
+    public MedicalTimelineEntryViewModel(MedicalTimelineEntryDefinition definition)
+    {
+        _definition = definition;
+        _phases = new ReadOnlyCollection<TimelineEntryViewModel>(CreatePhases(definition.Phases));
+        AccentBrush = string.IsNullOrWhiteSpace(definition.Accent)
+            ? BrushUtilities.CreateFrozenBrush("#FF2EC4B6", Brushes.SlateBlue)
+            : BrushUtilities.CreateFrozenBrush(definition.Accent!, Brushes.SlateBlue);
+    }
+
+    public string Player => _definition.Player;
+
+    public string Diagnosis => _definition.Diagnosis;
+
+    public string Status => _definition.Status;
+
+    public string ExpectedReturn => _definition.ExpectedReturn;
+
+    public string? Notes => _definition.Notes;
+
+    public IReadOnlyList<TimelineEntryViewModel> Phases => _phases;
+
+    public bool HasNotes => !string.IsNullOrWhiteSpace(Notes);
+
+    public Brush AccentBrush { get; }
+
+    private static List<TimelineEntryViewModel> CreatePhases(IReadOnlyList<TimelineEntryDefinition> definitions)
+    {
+        if (definitions is null || definitions.Count == 0)
+        {
+            return new List<TimelineEntryViewModel>();
+        }
+
+        var list = new List<TimelineEntryViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            list.Add(new TimelineEntryViewModel(definition));
+        }
+
+        return list;
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/NavigationSubItemViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/NavigationSubItemViewModel.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Globalization;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class NavigationSubItemViewModel : ObservableObject
+{
+    private bool _isActive;
+    private readonly string _tabIdentifier;
+    private readonly INavigationIndicatorService _indicatorService;
+    private NavigationIndicatorSnapshot _indicator = NavigationIndicatorSnapshot.None;
+    private readonly INavigationPermissionService _permissionService;
+    private bool _isVisible = true;
+
+    public NavigationSubItemViewModel(
+        NavigationSubItem model,
+        string tabIdentifier,
+        INavigationIndicatorService indicatorService,
+        INavigationPermissionService permissionService)
+    {
+        Model = model;
+        _tabIdentifier = tabIdentifier;
+        _indicatorService = indicatorService ?? throw new ArgumentNullException(nameof(indicatorService));
+        _permissionService = permissionService ?? throw new ArgumentNullException(nameof(permissionService));
+
+        UpdateIndicator();
+        _indicatorService.IndicatorsChanged += OnIndicatorsChanged;
+        RefreshPermissions();
+        _permissionService.PermissionsChanged += OnPermissionsChanged;
+    }
+
+    public NavigationSubItem Model { get; }
+
+    public string Title => Model.Title;
+
+    public string Identifier => Model.Identifier;
+
+    public bool IsActive
+    {
+        get => _isActive;
+        set
+        {
+            if (!IsVisible && value)
+            {
+                value = false;
+            }
+
+            SetProperty(ref _isActive, value);
+        }
+    }
+
+    public bool HasAlert => _indicator.HasAlert;
+
+    public NavigationIndicatorSeverity Severity => _indicator.Severity;
+
+    public int AlertCount => _indicator.Count;
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        private set
+        {
+            if (SetProperty(ref _isVisible, value) && !value && IsActive)
+            {
+                IsActive = false;
+            }
+        }
+    }
+
+    public string? BadgeText
+    {
+        get
+        {
+            if (!HasAlert)
+            {
+                return null;
+            }
+
+            if (AlertCount <= 0)
+            {
+                return "!";
+            }
+
+            return AlertCount > 99
+                ? "99+"
+                : AlertCount.ToString(CultureInfo.CurrentCulture);
+        }
+    }
+
+    public string? AlertTooltip => _indicator.Tooltip ?? (HasAlert ? $"{Title} requires attention" : null);
+
+    internal void RefreshPermissions()
+    {
+        var visible = _permissionService.IsSectionVisible(_tabIdentifier, Identifier);
+        IsVisible = visible;
+    }
+
+    private void OnIndicatorsChanged(object? sender, EventArgs e)
+    {
+        UpdateIndicator();
+    }
+
+    private void OnPermissionsChanged(object? sender, EventArgs e)
+    {
+        RefreshPermissions();
+    }
+
+    private void UpdateIndicator()
+    {
+        var indicator = _indicatorService.GetIndicator(_tabIdentifier, Identifier);
+        if (_indicator.Equals(indicator))
+        {
+            return;
+        }
+
+        _indicator = indicator;
+        OnPropertyChanged(nameof(HasAlert));
+        OnPropertyChanged(nameof(Severity));
+        OnPropertyChanged(nameof(AlertCount));
+        OnPropertyChanged(nameof(BadgeText));
+        OnPropertyChanged(nameof(AlertTooltip));
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/NavigationTabViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/NavigationTabViewModel.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class NavigationTabViewModel : ObservableObject
+{
+    private readonly IEventAggregator _eventAggregator;
+    private readonly INavigationPermissionService _permissionService;
+    private bool _isSelected;
+    private NavigationSubItemViewModel? _activeSubItem;
+    private bool _hasAlerts;
+    private NavigationIndicatorSeverity _highestSeverity;
+    private string? _alertSummary;
+    private bool _isVisible = true;
+
+    public NavigationTabViewModel(
+        NavigationTab model,
+        IEventAggregator eventAggregator,
+        Func<string, NavigationSubItem, NavigationSubItemViewModel> subItemFactory,
+        INavigationPermissionService permissionService)
+    {
+        Model = model;
+        _eventAggregator = eventAggregator;
+        _permissionService = permissionService ?? throw new ArgumentNullException(nameof(permissionService));
+
+        if (subItemFactory is null)
+        {
+            throw new ArgumentNullException(nameof(subItemFactory));
+        }
+
+        var subItems = model.SubItems
+            .Select(sub =>
+            {
+                var viewModel = subItemFactory(model.Identifier, sub);
+                viewModel.PropertyChanged += OnSubItemPropertyChanged;
+                viewModel.RefreshPermissions();
+                return viewModel;
+            })
+            .ToList();
+
+        SubItems = new ObservableCollection<NavigationSubItemViewModel>(subItems);
+
+        SelectSubItemCommand = new RelayCommand(param =>
+        {
+            if (param is NavigationSubItemViewModel subItem)
+            {
+                ActivateSubItem(subItem);
+            }
+        });
+
+        EnsureActiveSubItemAvailability();
+
+        UpdateAlertState();
+        RefreshPermissions();
+        _permissionService.PermissionsChanged += OnPermissionsChanged;
+    }
+
+    public NavigationTab Model { get; }
+
+    public string Title => Model.Title;
+
+    public string Identifier => Model.Identifier;
+
+    public ObservableCollection<NavigationSubItemViewModel> SubItems { get; }
+
+    public ICommand SelectSubItemCommand { get; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set
+        {
+            if (SetProperty(ref _isSelected, value) && value && ActiveSubItem is not null)
+            {
+                PublishSectionChanged(ActiveSubItem);
+            }
+        }
+    }
+
+    public NavigationSubItemViewModel? ActiveSubItem
+    {
+        get => _activeSubItem;
+        private set => SetProperty(ref _activeSubItem, value);
+    }
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        private set => SetProperty(ref _isVisible, value);
+    }
+
+    public bool HasVisibleSubItems => SubItems.Any(item => item.IsVisible);
+
+    public void ActivateSubItem(NavigationSubItemViewModel target)
+    {
+        if (target is null || !target.IsVisible)
+        {
+            target = SubItems.FirstOrDefault(item => item.IsVisible);
+            if (target is null)
+            {
+                ActiveSubItem = null;
+                return;
+            }
+        }
+
+        foreach (var item in SubItems)
+        {
+            item.IsActive = ReferenceEquals(item, target);
+        }
+
+        ActiveSubItem = target;
+
+        if (IsSelected)
+        {
+            PublishSectionChanged(target);
+        }
+    }
+
+    public void EnsureActiveSectionBroadcast()
+    {
+        if (IsSelected && ActiveSubItem is not null)
+        {
+            PublishSectionChanged(ActiveSubItem);
+        }
+    }
+
+    public bool HasAlerts
+    {
+        get => _hasAlerts;
+        private set => SetProperty(ref _hasAlerts, value);
+    }
+
+    public NavigationIndicatorSeverity HighestSeverity
+    {
+        get => _highestSeverity;
+        private set => SetProperty(ref _highestSeverity, value);
+    }
+
+    public string? AlertSummary
+    {
+        get => _alertSummary;
+        private set => SetProperty(ref _alertSummary, value);
+    }
+
+    private void PublishSectionChanged(NavigationSubItemViewModel subItem)
+    {
+        _eventAggregator.Publish(new NavigationSectionChangedEvent(Identifier, subItem.Identifier));
+    }
+
+    private void OnSubItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(NavigationSubItemViewModel.HasAlert)
+            or nameof(NavigationSubItemViewModel.Severity)
+            or nameof(NavigationSubItemViewModel.BadgeText))
+        {
+            UpdateAlertState();
+        }
+
+        if (e.PropertyName is nameof(NavigationSubItemViewModel.IsVisible))
+        {
+            OnPropertyChanged(nameof(HasVisibleSubItems));
+            EnsureActiveSubItemAvailability();
+        }
+    }
+
+    private void UpdateAlertState()
+    {
+        var severity = NavigationIndicatorSeverity.None;
+        var summaries = new List<string>();
+
+        foreach (var subItem in SubItems)
+        {
+            if (subItem.HasAlert)
+            {
+                severity = (NavigationIndicatorSeverity)Math.Max((int)severity, (int)subItem.Severity);
+
+                if (!string.IsNullOrWhiteSpace(subItem.AlertTooltip))
+                {
+                    summaries.Add(subItem.AlertTooltip!);
+                }
+                else
+                {
+                    summaries.Add($"{subItem.Title} requires attention");
+                }
+            }
+        }
+
+        HasAlerts = severity != NavigationIndicatorSeverity.None;
+        HighestSeverity = severity;
+        AlertSummary = summaries.Count > 0 ? string.Join(Environment.NewLine, summaries) : null;
+    }
+
+    private void OnPermissionsChanged(object? sender, EventArgs e)
+    {
+        RefreshPermissions();
+        foreach (var subItem in SubItems)
+        {
+            subItem.RefreshPermissions();
+        }
+
+        OnPropertyChanged(nameof(HasVisibleSubItems));
+        EnsureActiveSubItemAvailability();
+    }
+
+    private void RefreshPermissions()
+    {
+        IsVisible = _permissionService.IsTabVisible(Identifier);
+
+        if (!IsVisible && IsSelected)
+        {
+            IsSelected = false;
+        }
+    }
+
+    private void EnsureActiveSubItemAvailability()
+    {
+        var target = ActiveSubItem;
+        if (target is null || !target.IsVisible)
+        {
+            target = SubItems.FirstOrDefault(item => item.IsVisible);
+            ActiveSubItem = target;
+        }
+
+        if (IsSelected && target is not null)
+        {
+            PublishSectionChanged(target);
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/ShotMapViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/ShotMapViewModel.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+using System.Windows.Media;
+using FMUI.Wpf.Infrastructure;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class ShotMapViewModel : ObservableObject
+{
+    private const double DefaultPitchWidth = 120d;
+    private const double DefaultPitchHeight = 80d;
+
+    private readonly ReadOnlyCollection<ShotMapFilterViewModel> _filters;
+    private readonly ReadOnlyCollection<ShotMapEventViewModel> _shots;
+    private readonly RelayCommand _selectShotCommand;
+    private readonly RelayCommand _clearSelectionCommand;
+    private readonly Dictionary<string, ShotMapFilterViewModel> _filterLookup;
+    private ShotMapEventViewModel? _selectedShot;
+    private string _summary;
+    private readonly double _pitchWidth;
+    private readonly double _pitchHeight;
+
+    public ShotMapViewModel(ShotMapDefinition definition)
+    {
+        _pitchWidth = definition.PitchWidth <= 0 ? DefaultPitchWidth : definition.PitchWidth;
+        _pitchHeight = definition.PitchHeight <= 0 ? DefaultPitchHeight : definition.PitchHeight;
+
+        _filters = new ReadOnlyCollection<ShotMapFilterViewModel>(CreateFilters(definition.Filters));
+        foreach (var filter in _filters)
+        {
+            filter.PropertyChanged += OnFilterPropertyChanged;
+        }
+
+        _filterLookup = _filters.ToDictionary(f => f.Key, StringComparer.OrdinalIgnoreCase);
+        _shots = new ReadOnlyCollection<ShotMapEventViewModel>(CreateShots(definition.Events, _filterLookup, _pitchWidth, _pitchHeight));
+
+        _selectShotCommand = new RelayCommand(
+            parameter =>
+            {
+                if (parameter is ShotMapEventViewModel shot && shot.IsVisible)
+                {
+                    SelectedShot = shot;
+                }
+            },
+            parameter => parameter is ShotMapEventViewModel shot && shot.IsVisible);
+
+        _clearSelectionCommand = new RelayCommand(
+            _ => SelectedShot = null,
+            _ => SelectedShot is not null);
+
+        UpdateShotVisibility();
+        _summary = BuildSummary();
+    }
+
+    public IReadOnlyList<ShotMapFilterViewModel> Filters => _filters;
+
+    public IReadOnlyList<ShotMapEventViewModel> Shots => _shots;
+
+    public double PitchWidth => _pitchWidth;
+
+    public double PitchHeight => _pitchHeight;
+
+    public ICommand SelectShotCommand => _selectShotCommand;
+
+    public ICommand ClearSelectionCommand => _clearSelectionCommand;
+
+    public ShotMapEventViewModel? SelectedShot
+    {
+        get => _selectedShot;
+        private set
+        {
+            if (SetProperty(ref _selectedShot, value))
+            {
+                foreach (var shot in _shots)
+                {
+                    shot.IsSelected = shot == value;
+                }
+
+                _clearSelectionCommand.RaiseCanExecuteChanged();
+                OnPropertyChanged(nameof(HasSelectedShot));
+            }
+        }
+    }
+
+    public bool HasSelectedShot => SelectedShot is not null;
+
+    public string Summary
+    {
+        get => _summary;
+        private set => SetProperty(ref _summary, value);
+    }
+
+    private void OnFilterPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ShotMapFilterViewModel.IsEnabled))
+        {
+            UpdateShotVisibility();
+            Summary = BuildSummary();
+            _selectShotCommand.RaiseCanExecuteChanged();
+        }
+    }
+
+    private void UpdateShotVisibility()
+    {
+        foreach (var shot in _shots)
+        {
+            var isEnabled = shot.Filter is null || shot.Filter.IsEnabled;
+            shot.IsVisible = isEnabled;
+
+            if (!isEnabled && ReferenceEquals(SelectedShot, shot))
+            {
+                SelectedShot = null;
+            }
+        }
+    }
+
+    private string BuildSummary()
+    {
+        var total = _shots.Count;
+        if (total == 0)
+        {
+            return "No shots recorded";
+        }
+
+        var visible = _shots.Count(s => s.IsVisible);
+        var goals = _shots.Count(s => s.IsVisible && s.Filter?.IsGoal == true);
+        var onTarget = _shots.Count(s => s.IsVisible && s.Filter?.IsOnTarget == true);
+
+        return $"{visible} of {total} shots shown • {goals} goals • {onTarget} on target";
+    }
+
+    private static List<ShotMapFilterViewModel> CreateFilters(IReadOnlyList<ShotMapFilterDefinition> definitions)
+    {
+        if (definitions is null || definitions.Count == 0)
+        {
+            return new List<ShotMapFilterViewModel>();
+        }
+
+        var list = new List<ShotMapFilterViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            list.Add(new ShotMapFilterViewModel(definition));
+        }
+
+        return list;
+    }
+
+    private static List<ShotMapEventViewModel> CreateShots(
+        IReadOnlyList<ShotMapEventDefinition> definitions,
+        Dictionary<string, ShotMapFilterViewModel> filterLookup,
+        double pitchWidth,
+        double pitchHeight)
+    {
+        if (definitions is null || definitions.Count == 0)
+        {
+            return new List<ShotMapEventViewModel>();
+        }
+
+        var list = new List<ShotMapEventViewModel>(definitions.Count);
+        foreach (var definition in definitions)
+        {
+            filterLookup.TryGetValue(definition.OutcomeKey, out var filter);
+            list.Add(new ShotMapEventViewModel(definition, filter, pitchWidth, pitchHeight));
+        }
+
+        return list;
+    }
+}
+
+public sealed class ShotMapFilterViewModel : ObservableObject
+{
+    private readonly ShotMapFilterDefinition _definition;
+    private bool _isEnabled;
+
+    public ShotMapFilterViewModel(ShotMapFilterDefinition definition)
+    {
+        _definition = definition;
+        _isEnabled = definition.IsDefault;
+        Brush = BrushUtilities.CreateFrozenBrush(definition.Color, Brushes.DeepSkyBlue);
+        IsGoal = string.Equals(definition.Key, "goal", StringComparison.OrdinalIgnoreCase);
+        IsOnTarget = IsGoal || string.Equals(definition.Key, "on-target", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public string Key => _definition.Key;
+
+    public string DisplayName => _definition.DisplayName;
+
+    public Brush Brush { get; }
+
+    public bool IsGoal { get; }
+
+    public bool IsOnTarget { get; }
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set => SetProperty(ref _isEnabled, value);
+    }
+}
+
+public sealed class ShotMapEventViewModel : ObservableObject
+{
+    private const double TokenSize = 16d;
+
+    private readonly ShotMapEventDefinition _definition;
+    private readonly double _pitchWidth;
+    private readonly double _pitchHeight;
+    private readonly SolidColorBrush _fillBrush;
+    private bool _isVisible = true;
+    private bool _isSelected;
+
+    public ShotMapEventViewModel(ShotMapEventDefinition definition, ShotMapFilterViewModel? filter, double pitchWidth, double pitchHeight)
+    {
+        _definition = definition;
+        Filter = filter;
+        _pitchWidth = pitchWidth <= 0 ? 120d : pitchWidth;
+        _pitchHeight = pitchHeight <= 0 ? 80d : pitchHeight;
+
+        var baseColor = !string.IsNullOrWhiteSpace(definition.Accent)
+            ? BrushUtilities.CreateFrozenBrush(definition.Accent!, Brushes.DeepSkyBlue)
+            : filter?.Brush as SolidColorBrush ?? BrushUtilities.CreateFrozenBrush("#FF2EC4B6", Brushes.DeepSkyBlue);
+
+        _fillBrush = baseColor;
+    }
+
+    public ShotMapFilterViewModel? Filter { get; }
+
+    public string Player => _definition.Player;
+
+    public string Minute => _definition.Minute;
+
+    public string OutcomeKey => _definition.OutcomeKey;
+
+    public string OutcomeDisplay => Filter?.DisplayName ?? OutcomeKey;
+
+    public string? Assist => _definition.Assist;
+
+    public string? BodyPart => _definition.BodyPart;
+
+    public double? ExpectedGoals => _definition.ExpectedGoals;
+
+    public string? Detail => _definition.Detail;
+
+    public Brush FillBrush => _fillBrush;
+
+    public Brush StrokeBrush => Brushes.White;
+
+    public double NormalizedX => Math.Clamp(_definition.X / _pitchWidth, 0d, 1d);
+
+    public double NormalizedY => Math.Clamp(_definition.Y / _pitchHeight, 0d, 1d);
+
+    public double CanvasLeft => Math.Clamp(_definition.X, 0d, _pitchWidth) - (TokenSize / 2d);
+
+    public double CanvasTop => Math.Clamp(_definition.Y, 0d, _pitchHeight) - (TokenSize / 2d);
+
+    public double Diameter => TokenSize;
+
+    public bool IsVisible
+    {
+        get => _isVisible;
+        set => SetProperty(ref _isVisible, value);
+    }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => SetProperty(ref _isSelected, value);
+    }
+
+    public string Tooltip
+    {
+        get
+        {
+            var parts = new List<string>
+            {
+                $"{Minute} — {Player}",
+                $"Outcome: {OutcomeDisplay}"
+            };
+
+            if (ExpectedGoals is not null)
+            {
+                parts.Add($"xG: {ExpectedGoals:0.00}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(Assist))
+            {
+                parts.Add($"Assist: {Assist}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(BodyPart))
+            {
+                parts.Add($"Body Part: {BodyPart}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(Detail))
+            {
+                parts.Add(_definition.Detail!);
+            }
+
+            return string.Join("\n", parts);
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/TrainingCalendarViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/TrainingCalendarViewModel.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.Services;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class TrainingCalendarViewModel : ObservableObject
+{
+    private readonly IClubDataService _clubDataService;
+    private readonly IReadOnlyList<string> _days;
+    private readonly IReadOnlyList<string> _slots;
+    private readonly Dictionary<string, TrainingCalendarSlotViewModel> _slotLookup;
+    private bool _isBusy;
+    private string? _statusMessage;
+
+    public TrainingCalendarViewModel(TrainingCalendarDefinition definition, IClubDataService clubDataService)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+        _days = definition.Days?.Count > 0 ? definition.Days : Array.Empty<string>();
+        _slots = definition.Slots?.Count > 0 ? definition.Slots : Array.Empty<string>();
+        _slotLookup = new Dictionary<string, TrainingCalendarSlotViewModel>(StringComparer.OrdinalIgnoreCase);
+
+        Days = new ObservableCollection<TrainingCalendarDayViewModel>();
+
+        foreach (var day in _days)
+        {
+            var dayViewModel = new TrainingCalendarDayViewModel(day, _slots);
+            Days.Add(dayViewModel);
+
+            foreach (var slot in dayViewModel.Slots)
+            {
+                _slotLookup[CreateSlotKey(day, slot.Slot)] = slot;
+            }
+        }
+
+        if (definition.Sessions is { Count: > 0 })
+        {
+            foreach (var session in definition.Sessions)
+            {
+                var sessionViewModel = new TrainingCalendarSessionViewModel(session);
+
+                if (!TryGetSlot(session.Day, session.Slot, out var slotViewModel))
+                {
+                    continue;
+                }
+
+                slotViewModel.InsertSession(sessionViewModel, slotViewModel.Sessions.Count);
+            }
+        }
+    }
+
+    public ObservableCollection<TrainingCalendarDayViewModel> Days { get; }
+
+    public IReadOnlyList<string> Slots => _slots;
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                OnPropertyChanged(nameof(CanInteract));
+            }
+        }
+    }
+
+    public bool CanInteract => !IsBusy;
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set
+        {
+            if (SetProperty(ref _statusMessage, value))
+            {
+                OnPropertyChanged(nameof(HasStatusMessage));
+            }
+        }
+    }
+
+    public bool HasStatusMessage => !string.IsNullOrWhiteSpace(StatusMessage);
+
+    internal bool TryGetSlot(string day, string slot, out TrainingCalendarSlotViewModel slotViewModel)
+    {
+        return _slotLookup.TryGetValue(CreateSlotKey(day, slot), out slotViewModel!);
+    }
+
+    internal async Task<bool> MoveSessionAsync(TrainingCalendarSessionViewModel session, TrainingCalendarSlotViewModel targetSlot, int targetIndex)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        if (targetSlot is null)
+        {
+            throw new ArgumentNullException(nameof(targetSlot));
+        }
+
+        if (IsBusy)
+        {
+            return false;
+        }
+
+        if (!TryGetSlot(session.Day, session.Slot, out var originalSlot))
+        {
+            return false;
+        }
+
+        var originalIndex = originalSlot.Sessions.IndexOf(session);
+        if (originalIndex < 0)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(originalSlot, targetSlot))
+        {
+            if (targetIndex > originalSlot.Sessions.Count)
+            {
+                targetIndex = originalSlot.Sessions.Count;
+            }
+
+            if (targetIndex > originalIndex)
+            {
+                targetIndex--;
+            }
+
+            if (targetIndex == originalIndex)
+            {
+                return false;
+            }
+        }
+        else
+        {
+            if (targetIndex < 0)
+            {
+                targetIndex = 0;
+            }
+            else if (targetIndex > targetSlot.Sessions.Count)
+            {
+                targetIndex = targetSlot.Sessions.Count;
+            }
+        }
+
+        originalSlot.RemoveSession(session);
+        targetSlot.InsertSession(session, targetIndex);
+
+        try
+        {
+            IsBusy = true;
+            StatusMessage = $"Moving to {targetSlot.Day} {targetSlot.Slot}...";
+
+            var updatedSessions = Days
+                .SelectMany(day => day.Slots.SelectMany(slot => slot.Sessions.Select(item => item.ToSnapshot())))
+                .ToList();
+
+            var ordered = TrainingCalendarFormatter.OrderSessions(updatedSessions);
+            var overview = TrainingCalendarFormatter.BuildWeekOverview(ordered).ToList();
+
+            await _clubDataService.UpdateAsync(snapshot =>
+            {
+                var calendar = snapshot.Training.Calendar with
+                {
+                    SessionDetails = ordered,
+                    WeekOverview = overview
+                };
+
+                var training = snapshot.Training with { Calendar = calendar };
+                return snapshot with { Training = training };
+            }).ConfigureAwait(true);
+
+            StatusMessage = $"Session moved to {targetSlot.Day} {targetSlot.Slot}.";
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // revert
+            targetSlot.RemoveSession(session);
+            originalSlot.InsertSession(session, originalIndex);
+            StatusMessage = $"Unable to move session: {ex.Message}";
+            return false;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static string CreateSlotKey(string day, string slot)
+    {
+        return $"{day}|{slot}";
+    }
+}
+
+public sealed class TrainingCalendarDayViewModel : ObservableObject
+{
+    public TrainingCalendarDayViewModel(string day, IReadOnlyList<string> slots)
+    {
+        Day = day;
+        Slots = new ObservableCollection<TrainingCalendarSlotViewModel>(
+            slots?.Select(slot => new TrainingCalendarSlotViewModel(day, slot))
+            ?? Array.Empty<TrainingCalendarSlotViewModel>());
+    }
+
+    public string Day { get; }
+
+    public ObservableCollection<TrainingCalendarSlotViewModel> Slots { get; }
+}
+
+public sealed class TrainingCalendarSlotViewModel : ObservableObject
+{
+    public TrainingCalendarSlotViewModel(string day, string slot)
+    {
+        Day = day;
+        Slot = slot;
+        Sessions = new ObservableCollection<TrainingCalendarSessionViewModel>();
+        Sessions.CollectionChanged += (_, __) => OnPropertyChanged(nameof(HasSessions));
+    }
+
+    public string Day { get; }
+
+    public string Slot { get; }
+
+    public ObservableCollection<TrainingCalendarSessionViewModel> Sessions { get; }
+
+    public bool HasSessions => Sessions.Count > 0;
+
+    internal void InsertSession(TrainingCalendarSessionViewModel session, int index)
+    {
+        if (session is null)
+        {
+            throw new ArgumentNullException(nameof(session));
+        }
+
+        if (index < 0 || index > Sessions.Count)
+        {
+            index = Sessions.Count;
+        }
+
+        Sessions.Insert(index, session);
+        session.UpdatePosition(Day, Slot);
+    }
+
+    internal bool RemoveSession(TrainingCalendarSessionViewModel session)
+    {
+        if (session is null)
+        {
+            return false;
+        }
+
+        var index = Sessions.IndexOf(session);
+        if (index < 0)
+        {
+            return false;
+        }
+
+        Sessions.RemoveAt(index);
+        session.UpdatePosition(string.Empty, string.Empty);
+        return true;
+    }
+}
+
+public sealed class TrainingCalendarSessionViewModel : ObservableObject
+{
+    public TrainingCalendarSessionViewModel(TrainingCalendarSessionDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Id = definition.Id;
+        Activity = definition.Activity;
+        Focus = definition.Focus;
+        Intensity = definition.Intensity;
+        Day = definition.Day;
+        Slot = definition.Slot;
+    }
+
+    public string Id { get; }
+
+    public string Activity { get; }
+
+    public string? Focus { get; }
+
+    public string? Intensity { get; }
+
+    public string Day { get; private set; }
+
+    public string Slot { get; private set; }
+
+    public string? FocusDisplay => string.IsNullOrWhiteSpace(Focus) ? null : Focus;
+
+    public string? IntensityDisplay => string.IsNullOrWhiteSpace(Intensity) ? null : Intensity;
+
+    public bool HasFocus => !string.IsNullOrWhiteSpace(Focus);
+
+    public bool HasIntensity => !string.IsNullOrWhiteSpace(Intensity);
+
+    public TrainingSessionDetailSnapshot ToSnapshot()
+    {
+        return new TrainingSessionDetailSnapshot(Id, Day, Slot, Activity, Focus, Intensity);
+    }
+
+    internal void UpdatePosition(string day, string slot)
+    {
+        if (!string.Equals(Day, day, StringComparison.OrdinalIgnoreCase))
+        {
+            Day = day;
+            OnPropertyChanged(nameof(Day));
+        }
+
+        if (!string.Equals(Slot, slot, StringComparison.OrdinalIgnoreCase))
+        {
+            Slot = slot;
+            OnPropertyChanged(nameof(Slot));
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/TrainingProgressionViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/TrainingProgressionViewModel.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Media;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class TrainingProgressionViewModel
+{
+    public TrainingProgressionViewModel(TrainingProgressionDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Periods = new ReadOnlyCollection<string>(definition.Periods?.ToList() ?? new List<string>());
+        Minimum = definition.Minimum;
+        Maximum = definition.Maximum;
+        Summary = definition.Summary;
+
+        var series = new List<TrainingProgressionSeriesViewModel>();
+        var chartSeries = new List<ChartSeriesViewModel>();
+
+        if (definition.Series is { Count: > 0 })
+        {
+            foreach (var seriesDefinition in definition.Series)
+            {
+                var viewModel = new TrainingProgressionSeriesViewModel(seriesDefinition);
+                series.Add(viewModel);
+                chartSeries.Add(viewModel.ChartSeries);
+            }
+        }
+
+        Series = new ReadOnlyCollection<TrainingProgressionSeriesViewModel>(series);
+        ChartSeries = new ReadOnlyCollection<ChartSeriesViewModel>(chartSeries);
+    }
+
+    public IReadOnlyList<string> Periods { get; }
+
+    public double Minimum { get; }
+
+    public double Maximum { get; }
+
+    public string? Summary { get; }
+
+    public IReadOnlyList<TrainingProgressionSeriesViewModel> Series { get; }
+
+    public IReadOnlyList<ChartSeriesViewModel> ChartSeries { get; }
+
+    public bool HasSeries => Series.Count > 0;
+}
+
+public sealed class TrainingProgressionSeriesViewModel
+{
+    private static readonly Brush DefaultStroke = BrushUtilities.CreateFrozenBrush("#3E8EF7");
+    private readonly TrainingProgressionSeriesDefinition _definition;
+
+    public TrainingProgressionSeriesViewModel(TrainingProgressionSeriesDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+
+        var points = definition.Points is { Count: > 0 }
+            ? definition.Points.Select(point => new TrainingProgressionPointViewModel(point)).ToList()
+            : new List<TrainingProgressionPointViewModel>();
+
+        Points = new ReadOnlyCollection<TrainingProgressionPointViewModel>(points);
+
+        var chartPoints = points.Select(point => new ChartDataPointDefinition(point.Period, point.Value)).ToList();
+        var chartDefinition = new ChartSeriesDefinition(definition.Name, definition.Color, chartPoints);
+        ChartSeries = new ChartSeriesViewModel(chartDefinition);
+        Stroke = BrushUtilities.CreateFrozenBrush(definition.Color, DefaultStroke);
+    }
+
+    public string Id => _definition.Id;
+
+    public string Name => _definition.Name;
+
+    public string Color => _definition.Color;
+
+    public string? Accent => _definition.Accent;
+
+    public bool IsHighlighted => _definition.IsHighlighted;
+
+    public IReadOnlyList<TrainingProgressionPointViewModel> Points { get; }
+
+    public ChartSeriesViewModel ChartSeries { get; }
+
+    public Brush Stroke { get; }
+
+    public TrainingProgressionPointViewModel? LatestPoint => Points.Count > 0 ? Points[^1] : null;
+
+    public string LatestValueDisplay => LatestPoint is null ? "—" : FormatValue(LatestPoint.Value);
+
+    public string? LatestDetail => LatestPoint?.Detail;
+
+    public bool HasLatestDetail => !string.IsNullOrWhiteSpace(LatestDetail);
+
+    private static string FormatValue(double value)
+    {
+        return value.ToString(value >= 0 ? "+0.0" : "-0.0");
+    }
+}
+
+public sealed class TrainingProgressionPointViewModel
+{
+    private readonly TrainingProgressionPointDefinition _definition;
+
+    public TrainingProgressionPointViewModel(TrainingProgressionPointDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+    }
+
+    public string Period => _definition.Period;
+
+    public double Value => _definition.Value;
+
+    public string DisplayValue => Value.ToString("0.0");
+
+    public string? Detail => _definition.Detail;
+}

--- a/WPF/FMUI.Wpf/ViewModels/TrainingUnitBoardViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/TrainingUnitBoardViewModel.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class TrainingUnitBoardViewModel
+{
+    public TrainingUnitBoardViewModel(TrainingUnitBoardDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Units = new ReadOnlyCollection<TrainingUnitUnitViewModel>(
+            definition.Units
+                .Select(TrainingUnitUnitViewModel.FromDefinition)
+                .ToList());
+
+        AvailablePlayers = new ReadOnlyCollection<TrainingUnitMemberViewModel>(
+            definition.AvailablePlayers
+                .Select(TrainingUnitMemberViewModel.FromDefinition)
+                .ToList());
+
+        HasAvailablePlayers = AvailablePlayers.Count > 0;
+    }
+
+    public IReadOnlyList<TrainingUnitUnitViewModel> Units { get; }
+
+    public IReadOnlyList<TrainingUnitMemberViewModel> AvailablePlayers { get; }
+
+    public bool HasAvailablePlayers { get; }
+}
+
+public sealed class TrainingUnitUnitViewModel
+{
+    private TrainingUnitUnitViewModel(
+        string id,
+        string name,
+        string? coachId,
+        string? coachName,
+        string? coachAccent,
+        IReadOnlyList<TrainingUnitCoachOptionDefinition> coachOptions,
+        IReadOnlyList<TrainingUnitMemberViewModel> members)
+    {
+        Id = id;
+        Name = name;
+        CoachId = coachId;
+        CoachName = string.IsNullOrWhiteSpace(coachName) ? "Unassigned" : coachName;
+        CoachAccent = coachAccent;
+        CoachOptions = new ReadOnlyCollection<TrainingUnitCoachOptionDefinition>(coachOptions);
+        Members = new ReadOnlyCollection<TrainingUnitMemberViewModel>(members);
+        HasMembers = Members.Count > 0;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string? CoachId { get; }
+
+    public string CoachName { get; }
+
+    public string? CoachAccent { get; }
+
+    public IReadOnlyList<TrainingUnitCoachOptionDefinition> CoachOptions { get; }
+
+    public IReadOnlyList<TrainingUnitMemberViewModel> Members { get; }
+
+    public bool HasMembers { get; }
+
+    public static TrainingUnitUnitViewModel FromDefinition(TrainingUnitGroupDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        var members = definition.Members
+            .Select(TrainingUnitMemberViewModel.FromDefinition)
+            .ToList();
+
+        return new TrainingUnitUnitViewModel(
+            definition.Id,
+            definition.Name,
+            definition.CoachId,
+            definition.CoachName,
+            definition.CoachAccent,
+            definition.CoachOptions,
+            members);
+    }
+}
+
+public sealed class TrainingUnitMemberViewModel
+{
+    private TrainingUnitMemberViewModel(
+        string id,
+        string name,
+        string position,
+        string role,
+        string status,
+        string? accent,
+        string? detail)
+    {
+        Id = id;
+        Name = name;
+        Position = position;
+        Role = role;
+        Status = status;
+        Accent = accent;
+        Detail = detail;
+        HasDetail = !string.IsNullOrWhiteSpace(detail);
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string Position { get; }
+
+    public string Role { get; }
+
+    public string Status { get; }
+
+    public string? Accent { get; }
+
+    public string? Detail { get; }
+
+    public bool HasDetail { get; }
+
+    public static TrainingUnitMemberViewModel FromDefinition(TrainingUnitMemberDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        return new TrainingUnitMemberViewModel(
+            definition.Id,
+            definition.Name,
+            definition.Position,
+            definition.Role,
+            definition.Status,
+            definition.Accent,
+            definition.Detail);
+    }
+}

--- a/WPF/FMUI.Wpf/ViewModels/TransferNegotiationViewModel.cs
+++ b/WPF/FMUI.Wpf/ViewModels/TransferNegotiationViewModel.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.ViewModels;
+
+public sealed class TransferNegotiationCardViewModel
+{
+    public TransferNegotiationCardViewModel(TransferNegotiationDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Deals = definition.Deals is { Count: > 0 }
+            ? definition.Deals.Select(deal => new TransferNegotiationDealCardViewModel(deal)).ToList()
+            : new List<TransferNegotiationDealCardViewModel>();
+    }
+
+    public IReadOnlyList<TransferNegotiationDealCardViewModel> Deals { get; }
+
+    public bool HasDeals => Deals.Count > 0;
+}
+
+public sealed class TransferNegotiationDealCardViewModel
+{
+    public TransferNegotiationDealCardViewModel(TransferNegotiationDealDefinition definition)
+    {
+        if (definition is null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        Player = definition.Player;
+        Position = definition.Position;
+        Club = definition.Club;
+        Stage = definition.Stage;
+        Status = definition.Status;
+        Deadline = definition.Deadline;
+        Summary = definition.Summary;
+        Agent = definition.Agent;
+        Response = definition.Response;
+        Accent = definition.Accent;
+
+        Terms = definition.Terms is { Count: > 0 }
+            ? definition.Terms.Select(term => new TransferNegotiationTermCardViewModel(term)).ToList()
+            : new List<TransferNegotiationTermCardViewModel>();
+    }
+
+    public string Player { get; }
+
+    public string Position { get; }
+
+    public string Club { get; }
+
+    public string Stage { get; }
+
+    public string Status { get; }
+
+    public string Deadline { get; }
+
+    public string Summary { get; }
+
+    public string Agent { get; }
+
+    public string Response { get; }
+
+    public string? Accent { get; }
+
+    public IReadOnlyList<TransferNegotiationTermCardViewModel> Terms { get; }
+
+    public bool HasSummary => !string.IsNullOrWhiteSpace(Summary);
+
+    public bool HasAgent => !string.IsNullOrWhiteSpace(Agent);
+
+    public bool HasResponse => !string.IsNullOrWhiteSpace(Response);
+
+    public bool HasAccent => !string.IsNullOrWhiteSpace(Accent);
+}
+
+public sealed class TransferNegotiationTermCardViewModel
+{
+    private readonly TransferNegotiationTermDefinition _definition;
+
+    public TransferNegotiationTermCardViewModel(TransferNegotiationTermDefinition definition)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        DisplayValue = string.Format(CultureInfo.InvariantCulture, definition.Format, definition.Value);
+        TargetDisplay = string.Format(CultureInfo.InvariantCulture, definition.Format, definition.Target);
+        DeltaDisplay = string.Format(
+            CultureInfo.InvariantCulture,
+            definition.Format,
+            definition.Value - definition.Target);
+        Progress = CalculateProgress(definition.Value, definition.Target, definition.Maximum);
+        IsTargetMet = definition.Value >= definition.Target;
+    }
+
+    public string Label => _definition.Label;
+
+    public string DisplayValue { get; }
+
+    public string TargetDisplay { get; }
+
+    public string DeltaDisplay { get; }
+
+    public double Progress { get; }
+
+    public bool IsTargetMet { get; }
+
+    public string? Tooltip => _definition.Tooltip;
+
+    private static double CalculateProgress(double value, double target, double maximum)
+    {
+        if (target <= 0 && maximum <= 0)
+        {
+            return value > 0 ? 1d : 0d;
+        }
+
+        var denominator = target > 0 ? target : maximum;
+        if (denominator <= 0)
+        {
+            return 0d;
+        }
+
+        var ratio = value / denominator;
+        if (double.IsNaN(ratio) || double.IsInfinity(ratio))
+        {
+            return 0d;
+        }
+
+        return Math.Clamp(ratio, 0d, 1d);
+    }
+}

--- a/WPF/FMUI.Wpf/Views/AccentToBrushConverter.cs
+++ b/WPF/FMUI.Wpf/Views/AccentToBrushConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Views;
+
+public sealed class AccentToBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string accent && !string.IsNullOrWhiteSpace(accent))
+        {
+            return BrushUtilities.CreateFrozenBrush(accent, Brushes.DeepSkyBlue);
+        }
+
+        return Brushes.Transparent;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException("AccentToBrushConverter does not support ConvertBack.");
+    }
+}

--- a/WPF/FMUI.Wpf/Views/CardBodyTemplateSelector.cs
+++ b/WPF/FMUI.Wpf/Views/CardBodyTemplateSelector.cs
@@ -1,0 +1,100 @@
+using System.Windows;
+using System.Windows.Controls;
+using FMUI.Wpf.Models;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Views;
+
+public sealed class CardBodyTemplateSelector : DataTemplateSelector
+{
+    public DataTemplate? MetricTemplate { get; set; }
+
+    public DataTemplate? ListTemplate { get; set; }
+
+    public DataTemplate? FormationTemplate { get; set; }
+
+    public DataTemplate? FixtureTemplate { get; set; }
+
+    public DataTemplate? StatusTemplate { get; set; }
+
+    public DataTemplate? LineChartTemplate { get; set; }
+
+    public DataTemplate? GaugeTemplate { get; set; }
+
+    public DataTemplate? TimelineTemplate { get; set; }
+
+    public DataTemplate? TrainingCalendarTemplate { get; set; }
+
+    public DataTemplate? ForecastTemplate { get; set; }
+
+    public DataTemplate? WorkloadHeatmapTemplate { get; set; }
+
+    public DataTemplate? MoraleHeatmapTemplate { get; set; }
+
+    public DataTemplate? SquadTableTemplate { get; set; }
+
+    public DataTemplate? FixtureCalendarTemplate { get; set; }
+
+    public DataTemplate? TransferNegotiationTemplate { get; set; }
+
+    public DataTemplate? ScoutAssignmentsTemplate { get; set; }
+
+    public DataTemplate? ShortlistBoardTemplate { get; set; }
+
+    public DataTemplate? TrainingUnitBoardTemplate { get; set; }
+
+    public DataTemplate? TrainingProgressionTemplate { get; set; }
+
+    public DataTemplate? ShotMapTemplate { get; set; }
+
+    public DataTemplate? MedicalTimelineTemplate { get; set; }
+
+    public DataTemplate? ClubVisionRoadmapTemplate { get; set; }
+
+    public DataTemplate? ClubVisionExpectationsTemplate { get; set; }
+
+    public DataTemplate? FinanceCashflowTemplate { get; set; }
+
+    public DataTemplate? FinanceBudgetAllocatorTemplate { get; set; }
+
+    public DataTemplate? FinanceScenarioTemplate { get; set; }
+
+    public override DataTemplate? SelectTemplate(object item, DependencyObject container)
+    {
+        if (item is CardViewModel card)
+        {
+            return card.Kind switch
+            {
+                CardKind.Metric => MetricTemplate ?? base.SelectTemplate(item, container),
+                CardKind.List => ListTemplate ?? base.SelectTemplate(item, container),
+                CardKind.Formation => FormationTemplate ?? base.SelectTemplate(item, container),
+                CardKind.Fixture => FixtureTemplate ?? base.SelectTemplate(item, container),
+                CardKind.Status => StatusTemplate ?? base.SelectTemplate(item, container),
+                CardKind.LineChart => LineChartTemplate ?? base.SelectTemplate(item, container),
+                CardKind.Gauge => GaugeTemplate ?? base.SelectTemplate(item, container),
+                CardKind.Timeline => TimelineTemplate ?? base.SelectTemplate(item, container),
+                CardKind.TrainingCalendar => TrainingCalendarTemplate ?? base.SelectTemplate(item, container),
+                CardKind.Forecast => ForecastTemplate ?? base.SelectTemplate(item, container),
+                CardKind.WorkloadHeatmap => WorkloadHeatmapTemplate ?? base.SelectTemplate(item, container),
+                CardKind.MoraleHeatmap => MoraleHeatmapTemplate ?? base.SelectTemplate(item, container),
+                CardKind.SquadTable => SquadTableTemplate ?? base.SelectTemplate(item, container),
+                CardKind.FixtureCalendar => FixtureCalendarTemplate ?? base.SelectTemplate(item, container),
+                CardKind.TransferNegotiation => TransferNegotiationTemplate ?? base.SelectTemplate(item, container),
+                CardKind.ScoutAssignments => ScoutAssignmentsTemplate ?? base.SelectTemplate(item, container),
+                CardKind.ShortlistBoard => ShortlistBoardTemplate ?? base.SelectTemplate(item, container),
+                CardKind.TrainingUnitBoard => TrainingUnitBoardTemplate ?? base.SelectTemplate(item, container),
+                CardKind.TrainingProgression => TrainingProgressionTemplate ?? base.SelectTemplate(item, container),
+                CardKind.ShotMap => ShotMapTemplate ?? base.SelectTemplate(item, container),
+                CardKind.MedicalTimeline => MedicalTimelineTemplate ?? base.SelectTemplate(item, container),
+                CardKind.ClubVisionRoadmap => ClubVisionRoadmapTemplate ?? base.SelectTemplate(item, container),
+                CardKind.ClubVisionExpectations => ClubVisionExpectationsTemplate ?? base.SelectTemplate(item, container),
+                CardKind.FinanceCashflow => FinanceCashflowTemplate ?? base.SelectTemplate(item, container),
+                CardKind.FinanceBudgetAllocator => FinanceBudgetAllocatorTemplate ?? base.SelectTemplate(item, container),
+                CardKind.FinanceScenarioBoard => FinanceScenarioTemplate ?? base.SelectTemplate(item, container),
+                _ => base.SelectTemplate(item, container)
+            };
+        }
+
+        return base.SelectTemplate(item, container);
+    }
+}

--- a/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml
+++ b/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml
@@ -1,0 +1,4556 @@
+<UserControl x:Class="FMUI.Wpf.Views.CardSurfaceView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:editors="clr-namespace:FMUI.Wpf.ViewModels.Editors"
+             xmlns:controls="clr-namespace:FMUI.Wpf.Controls"
+             xmlns:behaviors="clr-namespace:FMUI.Wpf.Infrastructure.Behaviors"
+             xmlns:views="clr-namespace:FMUI.Wpf.Views"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=vm:CardSurfaceViewModel}"
+             Focusable="True">
+    <UserControl.InputBindings>
+        <KeyBinding Key="Z"
+                    Modifiers="Control"
+                    Command="{Binding UndoCommand}" />
+        <KeyBinding Key="Y"
+                    Modifiers="Control"
+                    Command="{Binding RedoCommand}" />
+        <KeyBinding Key="Z"
+                    Modifiers="Control,Shift"
+                    Command="{Binding RedoCommand}" />
+        <KeyBinding Key="Left"
+                    Command="{Binding NudgeLeftCommand}" />
+        <KeyBinding Key="Right"
+                    Command="{Binding NudgeRightCommand}" />
+        <KeyBinding Key="Up"
+                    Command="{Binding NudgeUpCommand}" />
+        <KeyBinding Key="Down"
+                    Command="{Binding NudgeDownCommand}" />
+        <KeyBinding Key="Escape"
+                    Command="{Binding ClearSelectionCommand}" />
+        <KeyBinding Key="Delete"
+                    Command="{Binding RemoveSelectedCardsCommand}" />
+    </UserControl.InputBindings>
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <views:RelativePositionConverter x:Key="RelativePositionConverter" />
+        <views:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+        <views:HexColorBrushConverter x:Key="HexColorBrushConverter" />
+
+        <Style x:Key="CardBorderStyle" TargetType="Border">
+            <Setter Property="Padding" Value="20" />
+            <Setter Property="CornerRadius" Value="18" />
+            <Setter Property="Background">
+                <Setter.Value>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Color="#1C2431" Offset="0" />
+                        <GradientStop Color="#141A24" Offset="1" />
+                    </LinearGradientBrush>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="BorderBrush" Value="#222D3C" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+            <Setter Property="Effect">
+                <Setter.Value>
+                    <DropShadowEffect BlurRadius="18" ShadowDepth="0" Opacity="0.22" Color="#000000" />
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                    <Setter Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+                    <Setter Property="BorderThickness" Value="2" />
+                    <Setter Property="Effect">
+                        <Setter.Value>
+                            <DropShadowEffect BlurRadius="24" ShadowDepth="0" Opacity="0.35" Color="#2EC4B6" />
+                        </Setter.Value>
+                    </Setter>
+                    <Setter Property="Background">
+                        <Setter.Value>
+                            <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                                <GradientStop Color="#1F2E3F" Offset="0" />
+                                <GradientStop Color="#17202D" Offset="1" />
+                            </LinearGradientBrush>
+                        </Setter.Value>
+                    </Setter>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="CardTitleTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="18" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardSubtitleTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardMetricValueTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="42" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+            <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
+        </Style>
+
+        <Style x:Key="CardMetricLabelTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardListPrimaryTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        </Style>
+
+        <Style x:Key="CardListSecondaryTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+        </Style>
+
+        <Style x:Key="PaletteListBoxItemStyle" TargetType="ListBoxItem">
+            <Setter Property="Padding" Value="12" />
+            <Setter Property="Margin" Value="0,0,0,10" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Background" Value="{StaticResource OverlayListItemBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource OverlayListItemBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Focusable" Value="True" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListBoxItem">
+                        <Border x:Name="Container"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="14"
+                                SnapsToDevicePixels="True">
+                            <ContentPresenter HorizontalAlignment="Stretch"
+                                              VerticalAlignment="Center"
+                                              Margin="0" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Container" Property="Background" Value="{StaticResource OverlayListItemHoverBrush}" />
+                                <Setter TargetName="Container" Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Container" Property="Background" Value="{StaticResource OverlayListItemSelectedBrush}" />
+                                <Setter TargetName="Container" Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+                                <Setter TargetName="Container" Property="BorderThickness" Value="2" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Container" Property="Opacity" Value="0.45" />
+                            </Trigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsFocused" Value="True" />
+                                    <Condition Property="IsSelected" Value="False" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="Container" Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+                                <Setter TargetName="Container" Property="BorderThickness" Value="2" />
+                                <Setter TargetName="Container" Property="Background" Value="{StaticResource OverlayListItemHoverBrush}" />
+                            </MultiTrigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style TargetType="controls:CardDragThumb">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="controls:CardDragThumb">
+                        <Border Background="{TemplateBinding Background}"
+                                CornerRadius="18" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style TargetType="controls:CardResizeThumb">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="controls:CardResizeThumb">
+                        <Border Background="{TemplateBinding Background}"
+                                CornerRadius="3"
+                                BorderBrush="Transparent"
+                                BorderThickness="1" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <DataTemplate x:Key="CardPreviewTemplate" DataType="{x:Type vm:CardPreviewViewModel}">
+            <Border Width="{Binding Width}"
+                    Height="{Binding Height}"
+                    Canvas.Left="{Binding Left}"
+                    Canvas.Top="{Binding Top}"
+                    CornerRadius="18"
+                    BorderThickness="2"
+                    IsHitTestVisible="False">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="#402EC4B6" />
+                        <Setter Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+                        <Setter Property="Opacity" Value="0.9" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsValid}" Value="False">
+                                <Setter Property="Background" Value="#40ED5E68" />
+                                <Setter Property="BorderBrush" Value="#FFED5E68" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+            </Border>
+        </DataTemplate>
+
+        <Style x:Key="CardHeaderButtonStyle" TargetType="Button" BasedOn="{StaticResource SurfaceToolbarButtonStyle}">
+            <Setter Property="Padding" Value="10,4" />
+            <Setter Property="Margin" Value="12,0,0,0" />
+            <Setter Property="FontSize" Value="12" />
+        </Style>
+
+        <DataTemplate x:Key="StandardListItemTemplate" DataType="{x:Type vm:CardListItemViewModel}">
+            <Border Margin="0,0,0,10"
+                    Padding="0,0,0,8"
+                    Background="Transparent"
+                    BorderBrush="#1F2A39"
+                    BorderThickness="0 0 0 1"
+                    ToolTipService.InitialShowDelay="250"
+                    ToolTipService.ShowDuration="8000">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="Transparent" />
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="#162434" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <Border.ToolTip>
+                    <ToolTip Style="{StaticResource CardToolTipStyle}">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Primary}" FontWeight="SemiBold" />
+                            <TextBlock Text="{Binding Secondary}" Margin="0,6,0,0" Foreground="{StaticResource NeutralTextBrush}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasSecondary}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                            <TextBlock Text="{Binding Tertiary}" Margin="0,4,0,0" Foreground="{StaticResource NeutralTextBrush}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasTertiary}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+                    </ToolTip>
+                </Border.ToolTip>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="{Binding Primary}"
+                               Style="{StaticResource CardListPrimaryTextStyle}" />
+
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding Secondary}"
+                               Style="{StaticResource CardListSecondaryTextStyle}"
+                               TextAlignment="Right">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource CardListSecondaryTextStyle}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Setter Property="TextAlignment" Value="Right" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasSecondary}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <StackPanel Grid.Column="2" Orientation="Horizontal">
+                        <Border Background="#2EC4B622"
+                                Padding="8,2"
+                                CornerRadius="10"
+                                Margin="0,0,8,0">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasAccent}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                            <TextBlock Text="{Binding Accent}"
+                                       Foreground="{StaticResource AccentPrimaryBrush}"
+                                       FontSize="11"
+                                       FontWeight="SemiBold" />
+                        </Border>
+                        <TextBlock Text="{Binding Tertiary}"
+                                   Style="{StaticResource CardListSecondaryTextStyle}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource CardListSecondaryTextStyle}">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding HasTertiary}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FinanceForecastImpactTemplate" DataType="{x:Type vm:FinanceForecastImpactItemViewModel}">
+            <Grid Margin="0,0,0,10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{Binding Label}"
+                           Style="{StaticResource CardListPrimaryTextStyle}" />
+                <TextBlock Grid.Column="1"
+                           Text="{Binding DisplayValue}"
+                           Style="{StaticResource CardListPrimaryTextStyle}"
+                           FontWeight="SemiBold"
+                           Margin="12,0,0,0" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="StatusListItemTemplate" DataType="{x:Type vm:CardListItemViewModel}">
+            <Border Margin="0,0,0,10"
+                    Padding="0,2,0,6"
+                    Background="Transparent"
+                    ToolTipService.InitialShowDelay="250"
+                    ToolTipService.ShowDuration="8000">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="Transparent" />
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="#162434" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <Border.ToolTip>
+                    <ToolTip Style="{StaticResource CardToolTipStyle}">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Primary}" FontWeight="SemiBold" />
+                            <TextBlock Text="{Binding Secondary}" Margin="0,6,0,0" Foreground="{StaticResource NeutralTextBrush}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasSecondary}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+                    </ToolTip>
+                </Border.ToolTip>
+                <DockPanel>
+                    <Ellipse Width="10"
+                             Height="10"
+                             Fill="#2EC4B6"
+                             Opacity="0.65"
+                             Margin="0,4,12,0"
+                             DockPanel.Dock="Left" />
+                    <StackPanel>
+                        <TextBlock Text="{Binding Primary}"
+                                   Style="{StaticResource CardListPrimaryTextStyle}" />
+                        <TextBlock Text="{Binding Secondary}"
+                                   Style="{StaticResource CardListSecondaryTextStyle}"
+                                   Visibility="{Binding HasSecondary, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    </StackPanel>
+                </DockPanel>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FixtureListItemTemplate" DataType="{x:Type vm:CardListItemViewModel}">
+            <Grid Margin="0,0,0,12">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="{Binding Primary}"
+                           Style="{StaticResource CardListSecondaryTextStyle}" />
+                <StackPanel Grid.Column="1" Margin="16,0,0,0">
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                        <TextBlock Text="{Binding Secondary}"
+                                   Style="{StaticResource CardListPrimaryTextStyle}" />
+                        <Border Background="#2EC4B622"
+                                Padding="8,2"
+                                CornerRadius="10"
+                                Margin="12,0,0,0"
+                                Visibility="{Binding HasAccent, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <TextBlock Text="{Binding Accent}"
+                                       Foreground="{StaticResource AccentPrimaryBrush}"
+                                       FontSize="11"
+                                       FontWeight="SemiBold" />
+                        </Border>
+                    </StackPanel>
+                    <TextBlock Text="{Binding Tertiary}"
+                               Style="{StaticResource CardListSecondaryTextStyle}"
+                               Visibility="{Binding HasTertiary, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FormationPlayerTemplate" DataType="{x:Type vm:FormationPlayerViewModel}">
+            <controls:FormationPlayerThumb Width="56"
+                                            Height="56"
+                                            PitchWidth="{Binding RelativeSource={RelativeSource AncestorType=Canvas}, Path=ActualWidth}"
+                                            PitchHeight="{Binding RelativeSource={RelativeSource AncestorType=Canvas}, Path=ActualHeight}"
+                                            TokenSize="56"
+                                            BeginDragCommand="{Binding BeginDragCommand}"
+                                            DragDeltaCommand="{Binding DragDeltaCommand}"
+                                            DragCompletedCommand="{Binding CompleteDragCommand}"
+                                            Cursor="Hand">
+                <controls:FormationPlayerThumb.Template>
+                    <ControlTemplate TargetType="controls:FormationPlayerThumb">
+                        <Border Background="#2EC4B6"
+                                CornerRadius="28"
+                                BorderBrush="#FFFFFFFF"
+                                BorderThickness="2"
+                                Padding="8">
+                            <Border.Effect>
+                                <DropShadowEffect BlurRadius="18"
+                                                  ShadowDepth="0"
+                                                  Opacity="0.45"
+                                                  Color="#AA000000" />
+                            </Border.Effect>
+                            <TextBlock Text="{Binding Name}"
+                                       Foreground="White"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       TextWrapping="Wrap"
+                                       TextAlignment="Center" />
+                        </Border>
+                    </ControlTemplate>
+                </controls:FormationPlayerThumb.Template>
+            </controls:FormationPlayerThumb>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FormationLineTemplate" DataType="{x:Type vm:FormationLineViewModel}">
+            <StackPanel Margin="0,0,0,18">
+                <TextBlock Text="{Binding Role}"
+                           Foreground="#B3C6DC"
+                           FontSize="12"
+                           FontWeight="SemiBold"
+                           Margin="0,0,0,6" />
+                <ItemsControl ItemsSource="{Binding Players}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Rows="1" HorizontalAlignment="Stretch" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Margin="6,0"
+                                    Padding="14,10"
+                                    Background="#1AFFFFFF"
+                                    BorderBrush="#33FFFFFF"
+                                    BorderThickness="1.2"
+                                    CornerRadius="18">
+                                <TextBlock Text="{Binding Name}"
+                                           Foreground="White"
+                                           VerticalAlignment="Center"
+                                           HorizontalAlignment="Center"
+                                           FontWeight="SemiBold"
+                                           FontSize="12"
+                                           TextAlignment="Center"
+                                           TextWrapping="Wrap" />
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ComparisonPlayerTemplate">
+            <Border Background="{StaticResource SurfaceMediumBrush}"
+                    BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="10,4"
+                    Margin="0,0,8,8">
+                <TextBlock Text="{Binding}"
+                           Foreground="{StaticResource PrimaryTextBrush}"
+                           FontWeight="SemiBold" />
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="SquadComparisonMetricTemplate" DataType="{x:Type vm:SquadComparisonMetricViewModel}">
+            <Border Background="{StaticResource SurfaceMediumBrush}"
+                    BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="10"
+                    Padding="12"
+                    Margin="0,0,12,12">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="{Binding Metric}"
+                                   FontWeight="SemiBold"
+                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                        <Border Background="{StaticResource AccentPrimaryBrush}"
+                                CornerRadius="10"
+                                Padding="8,2"
+                                Margin="12,0,0,0"
+                                Visibility="{Binding TieBadge, Converter={StaticResource NullToVisibilityConverter}}">
+                            <TextBlock Text="{Binding TieBadge}"
+                                       FontSize="11"
+                                       FontWeight="SemiBold"
+                                       Foreground="White" />
+                        </Border>
+                    </StackPanel>
+                    <TextBlock Text="{Binding LeaderName}"
+                               Margin="0,6,0,0"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+                    <TextBlock Text="{Binding LeaderValue}"
+                               Margin="0,4,0,0"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               Foreground="{StaticResource PrimaryTextBrush}" />
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <DataTemplate x:Key="MetricCardBodyTemplate">
+            <StackPanel ToolTipService.IsEnabled="{Binding HasDescription}"
+                        ToolTipService.InitialShowDelay="250"
+                        ToolTipService.ShowDuration="8000">
+                <StackPanel.ToolTip>
+                    <ToolTip Style="{StaticResource CardToolTipStyle}">
+                        <TextBlock Text="{Binding Description}"
+                                   TextWrapping="Wrap"
+                                   MaxWidth="280" />
+                    </ToolTip>
+                </StackPanel.ToolTip>
+                <TextBlock Text="{Binding MetricValue}"
+                           Style="{StaticResource CardMetricValueTextStyle}" />
+                <TextBlock Text="{Binding MetricLabel}"
+                           Margin="0,8,0,0"
+                           Style="{StaticResource CardMetricLabelTextStyle}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="ListCardBodyTemplate">
+            <ItemsControl ItemsSource="{Binding ListItems}"
+                          ItemTemplate="{StaticResource StandardListItemTemplate}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="SquadTableCardBodyTemplate">
+            <Grid DataContext="{Binding SquadTable}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0" Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <WrapPanel Grid.Column="0"
+                               VerticalAlignment="Center"
+                               Margin="0,0,16,0">
+                        <StackPanel Width="160" Margin="0,0,12,0">
+                            <TextBlock Text="Position"
+                                       Style="{StaticResource CardListSecondaryTextStyle}" />
+                            <ComboBox ItemsSource="{Binding PositionFilters}"
+                                      SelectedItem="{Binding SelectedPositionFilter, Mode=TwoWay}"
+                                      Background="{StaticResource SurfaceMediumBrush}"
+                                      Foreground="{StaticResource PrimaryTextBrush}"
+                                      BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                                      Margin="0,4,0,0"
+                                      Padding="6,4"
+                                      AutomationProperties.Name="Filter squad by position" />
+                        </StackPanel>
+                        <StackPanel Width="160" Margin="0,0,12,0">
+                            <TextBlock Text="Role"
+                                       Style="{StaticResource CardListSecondaryTextStyle}" />
+                            <ComboBox ItemsSource="{Binding RoleFilters}"
+                                      SelectedItem="{Binding SelectedRoleFilter, Mode=TwoWay}"
+                                      Background="{StaticResource SurfaceMediumBrush}"
+                                      Foreground="{StaticResource PrimaryTextBrush}"
+                                      BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                                      Margin="0,4,0,0"
+                                      Padding="6,4"
+                                      AutomationProperties.Name="Filter squad by role" />
+                        </StackPanel>
+                        <StackPanel Width="200" Margin="0,0,12,0">
+                            <TextBlock Text="Search"
+                                       Style="{StaticResource CardListSecondaryTextStyle}" />
+                            <TextBox Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     Background="{StaticResource SurfaceMediumBrush}"
+                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                     BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                                     Margin="0,4,0,0"
+                                     Padding="6,4"
+                                     AutomationProperties.Name="Search squad roster" />
+                        </StackPanel>
+                    </WrapPanel>
+
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="{Binding SelectedCount, StringFormat=Selected: {0}}"
+                                   Style="{StaticResource CardListSecondaryTextStyle}"
+                                   Margin="0,0,16,0" />
+                        <Button Content="Clear Filters"
+                                Command="{Binding ClearFiltersCommand}"
+                                Style="{StaticResource CardHeaderButtonStyle}"
+                                Margin="0,0,8,0"
+                                Padding="16,6"
+                                AutomationProperties.Name="Clear squad filters" />
+                        <Button Content="Clear Selection"
+                                Command="{Binding ClearSelectionCommand}"
+                                Style="{StaticResource CardHeaderButtonStyle}"
+                                Margin="0,0,8,0"
+                                Padding="16,6"
+                                AutomationProperties.Name="Clear squad selection" />
+                        <Button Content="Compare Selected"
+                                Command="{Binding CompareCommand}"
+                                Style="{StaticResource CardHeaderButtonStyle}"
+                                Padding="18,6"
+                                AutomationProperties.Name="Compare selected players" />
+                    </StackPanel>
+                </Grid>
+
+                <DataGrid Grid.Row="1"
+                          ItemsSource="{Binding PlayersView}"
+                          AutoGenerateColumns="False"
+                          CanUserAddRows="False"
+                          CanUserDeleteRows="False"
+                          CanUserResizeRows="False"
+                          HeadersVisibility="Column"
+                          GridLinesVisibility="None"
+                          BorderThickness="0"
+                          RowHeight="42"
+                          ColumnHeaderHeight="34"
+                          IsReadOnly="True"
+                          AlternationCount="2"
+                          AlternatingRowBackground="#152030"
+                          Background="{StaticResource SurfaceDarkBrush}"
+                          Foreground="{StaticResource PrimaryTextBrush}"
+                          ScrollViewer.CanContentScroll="True">
+                    <DataGrid.Resources>
+                        <Style TargetType="DataGridColumnHeader">
+                            <Setter Property="Background" Value="{StaticResource SurfaceMediumBrush}" />
+                            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource SurfaceToolbarBorderBrush}" />
+                            <Setter Property="BorderThickness" Value="0,0,0,1" />
+                            <Setter Property="FontSize" Value="12" />
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                        </Style>
+                        <Style TargetType="DataGridRow">
+                            <Setter Property="Background" Value="{StaticResource SurfaceDarkBrush}" />
+                            <Setter Property="BorderThickness" Value="0,0,0,1" />
+                            <Setter Property="BorderBrush" Value="#1A2A3A" />
+                            <Setter Property="SnapsToDevicePixels" Value="True" />
+                            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                        </Style>
+                        <Style TargetType="DataGridCell">
+                            <Setter Property="Background" Value="{StaticResource SurfaceDarkBrush}" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="Padding" Value="8,4" />
+                        </Style>
+                    </DataGrid.Resources>
+
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn Width="40" IsReadOnly="False" SortMemberPath="IsSelected">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}" HorizontalAlignment="Center" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Name"
+                                            Binding="{Binding Name}"
+                                            Width="2*" />
+                        <DataGridTextColumn Header="Position"
+                                            Binding="{Binding Position}"
+                                            Width="1.1*"
+                                            SortMemberPath="Position" />
+                        <DataGridTextColumn Header="Role"
+                                            Binding="{Binding Role}"
+                                            Width="1.2*"
+                                            SortMemberPath="Role" />
+                        <DataGridTextColumn Header="Morale"
+                                            Binding="{Binding Morale}"
+                                            Width="1.2*"
+                                            SortMemberPath="Morale" />
+                        <DataGridTemplateColumn Header="Condition"
+                                               SortMemberPath="Condition"
+                                               Width="1.2*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <ProgressBar Value="{Binding ConditionPercentage}"
+                                                     Maximum="100"
+                                                     Height="6"
+                                                     Foreground="{StaticResource AccentPrimaryBrush}"
+                                                     Background="#152030" />
+                                        <TextBlock Text="{Binding ConditionDisplay}"
+                                                   Foreground="{StaticResource NeutralTextBrush}"
+                                                   FontSize="11"
+                                                   Margin="0,4,0,0" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTemplateColumn Header="Sharpness"
+                                               SortMemberPath="MatchSharpness"
+                                               Width="1.2*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <ProgressBar Value="{Binding MatchSharpnessPercentage}"
+                                                     Maximum="100"
+                                                     Height="6"
+                                                     Foreground="{StaticResource AccentSecondaryBrush}"
+                                                     Background="#152030" />
+                                        <TextBlock Text="{Binding MatchSharpnessDisplay}"
+                                                   Foreground="{StaticResource NeutralTextBrush}"
+                                                   FontSize="11"
+                                                   Margin="0,4,0,0" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Avg Rating"
+                                            Binding="{Binding AverageRating, StringFormat=F2}"
+                                            SortMemberPath="AverageRating"
+                                            Width="1.1*" />
+                        <DataGridTextColumn Header="Apps"
+                                            Binding="{Binding Appearances}"
+                                            SortMemberPath="Appearances"
+                                            Width="0.9*" />
+                        <DataGridTextColumn Header="Minutes"
+                                            Binding="{Binding Minutes}"
+                                            SortMemberPath="Minutes"
+                                            Width="1.1*" />
+                        <DataGridTextColumn Header="Nation"
+                                            Binding="{Binding Nationality}"
+                                            Width="1*"
+                                            SortMemberPath="Nationality" />
+                        <DataGridTemplateColumn Header="Status"
+                                               Width="1.2*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border Background="{StaticResource AccentPrimaryBrush}"
+                                            CornerRadius="12"
+                                            Padding="10,4"
+                                            HorizontalAlignment="Left"
+                                            Visibility="{Binding HasStatus, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        <TextBlock Text="{Binding Status}"
+                                                   FontSize="11"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="White" />
+                                    </Border>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <Border Grid.Row="2"
+                        Background="{StaticResource SurfaceMediumBrush}"
+                        BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="12"
+                        Padding="16"
+                        Margin="0,12,0,0"
+                        Visibility="{Binding HasComparison, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock Text="{Binding ComparisonSummary}"
+                                       Style="{StaticResource CardListPrimaryTextStyle}"
+                                       FontSize="16"
+                                       FontWeight="SemiBold" />
+                            <Button Content="Dismiss"
+                                    Command="{Binding DismissComparisonCommand}"
+                                    Style="{StaticResource CardHeaderButtonStyle}"
+                                    Margin="12,0,0,0"
+                                    Padding="14,4"
+                                    AutomationProperties.Name="Dismiss comparison" />
+                        </StackPanel>
+
+                        <ItemsControl ItemsSource="{Binding ComparisonPlayers}"
+                                      ItemTemplate="{StaticResource ComparisonPlayerTemplate}"
+                                      Margin="0,12,0,0">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+
+                        <ItemsControl ItemsSource="{Binding ComparisonMetrics}"
+                                      ItemTemplate="{StaticResource SquadComparisonMetricTemplate}"
+                                      Margin="0,8,0,0">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="StatusCardBodyTemplate">
+            <ItemsControl ItemsSource="{Binding ListItems}"
+                          ItemTemplate="{StaticResource StatusListItemTemplate}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="LineChartCardBodyTemplate">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,12">
+                    <TextBlock Text="{Binding MetricValue}" Style="{StaticResource CardMetricValueTextStyle}" />
+                    <TextBlock Text="{Binding MetricLabel}" Style="{StaticResource CardMetricLabelTextStyle}" Margin="12,16,0,0" />
+                </StackPanel>
+
+                <controls:LineChartControl Grid.Row="1"
+                                           Series="{Binding ChartSeries}"
+                                           MinHeight="180"
+                                           Margin="0,0,0,8" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="GaugeCardBodyTemplate">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <controls:RadialGaugeControl Gauge="{Binding Gauge}"
+                                             Margin="0,0,18,0"
+                                             MinHeight="220" />
+
+                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Gauge.DisplaySummary}"
+                               Foreground="{StaticResource NeutralTextBrush}"
+                               FontSize="13"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,12">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Gauge.DisplaySummary}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Gauge.DisplaySummary}" Value="">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <ItemsControl ItemsSource="{Binding ListItems}"
+                                  ItemTemplate="{StaticResource StandardListItemTemplate}" />
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="TrainingCalendarCardBodyTemplate">
+            <views:TrainingCalendarView DataContext="{Binding TrainingCalendar}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="TrainingProgressionCardBodyTemplate">
+            <views:TrainingProgressionView DataContext="{Binding}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="FixtureCalendarCardBodyTemplate">
+            <views:FixtureCalendarView DataContext="{Binding FixtureCalendar}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ForecastCardBodyTemplate">
+            <StackPanel>
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasForecast}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+
+                <StackPanel Orientation="Horizontal"
+                            Margin="0,0,0,16">
+                    <TextBlock Text="{Binding Forecast.SummaryLabel}"
+                               Style="{StaticResource CardListSecondaryTextStyle}"
+                               Margin="0,0,12,0" />
+                    <TextBlock Text="{Binding Forecast.SummaryValue}"
+                               Style="{StaticResource CardListPrimaryTextStyle}"
+                               FontSize="16"
+                               FontWeight="SemiBold" />
+                </StackPanel>
+
+                <TextBlock Text="{Binding Forecast.SliderLabel}"
+                           Style="{StaticResource CardListSecondaryTextStyle}" />
+
+                <Slider Minimum="{Binding Forecast.Minimum}"
+                        Maximum="{Binding Forecast.Maximum}"
+                        Value="{Binding Forecast.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        TickFrequency="{Binding Forecast.TickFrequency}"
+                        IsSnapToTickEnabled="{Binding Forecast.UseTicks}"
+                        Margin="0,12,0,0"
+                        AutomationProperties.Name="Finance forecast allocation" />
+
+                <TextBlock Text="{Binding Forecast.ValueDisplay}"
+                           Style="{StaticResource CardListPrimaryTextStyle}"
+                           FontSize="16"
+                           FontWeight="SemiBold"
+                           Margin="0,8,0,16" />
+
+                <ItemsControl ItemsSource="{Binding Forecast.Impacts}"
+                              ItemTemplate="{StaticResource FinanceForecastImpactTemplate}" />
+
+                <Button Content="{Binding Forecast.CommitLabel}"
+                        Command="{Binding Forecast.SaveCommand}"
+                        IsEnabled="{Binding Forecast.CanSave}"
+                        Style="{StaticResource CardHeaderButtonStyle}"
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Left"
+                        Padding="16,6"
+                        AutomationProperties.Name="Save finance forecast" />
+
+                <TextBlock Text="{Binding Forecast.StatusMessage}"
+                           Foreground="{StaticResource NeutralTextBrush}"
+                           Margin="0,8,0,0"
+                           Visibility="{Binding Forecast.HasStatusMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FinanceCashflowCardBodyTemplate">
+            <views:FinanceCashflowView DataContext="{Binding FinanceCashflow}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="FinanceBudgetAllocatorCardBodyTemplate">
+            <views:FinanceBudgetAllocatorView DataContext="{Binding FinanceBudgetAllocator}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="FinanceScenarioCardBodyTemplate">
+            <views:FinanceScenarioBoardView DataContext="{Binding FinanceScenario}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ScoutAssignmentsCardBodyTemplate">
+            <views:ScoutAssignmentBoardView DataContext="{Binding ScoutAssignments}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ShortlistBoardCardBodyTemplate">
+            <views:ShortlistBoardView DataContext="{Binding ShortlistBoard}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="TrainingUnitBoardCardBodyTemplate">
+            <views:TrainingUnitBoardView DataContext="{Binding TrainingUnitBoard}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ClubVisionRoadmapCardBodyTemplate">
+            <views:ClubVisionRoadmapView DataContext="{Binding ClubVisionRoadmap}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ClubVisionExpectationBoardCardBodyTemplate">
+            <views:ClubVisionExpectationBoardView DataContext="{Binding ClubVisionExpectations}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ShotMapCardBodyTemplate">
+            <views:ShotMapView DataContext="{Binding ShotMap}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="MedicalTimelineCardBodyTemplate">
+            <views:MedicalTimelineView DataContext="{Binding MedicalTimeline}" />
+        </DataTemplate>
+
+        <DataTemplate x:Key="TimelineCardBodyTemplate">
+            <Grid>
+                <controls:TimelineControl Items="{Binding TimelineEntries}" MinHeight="190" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="WorkloadHeatmapCardBodyTemplate">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0"
+                      Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="140" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="Unit"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+
+                    <ItemsControl Grid.Column="1"
+                                  ItemsSource="{Binding WorkloadHeatmap.Columns}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Width="112"
+                                        Margin="4,0"
+                                        Background="#152032"
+                                        BorderBrush="#233246"
+                                        BorderThickness="1"
+                                        CornerRadius="12">
+                                    <TextBlock Text="{Binding}"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               FontWeight="SemiBold"
+                                               Margin="8,6" />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Grid>
+
+                <ScrollViewer Grid.Row="1"
+                              HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding WorkloadHeatmap.Rows}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:TrainingWorkloadHeatmapRowViewModel}">
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,4">
+                                    <Border Width="140"
+                                            Margin="0,0,8,0"
+                                            Background="#152032"
+                                            BorderBrush="#233246"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="12,10">
+                                        <TextBlock Text="{Binding Label}"
+                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                   FontWeight="SemiBold" />
+                                    </Border>
+
+                                    <ItemsControl ItemsSource="{Binding Cells}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate DataType="{x:Type vm:TrainingWorkloadHeatmapCellViewModel}">
+                                                <Border Width="112"
+                                                        Height="72"
+                                                        Margin="4,0"
+                                                        Background="{Binding BackgroundBrush}"
+                                                        CornerRadius="14"
+                                                        BorderBrush="#202F43"
+                                                        BorderThickness="1"
+                                                        ToolTip="{Binding Tooltip}">
+                                                    <StackPanel HorizontalAlignment="Center"
+                                                                VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding DisplayLoad}"
+                                                                   Foreground="White"
+                                                                   FontSize="18"
+                                                                   FontWeight="SemiBold"
+                                                                   HorizontalAlignment="Center" />
+                                                        <TextBlock Text="{Binding IntensityDisplay}"
+                                                                   Foreground="#E6FFFFFF"
+                                                                   FontSize="12"
+                                                                   HorizontalAlignment="Center"
+                                                                   Margin="0,4,0,0" />
+                                                    </StackPanel>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <StackPanel Grid.Row="2"
+                            Margin="0,16,0,0"
+                            Orientation="Vertical"
+                            Visibility="{Binding WorkloadHeatmap.HasLegend, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock Text="{Binding WorkloadHeatmap.LegendTitle}"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               FontWeight="SemiBold"
+                               Visibility="{Binding WorkloadHeatmap.HasLegendTitle, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    <TextBlock Text="{Binding WorkloadHeatmap.LegendSubtitle}"
+                               Foreground="{StaticResource NeutralTextBrush}"
+                               Margin="0,4,0,12"
+                               Visibility="{Binding WorkloadHeatmap.HasLegendSubtitle, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                    <ItemsControl ItemsSource="{Binding WorkloadHeatmap.Intensities}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:TrainingIntensityLevelViewModel}">
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,0,16,0"
+                                            VerticalAlignment="Center">
+                                    <Border Width="18"
+                                            Height="18"
+                                            CornerRadius="4"
+                                            Background="{Binding Brush}"
+                                            Margin="0,0,8,0" />
+                                    <TextBlock Text="{Binding DisplayName}"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="MoraleHeatmapCardBodyTemplate">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0"
+                      Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="160" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="Group"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+
+                    <ItemsControl Grid.Column="1"
+                                  ItemsSource="{Binding MoraleHeatmap.Columns}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Width="128"
+                                        Margin="4,0"
+                                        Background="#152032"
+                                        BorderBrush="#233246"
+                                        BorderThickness="1"
+                                        CornerRadius="12">
+                                    <TextBlock Text="{Binding}"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               FontWeight="SemiBold"
+                                               Margin="12,6" />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Grid>
+
+                <ScrollViewer Grid.Row="1"
+                              HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Auto">
+                    <ItemsControl ItemsSource="{Binding MoraleHeatmap.Rows}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:MoraleHeatmapRowViewModel}">
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,4">
+                                    <Border Width="160"
+                                            Margin="0,0,8,0"
+                                            Background="#152032"
+                                            BorderBrush="#233246"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="12,10">
+                                        <TextBlock Text="{Binding Label}"
+                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                   FontWeight="SemiBold" />
+                                    </Border>
+
+                                    <ItemsControl ItemsSource="{Binding Cells}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <StackPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate DataType="{x:Type vm:MoraleHeatmapCellViewModel}">
+                                                <Border Width="128"
+                                                        Height="80"
+                                                        Margin="4,0"
+                                                        Background="{Binding BackgroundBrush}"
+                                                        CornerRadius="14"
+                                                        BorderBrush="#202F43"
+                                                        BorderThickness="1"
+                                                        ToolTip="{Binding Tooltip}">
+                                                    <StackPanel HorizontalAlignment="Center"
+                                                                VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding DisplayLabel}"
+                                                                   Foreground="White"
+                                                                   FontWeight="SemiBold"
+                                                                   TextAlignment="Center"
+                                                                   TextWrapping="Wrap"
+                                                                   Margin="4,0" />
+                                                        <TextBlock Text="{Binding IntensityDisplay}"
+                                                                   Foreground="#E6FFFFFF"
+                                                                   FontSize="12"
+                                                                   HorizontalAlignment="Center" />
+                                                        <TextBlock Text="{Binding Detail}"
+                                                                   Foreground="#CCE8FF"
+                                                                   FontSize="11"
+                                                                   Margin="0,4,0,0"
+                                                                   TextAlignment="Center"
+                                                                   TextWrapping="Wrap"
+                                                                   Visibility="{Binding HasDetail, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                    </StackPanel>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <StackPanel Grid.Row="2"
+                            Margin="0,16,0,0"
+                            Orientation="Vertical"
+                            Visibility="{Binding MoraleHeatmap.HasLegend, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock Text="{Binding MoraleHeatmap.LegendTitle}"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               FontWeight="SemiBold"
+                               Visibility="{Binding MoraleHeatmap.HasLegendTitle, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    <TextBlock Text="{Binding MoraleHeatmap.LegendSubtitle}"
+                               Foreground="{StaticResource NeutralTextBrush}"
+                               Margin="0,4,0,12"
+                               Visibility="{Binding MoraleHeatmap.HasLegendSubtitle, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                    <ItemsControl ItemsSource="{Binding MoraleHeatmap.Intensities}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:MoraleIntensityViewModel}">
+                                <Border Margin="0,0,12,0"
+                                        Padding="10,6"
+                                        CornerRadius="12"
+                                        Background="#152032"
+                                        BorderBrush="#233246"
+                                        BorderThickness="1">
+                                    <StackPanel Orientation="Horizontal"
+                                                VerticalAlignment="Center">
+                                        <Border Width="16"
+                                                Height="16"
+                                                Background="{Binding Brush}"
+                                                CornerRadius="8"
+                                                Margin="0,0,8,0" />
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding DisplayName}"
+                                                       Foreground="{StaticResource PrimaryTextBrush}" />
+                                            <TextBlock Text="{Binding Description}"
+                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                       FontSize="11"
+                                                       TextWrapping="Wrap"
+                                                       Visibility="{Binding Description, Converter={StaticResource StringToVisibilityConverter}}" />
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FixtureCardBodyTemplate">
+            <StackPanel>
+                <Border Background="#19202E"
+                        CornerRadius="14"
+                        Padding="16"
+                        Margin="0,0,0,16">
+                    <StackPanel>
+                        <TextBlock Text="{Binding Description}"
+                                   Foreground="White"
+                                   FontSize="20"
+                                   FontWeight="SemiBold" />
+                    </StackPanel>
+                </Border>
+                <ItemsControl ItemsSource="{Binding ListItems}"
+                              ItemTemplate="{StaticResource FixtureListItemTemplate}" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="FormationCardBodyTemplate">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0"
+                        Background="#0E4022"
+                        CornerRadius="16"
+                        Padding="18"
+                        BorderBrush="#1ABF8F"
+                        BorderThickness="1">
+                    <Grid>
+                        <Rectangle Height="2"
+                                   Fill="#1ABF8F"
+                                   Opacity="0.35"
+                                   HorizontalAlignment="Stretch"
+                                   VerticalAlignment="Center" />
+
+                        <ItemsControl ItemsSource="{Binding FormationPlayers}"
+                                      ItemTemplate="{StaticResource FormationPlayerTemplate}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <Canvas />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemContainerStyle>
+                                <Style TargetType="ContentPresenter">
+                                    <Setter Property="Canvas.Left">
+                                        <Setter.Value>
+                                            <MultiBinding Converter="{StaticResource RelativePositionConverter}" ConverterParameter="56">
+                                                <Binding Path="NormalizedX" />
+                                                <Binding RelativeSource="{RelativeSource AncestorType=Canvas}" Path="ActualWidth" />
+                                            </MultiBinding>
+                                        </Setter.Value>
+                                    </Setter>
+                                    <Setter Property="Canvas.Top">
+                                        <Setter.Value>
+                                            <MultiBinding Converter="{StaticResource RelativePositionConverter}" ConverterParameter="56">
+                                                <Binding Path="NormalizedY" />
+                                                <Binding RelativeSource="{RelativeSource AncestorType=Canvas}" Path="ActualHeight" />
+                                            </MultiBinding>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </ItemsControl.ItemContainerStyle>
+                        </ItemsControl>
+                    </Grid>
+                </Border>
+
+                <ItemsControl Grid.Row="1"
+                              Margin="0,16,0,0"
+                              ItemsSource="{Binding FormationLines}"
+                              ItemTemplate="{StaticResource FormationLineTemplate}" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:FormationEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ScrollViewer Grid.Row="0"
+                              VerticalScrollBarVisibility="Auto"
+                              Margin="0,0,0,16">
+                    <StackPanel>
+                        <ItemsControl ItemsSource="{Binding Lines}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type editors:FormationLineEditorViewModel}">
+                                    <StackPanel Margin="0,0,0,24">
+                                        <TextBlock Text="{Binding Role}"
+                                                   FontSize="16"
+                                                   FontWeight="SemiBold"
+                                                   Foreground="{StaticResource PrimaryTextBrush}" />
+
+                                        <ItemsControl Margin="0,12,0,0"
+                                                      ItemsSource="{Binding Slots}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type editors:FormationSlotEditorViewModel}">
+                                                    <StackPanel Margin="0,12,0,0">
+                                                        <TextBlock Text="{Binding Label}"
+                                                                   FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource NeutralTextBrush}" />
+                                                        <ComboBox ItemsSource="{Binding AvailablePlayers}"
+                                                                  SelectedValue="{Binding SelectedPlayerId, UpdateSourceTrigger=PropertyChanged}"
+                                                                  SelectedValuePath="Id"
+                                                                  Margin="0,8,0,0"
+                                                                  Background="#152032"
+                                                                  Foreground="{StaticResource PrimaryTextBrush}"
+                                                                  BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                  BorderThickness="1"
+                                                                  Padding="8,6"
+                                                                  ScrollViewer.VerticalScrollBarVisibility="Auto">
+                                                            <ComboBox.ItemTemplate>
+                                                                <DataTemplate DataType="{x:Type editors:FormationPlayerOptionViewModel}">
+                                                                    <StackPanel>
+                                                                        <TextBlock Text="{Binding DisplayName}"
+                                                                                   FontWeight="SemiBold"
+                                                                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                                                                        <StackPanel Orientation="Horizontal"
+                                                                                    Margin="0,2,0,0">
+                                                                            <TextBlock Text="{Binding Position}"
+                                                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                                                            <TextBlock Text=" • "
+                                                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                                                       Visibility="{Binding Detail, Converter={StaticResource NullToVisibilityConverter}}" />
+                                                                            <TextBlock Text="{Binding Detail}"
+                                                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                                                       Visibility="{Binding Detail, Converter={StaticResource NullToVisibilityConverter}}" />
+                                                                        </StackPanel>
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ComboBox.ItemTemplate>
+                                                        </ComboBox>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <Grid Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding ValidationMessage}"
+                               Foreground="{StaticResource AlertTextBrush}"
+                               VerticalAlignment="Center"
+                               Margin="0,0,16,0"
+                               Visibility="{Binding HasValidationMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                    <Button Grid.Column="1"
+                            Margin="0,0,12,0"
+                            Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding CancelCommand}"
+                            Content="Cancel" />
+
+                    <Button Grid.Column="2"
+                            Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding SaveCommand}"
+                            Content="Save Changes" />
+                </Grid>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:ListCardEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="0"
+                         ItemsSource="{Binding Items}"
+                         SelectedItem="{Binding SelectedItem}"
+                         behaviors:ListBoxDragReorderBehavior.EnableReorder="True"
+                         BorderThickness="1"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         Background="{StaticResource OverlayListBackgroundBrush}"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         Margin="0,0,0,12"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type editors:EditableListItemViewModel}">
+                            <Border Padding="12"
+                                    Margin="0,0,0,10"
+                                    Background="{StaticResource OverlayListItemBrush}"
+                                    BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="0"
+                                               Text="Primary"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,0,12,6" />
+                                    <TextBox Grid.Row="0"
+                                             Grid.Column="1"
+                                             Text="{Binding Primary, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4"
+                                             MinWidth="220" />
+
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="0"
+                                               Text="Secondary"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,12,6" />
+                                    <TextBox Grid.Row="1"
+                                             Grid.Column="1"
+                                             Margin="0,8,0,0"
+                                             Text="{Binding Secondary, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="0"
+                                               Text="Tertiary"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,12,6" />
+                                    <TextBox Grid.Row="2"
+                                             Grid.Column="1"
+                                             Margin="0,8,0,0"
+                                             Text="{Binding Tertiary, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="0"
+                                               Text="Accent"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,12,0" />
+                                    <TextBox Grid.Row="3"
+                                             Grid.Column="1"
+                                             Margin="0,8,0,0"
+                                             Text="{Binding Accent, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <StackPanel Grid.Row="1"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right">
+                    <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding AddItemCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Add list item">
+                        <AccessText Text="_Add Item" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding RemoveSelectedCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Remove selected item">
+                        <AccessText Text="_Remove" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveUpCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Move item up">
+                        <AccessText Text="Move _Up" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveDownCommand}"
+                            AutomationProperties.Name="Move item down">
+                        <AccessText Text="Move _Down" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:ClubVisionRoadmapEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="0"
+                         ItemsSource="{Binding Phases}"
+                         SelectedItem="{Binding SelectedPhase}"
+                         BorderThickness="1"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         Background="{StaticResource OverlayListBackgroundBrush}"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         Margin="0,0,0,12"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type editors:ClubVisionRoadmapPhaseEditorViewModel}">
+                            <Border Padding="14"
+                                    Margin="0,0,0,12"
+                                    Background="{StaticResource OverlayListItemBrush}"
+                                    BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Text="Title"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Column="1"
+                                             Text="{Binding Title, UpdateSourceTrigger=PropertyChanged}"
+                                             Margin="12,0,0,0"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4"
+                                             MinWidth="220" />
+
+                                    <TextBlock Grid.Row="1"
+                                               Text="Timeline"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <TextBox Grid.Row="1"
+                                             Grid.Column="1"
+                                             Text="{Binding Timeline, UpdateSourceTrigger=PropertyChanged}"
+                                             Margin="12,8,0,0"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="2"
+                                               Text="Status"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <ComboBox Grid.Row="2"
+                                              Grid.Column="1"
+                                              Margin="12,8,0,0"
+                                              ItemsSource="{Binding DataContext.StatusOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              Text="{Binding Status, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="6,4"
+                                              IsEditable="True"
+                                              StaysOpenOnEdit="True" />
+
+                                    <TextBlock Grid.Row="3"
+                                               Text="Pill"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <ComboBox Grid.Row="3"
+                                              Grid.Column="1"
+                                              Margin="12,8,0,0"
+                                              ItemsSource="{Binding DataContext.PillOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              Text="{Binding Pill, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="6,4"
+                                              IsEditable="True"
+                                              StaysOpenOnEdit="True" />
+
+                                    <TextBlock Grid.Row="4"
+                                               Text="Description"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <TextBox Grid.Row="4"
+                                             Grid.Column="1"
+                                             Margin="12,8,0,0"
+                                             Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4"
+                                             AcceptsReturn="True"
+                                             MinHeight="60"
+                                             TextWrapping="Wrap" />
+
+                                    <TextBlock Grid.Row="5"
+                                               Text="Accent (Hex)"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <TextBox Grid.Row="5"
+                                             Grid.Column="1"
+                                             Margin="12,8,0,0"
+                                             Text="{Binding Accent, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <StackPanel Grid.Row="1"
+                            Orientation="Vertical">
+                    <TextBlock Text="{Binding ValidationMessage}"
+                               Foreground="#FFE05D5D"
+                               Margin="0,0,0,12"
+                               Visibility="{Binding HasValidationMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Right">
+                        <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                                Command="{Binding AddPhaseCommand}"
+                                Margin="0,0,12,0"
+                                AutomationProperties.Name="Add milestone">
+                            <AccessText Text="_Add Milestone" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding RemovePhaseCommand}"
+                                Margin="0,0,12,0"
+                                AutomationProperties.Name="Remove milestone">
+                            <AccessText Text="_Remove" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding MoveUpCommand}"
+                                Margin="0,0,12,0"
+                                AutomationProperties.Name="Move milestone up">
+                            <AccessText Text="Move _Up" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding MoveDownCommand}"
+                                AutomationProperties.Name="Move milestone down">
+                            <AccessText Text="Move _Down" />
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:ClubVisionExpectationBoardEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="0"
+                         ItemsSource="{Binding Objectives}"
+                         SelectedItem="{Binding SelectedObjective}"
+                         BorderThickness="1"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         Background="{StaticResource OverlayListBackgroundBrush}"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         Margin="0,0,0,12"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type editors:ClubVisionExpectationEditorItemViewModel}">
+                            <Border Padding="14"
+                                    Margin="0,0,0,12"
+                                    Background="{StaticResource OverlayListItemBrush}"
+                                    BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Text="Objective"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Column="1"
+                                             Text="{Binding Objective, UpdateSourceTrigger=PropertyChanged}"
+                                             Margin="12,0,0,0"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4"
+                                             MinWidth="240" />
+
+                                    <TextBlock Grid.Row="1"
+                                               Text="Competition"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <TextBox Grid.Row="1"
+                                             Grid.Column="1"
+                                             Text="{Binding Competition, UpdateSourceTrigger=PropertyChanged}"
+                                             Margin="12,8,0,0"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <StackPanel Grid.Row="2"
+                                                Grid.ColumnSpan="2"
+                                                Orientation="Horizontal"
+                                                Margin="0,8,0,0"
+                                                Spacing="12">
+                                        <StackPanel Width="180">
+                                            <TextBlock Text="Priority"
+                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                            <ComboBox ItemsSource="{Binding DataContext.PriorityOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                                      Text="{Binding Priority, UpdateSourceTrigger=PropertyChanged}"
+                                                      Background="#152032"
+                                                      Foreground="{StaticResource PrimaryTextBrush}"
+                                                      BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                      BorderThickness="1"
+                                                      Padding="6,4"
+                                                      IsEditable="True"
+                                                      StaysOpenOnEdit="True" />
+                                        </StackPanel>
+                                        <StackPanel Width="200">
+                                            <TextBlock Text="Status"
+                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                            <ComboBox ItemsSource="{Binding DataContext.StatusOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                                      Text="{Binding Status, UpdateSourceTrigger=PropertyChanged}"
+                                                      Background="#152032"
+                                                      Foreground="{StaticResource PrimaryTextBrush}"
+                                                      BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                      BorderThickness="1"
+                                                      Padding="6,4"
+                                                      IsEditable="True"
+                                                      StaysOpenOnEdit="True" />
+                                        </StackPanel>
+                                        <StackPanel Width="200">
+                                            <TextBlock Text="Deadline"
+                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                            <TextBox Text="{Binding Deadline, UpdateSourceTrigger=PropertyChanged}"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     BorderThickness="1"
+                                                     Padding="8,4" />
+                                        </StackPanel>
+                                    </StackPanel>
+
+                                    <TextBlock Grid.Row="3"
+                                               Text="Notes"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <TextBox Grid.Row="3"
+                                             Grid.Column="1"
+                                             Margin="12,8,0,0"
+                                             Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4"
+                                             AcceptsReturn="True"
+                                             MinHeight="60"
+                                             TextWrapping="Wrap" />
+
+                                    <TextBlock Grid.Row="4"
+                                               Text="Accent (Hex)"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,8,0,0" />
+                                    <TextBox Grid.Row="4"
+                                             Grid.Column="1"
+                                             Margin="12,8,0,0"
+                                             Text="{Binding Accent, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <StackPanel Grid.Row="1"
+                            Orientation="Vertical">
+                    <TextBlock Text="{Binding ValidationMessage}"
+                               Foreground="#FFE05D5D"
+                               Margin="0,0,0,12"
+                               Visibility="{Binding HasValidationMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Right">
+                        <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                                Command="{Binding AddObjectiveCommand}"
+                                Margin="0,0,12,0"
+                                AutomationProperties.Name="Add objective">
+                            <AccessText Text="_Add Objective" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding RemoveObjectiveCommand}"
+                                Margin="0,0,12,0"
+                                AutomationProperties.Name="Remove objective">
+                            <AccessText Text="_Remove" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding MoveUpCommand}"
+                                Margin="0,0,12,0"
+                                AutomationProperties.Name="Move objective up">
+                            <AccessText Text="Move _Up" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding MoveDownCommand}"
+                                AutomationProperties.Name="Move objective down">
+                            <AccessText Text="Move _Down" />
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:TrainingSessionEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="0"
+                         ItemsSource="{Binding Sessions}"
+                         SelectedItem="{Binding SelectedSession}"
+                         behaviors:ListBoxDragReorderBehavior.EnableReorder="True"
+                         BorderThickness="1"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         Background="{StaticResource OverlayListBackgroundBrush}"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         Margin="0,0,0,12"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type editors:TrainingSessionEditorItemViewModel}">
+                            <Border Padding="12"
+                                    Margin="0,0,0,10"
+                                    Background="{StaticResource OverlayListItemBrush}"
+                                    BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="0"
+                                               Text="Day"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,0,12,6" />
+                                    <ComboBox Grid.Row="0"
+                                              Grid.Column="1"
+                                              ItemsSource="{Binding DataContext.DayOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              SelectedItem="{Binding Day, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="8,4"
+                                              MinWidth="160" />
+
+                                    <TextBlock Grid.Row="0"
+                                               Grid.Column="2"
+                                               Text="Slot"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="24,0,12,6" />
+                                    <ComboBox Grid.Row="0"
+                                              Grid.Column="3"
+                                              ItemsSource="{Binding DataContext.SlotOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              SelectedItem="{Binding Slot, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="8,4"
+                                              MinWidth="150" />
+
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="0"
+                                               Grid.ColumnSpan="1"
+                                               Text="Activity"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,12,12,6" />
+                                    <TextBox Grid.Row="1"
+                                             Grid.Column="1"
+                                             Grid.ColumnSpan="3"
+                                             Margin="0,12,0,0"
+                                             Text="{Binding Activity, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="0"
+                                               Grid.ColumnSpan="1"
+                                               Text="Focus"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,12,12,6" />
+                                    <TextBox Grid.Row="2"
+                                             Grid.Column="1"
+                                             Grid.ColumnSpan="3"
+                                             Margin="0,12,0,0"
+                                             Text="{Binding Focus, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="0"
+                                               Grid.ColumnSpan="1"
+                                               Text="Intensity"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,12,12,0" />
+                                    <TextBox Grid.Row="3"
+                                             Grid.Column="1"
+                                             Grid.ColumnSpan="3"
+                                             Margin="0,12,0,0"
+                                             Text="{Binding Intensity, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <StackPanel Grid.Row="1"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right">
+                    <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding AddSessionCommand}"
+                            Margin="0,0,12,0"
+                            Content="Add Session" />
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding RemoveSessionCommand}"
+                            Margin="0,0,12,0"
+                            Content="Remove" />
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveUpCommand}"
+                            Margin="0,0,12,0"
+                            Content="Move Up" />
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveDownCommand}"
+                            Content="Move Down" />
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:GaugeEditorViewModel}">
+            <StackPanel>
+                <TextBlock Text="Adjust the value and target for this gauge"
+                           Foreground="{StaticResource NeutralTextBrush}"
+                           Margin="0,0,0,12" />
+
+                <StackPanel Margin="0,0,0,12">
+                    <TextBlock Text="Current Value"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               FontWeight="SemiBold" />
+                    <Slider Minimum="{Binding Minimum}"
+                            Maximum="{Binding Maximum}"
+                            Value="{Binding Value, Mode=TwoWay}"
+                            Margin="0,8,0,4"
+                            TickFrequency="1"
+                            IsSnapToTickEnabled="False" />
+                    <TextBlock Text="{Binding Value, StringFormat=Current: {0:0.##}}"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+                </StackPanel>
+
+                <StackPanel Margin="0,0,0,16">
+                    <TextBlock Text="Target"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               FontWeight="SemiBold" />
+                    <Slider Minimum="{Binding Minimum}"
+                            Maximum="{Binding Maximum}"
+                            Value="{Binding Target, Mode=TwoWay}"
+                            Margin="0,8,0,4"
+                            TickFrequency="1"
+                            IsSnapToTickEnabled="False" />
+                    <TextBlock Text="{Binding Target, StringFormat=Target: {0:0.##}}"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+                </StackPanel>
+
+                <TextBlock Text="Displayed Value"
+                           Foreground="{StaticResource PrimaryTextBrush}"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding DisplayValue, UpdateSourceTrigger=PropertyChanged}"
+                         Margin="0,6,0,16"
+                         Background="#152032"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         BorderThickness="1"
+                         Padding="10,6" />
+
+                <TextBlock Text="Summary"
+                           Foreground="{StaticResource PrimaryTextBrush}"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding Summary, UpdateSourceTrigger=PropertyChanged}"
+                         Margin="0,6,0,16"
+                         Background="#152032"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         BorderThickness="1"
+                         Padding="10,6"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         MinHeight="70" />
+
+                <TextBlock Text="Pill Label"
+                           Foreground="{StaticResource PrimaryTextBrush}"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding Pill, UpdateSourceTrigger=PropertyChanged}"
+                         Margin="0,6,0,0"
+                         Background="#152032"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         BorderThickness="1"
+                         Padding="10,6" />
+
+                <TextBlock Text="{Binding Unit, StringFormat=Unit: {0}}"
+                           Foreground="{StaticResource NeutralTextBrush}"
+                           Margin="0,12,0,0" />
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:TransferNegotiationEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0" ColumnSpacing="24">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="260" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="0"
+                            Background="{StaticResource OverlayListBackgroundBrush}"
+                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="16"
+                            Padding="0">
+                        <ListBox ItemsSource="{Binding Deals}"
+                                 SelectedItem="{Binding SelectedDeal, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Background="Transparent"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 ScrollViewer.VerticalScrollBarVisibility="Auto">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type editors:TransferNegotiationDealEditorViewModel}">
+                                    <Border Margin="8"
+                                            Padding="10"
+                                            Background="#152032"
+                                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="12">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Player}"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <TextBlock Text="{Binding Club}"
+                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                       FontSize="12"
+                                                       Margin="0,4,0,6" />
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Stage}"
+                                                           Foreground="{StaticResource NeutralTextBrush}"
+                                                           FontSize="11" />
+                                                <TextBlock Text=" • "
+                                                           Margin="4,0"
+                                                           Foreground="{StaticResource NeutralTextBrush}" />
+                                                <TextBlock Text="{Binding Status}"
+                                                           Foreground="{StaticResource NeutralTextBrush}"
+                                                           FontSize="11" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Border>
+
+                    <Border Grid.Column="1"
+                            Background="{StaticResource OverlayListBackgroundBrush}"
+                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="16"
+                            Padding="20">
+                        <ContentControl Content="{Binding SelectedDeal}">
+                            <ContentControl.Resources>
+                                <DataTemplate DataType="{x:Type editors:TransferNegotiationDealEditorViewModel}">
+                                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                        <StackPanel>
+                                            <Grid Margin="0,0,0,18">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <StackPanel Grid.Column="0">
+                                                    <TextBlock Text="Player"
+                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                               FontWeight="SemiBold" />
+                                                    <TextBox Text="{Binding Player, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                             Margin="0,6,0,0"
+                                                             Background="#152032"
+                                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                             BorderThickness="1"
+                                                             Padding="10,6"
+                                                             FontSize="18"
+                                                             FontWeight="SemiBold" />
+                                                </StackPanel>
+
+                                                <Button Grid.Column="1"
+                                                        Margin="16,24,0,0"
+                                                        Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                                        Command="{Binding ResetCommand}"
+                                                        Content="Reset Deal"
+                                                        IsEnabled="{Binding IsDirty}" />
+                                            </Grid>
+
+                                            <Grid Margin="0,0,0,18">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                                                    <TextBlock Text="Position"
+                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                               FontWeight="SemiBold" />
+                                                    <TextBox Text="{Binding Position, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                             Margin="0,6,0,0"
+                                                             Background="#152032"
+                                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                             BorderThickness="1"
+                                                             Padding="10,6" />
+                                                </StackPanel>
+
+                                                <StackPanel Grid.Column="1">
+                                                    <TextBlock Text="Club"
+                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                               FontWeight="SemiBold" />
+                                                    <TextBox Text="{Binding Club, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                             Margin="0,6,0,0"
+                                                             Background="#152032"
+                                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                             BorderThickness="1"
+                                                             Padding="10,6" />
+                                                </StackPanel>
+                                            </Grid>
+
+                                            <StackPanel Margin="0,0,0,18">
+                                                <TextBlock Text="Accent Tag"
+                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                           FontWeight="SemiBold" />
+                                                <TextBox Text="{Binding Accent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                         Margin="0,6,0,0"
+                                                         Background="#152032"
+                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                         BorderThickness="1"
+                                                         Padding="10,6" />
+                                            </StackPanel>
+
+                                            <TextBlock Text="Stage"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <ComboBox ItemsSource="{Binding StageOptions}"
+                                                      SelectedItem="{Binding Stage, Mode=TwoWay}"
+                                                      IsEditable="True"
+                                                      Background="#152032"
+                                                      Foreground="{StaticResource PrimaryTextBrush}"
+                                                      BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                      Margin="0,6,0,16" />
+
+                                            <TextBlock Text="Status"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <ComboBox ItemsSource="{Binding StatusOptions}"
+                                                      SelectedItem="{Binding Status, Mode=TwoWay}"
+                                                      IsEditable="True"
+                                                      Background="#152032"
+                                                      Foreground="{StaticResource PrimaryTextBrush}"
+                                                      BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                      Margin="0,6,0,16" />
+
+                                            <TextBlock Text="Deadline"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <TextBox Text="{Binding Deadline, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,6,0,16"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     Padding="10,6" />
+
+                                            <TextBlock Text="Summary"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <TextBox Text="{Binding Summary, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,6,0,16"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     Padding="10,6"
+                                                     AcceptsReturn="True"
+                                                     TextWrapping="Wrap"
+                                                     MinHeight="60" />
+
+                                            <TextBlock Text="Agent"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <TextBox Text="{Binding Agent, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,6,0,16"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     Padding="10,6" />
+
+                                            <TextBlock Text="Latest Response"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <TextBox Text="{Binding Response, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,6,0,20"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     Padding="10,6"
+                                                     AcceptsReturn="True"
+                                                     TextWrapping="Wrap"
+                                                     MinHeight="70" />
+
+                                            <TextBlock Text="Offer Terms"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold"
+                                                       Margin="0,0,0,12" />
+
+                                            <ItemsControl ItemsSource="{Binding Terms}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <WrapPanel />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type editors:TransferNegotiationTermEditorViewModel}">
+                                                        <Border Width="240"
+                                                                Margin="0,0,16,16"
+                                                                Background="#152032"
+                                                                BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                BorderThickness="1"
+                                                                CornerRadius="16"
+                                                                Padding="14">
+                                                            <StackPanel>
+                                                                <TextBlock Text="{Binding Label}"
+                                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                                           FontWeight="SemiBold" />
+                                                                <Slider Minimum="{Binding Minimum}"
+                                                                        Maximum="{Binding Maximum}"
+                                                                        Value="{Binding Value, Mode=TwoWay}"
+                                                                        TickFrequency="{Binding TickFrequency}"
+                                                                        IsSnapToTickEnabled="True"
+                                                                        Margin="0,10,0,4" />
+                                                                <StackPanel Orientation="Horizontal"
+                                                                            Margin="0,4,0,0">
+                                                                    <TextBlock Text="{Binding DisplayValue}"
+                                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                                               FontWeight="SemiBold" />
+                                                                    <TextBlock Text=" / "
+                                                                               Foreground="{StaticResource NeutralTextBrush}"
+                                                                               Margin="6,0" />
+                                                                    <TextBlock Text="{Binding TargetDisplay}"
+                                                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                                                </StackPanel>
+                                                                <TextBlock Text="{Binding DeltaDisplay}"
+                                                                           Margin="0,6,0,0">
+                                                                    <TextBlock.Style>
+                                                                        <Style TargetType="TextBlock">
+                                                                            <Setter Property="Foreground" Value="{StaticResource AccentSecondaryBrush}" />
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding MeetsTarget}" Value="False">
+                                                                                    <Setter Property="Foreground" Value="{StaticResource AlertTextBrush}" />
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </TextBlock.Style>
+                                                                </TextBlock>
+                                                                <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                                                        Command="{Binding ResetCommand}"
+                                                                        Content="Reset term"
+                                                                        Margin="0,10,0,0"
+                                                                        IsEnabled="{Binding IsDirty}" />
+                                                            </StackPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </ScrollViewer>
+                                </DataTemplate>
+                                <DataTemplate DataType="{x:Null}">
+                                    <Border Padding="16"
+                                            Background="#152032"
+                                            CornerRadius="12">
+                                        <TextBlock Text="Select a negotiation to edit."
+                                                   Foreground="{StaticResource NeutralTextBrush}"
+                                                   FontStyle="Italic" />
+                                    </Border>
+                                </DataTemplate>
+                            </ContentControl.Resources>
+                        </ContentControl>
+                    </Border>
+                </Grid>
+
+                <Grid Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding ValidationMessage}"
+                               Foreground="{StaticResource AlertTextBrush}"
+                               VerticalAlignment="Center"
+                               Margin="0,0,16,0"
+                               Visibility="{Binding HasValidationMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                    <Button Grid.Column="1"
+                            Margin="0,0,12,0"
+                            Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding AddDealCommand}"
+                            Content="Add Negotiation" />
+
+                    <Button Grid.Column="2"
+                            Margin="0,0,12,0"
+                            Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding RemoveSelectedDealCommand}"
+                            Content="Remove"
+                            ToolTip="Remove the selected negotiation" />
+
+                    <Button Grid.Column="3"
+                            Margin="0,0,12,0"
+                            Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding CancelCommand}"
+                            Content="Cancel" />
+
+                    <Button Grid.Column="4"
+                            Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding SaveCommand}"
+                            Content="Save Changes" />
+                </Grid>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:ScoutAssignmentEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="0"
+                         ItemsSource="{Binding Assignments}"
+                         SelectedItem="{Binding SelectedAssignment}"
+                         behaviors:ListBoxDragReorderBehavior.EnableReorder="True"
+                         BorderThickness="1"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         Background="{StaticResource OverlayListBackgroundBrush}"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         Margin="0,0,0,12"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type editors:ScoutAssignmentEditorItemViewModel}">
+                            <Border Padding="14"
+                                    Margin="0,0,0,12"
+                                    Background="{StaticResource OverlayListItemBrush}"
+                                    BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="1"
+                                               Text="Focus"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3"
+                                             Margin="12,0,0,0"
+                                             Text="{Binding Focus, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0"
+                                               Margin="0,8,0,0"
+                                               Text="Role"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="1" Grid.Column="1"
+                                             Margin="12,8,12,0"
+                                             Text="{Binding Role, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="2"
+                                               Margin="0,8,0,0"
+                                               Text="Region"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="1" Grid.Column="3"
+                                             Margin="12,8,0,0"
+                                             Text="{Binding Region, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0"
+                                               Margin="0,8,0,0"
+                                               Text="Stage"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <ComboBox Grid.Row="2" Grid.Column="1"
+                                              Margin="12,8,12,0"
+                                              ItemsSource="{Binding DataContext.StageOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              SelectedItem="{Binding Stage, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="6,2"
+                                              IsEditable="True" />
+
+                                    <TextBlock Grid.Row="2" Grid.Column="2"
+                                               Margin="0,8,0,0"
+                                               Text="Priority"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <ComboBox Grid.Row="2" Grid.Column="3"
+                                              Margin="12,8,0,0"
+                                              ItemsSource="{Binding DataContext.PriorityOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              SelectedItem="{Binding Priority, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="6,2"
+                                              IsEditable="True" />
+
+                                    <TextBlock Grid.Row="3" Grid.Column="0"
+                                               Margin="0,8,0,0"
+                                               Text="Deadline"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="3" Grid.Column="1"
+                                             Margin="12,8,12,0"
+                                             Text="{Binding Deadline, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="3" Grid.Column="2"
+                                               Margin="0,8,0,0"
+                                               Text="Scout"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <ComboBox Grid.Row="3" Grid.Column="3"
+                                              Margin="12,8,0,0"
+                                              ItemsSource="{Binding DataContext.ScoutOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              DisplayMemberPath="Display"
+                                              SelectedValuePath="Name"
+                                              SelectedValue="{Binding Scout, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="6,2"
+                                              IsEditable="True" />
+
+                                    <TextBlock Grid.Row="4" Grid.Column="0"
+                                               Margin="0,10,0,0"
+                                               Text="Notes"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="3"
+                                             Margin="12,10,0,0"
+                                             Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,6"
+                                             AcceptsReturn="True"
+                                             TextWrapping="Wrap"
+                                             MinHeight="60" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <StackPanel Grid.Row="1"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right">
+                    <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding AddAssignmentCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Add scout assignment">
+                        <AccessText Text="_Add Assignment" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding RemoveAssignmentCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Remove scout assignment">
+                        <AccessText Text="_Remove" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveUpCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Move assignment up">
+                        <AccessText Text="Move _Up" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveDownCommand}"
+                            AutomationProperties.Name="Move assignment down">
+                        <AccessText Text="Move _Down" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:ShortlistEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ListBox Grid.Row="0"
+                         ItemsSource="{Binding Players}"
+                         SelectedItem="{Binding SelectedPlayer}"
+                         behaviors:ListBoxDragReorderBehavior.EnableReorder="True"
+                         BorderThickness="1"
+                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                         Background="{StaticResource OverlayListBackgroundBrush}"
+                         Foreground="{StaticResource PrimaryTextBrush}"
+                         Margin="0,0,0,12"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type editors:ShortlistEditorItemViewModel}">
+                            <Border Padding="14"
+                                    Margin="0,0,0,12"
+                                    Background="{StaticResource OverlayListItemBrush}"
+                                    BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <TextBlock Grid.Row="0" Grid.Column="0"
+                                               Text="Name"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="0" Grid.Column="1"
+                                             Margin="12,0,12,0"
+                                             Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="0" Grid.Column="2"
+                                               Text="Position"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="0" Grid.Column="3"
+                                             Margin="12,0,0,0"
+                                             Text="{Binding Position, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="0"
+                                               Margin="0,8,0,0"
+                                               Text="Status"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <ComboBox Grid.Row="1" Grid.Column="1"
+                                              Margin="12,8,12,0"
+                                              ItemsSource="{Binding DataContext.StatusOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              SelectedItem="{Binding Status, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="6,2"
+                                              IsEditable="True" />
+
+                                    <TextBlock Grid.Row="1" Grid.Column="2"
+                                               Margin="0,8,0,0"
+                                               Text="Action"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <ComboBox Grid.Row="1" Grid.Column="3"
+                                              Margin="12,8,0,0"
+                                              ItemsSource="{Binding DataContext.ActionOptions, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                              SelectedItem="{Binding Action, UpdateSourceTrigger=PropertyChanged}"
+                                              Background="#152032"
+                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                              BorderThickness="1"
+                                              Padding="6,2"
+                                              IsEditable="True" />
+
+                                    <TextBlock Grid.Row="2" Grid.Column="0"
+                                               Margin="0,8,0,0"
+                                               Text="Priority"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="2" Grid.Column="1"
+                                             Margin="12,8,12,0"
+                                             Text="{Binding Priority, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,4" />
+
+                                    <TextBlock Grid.Row="2" Grid.Column="2"
+                                               Margin="0,8,0,0"
+                                               Text="Notes"
+                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                    <TextBox Grid.Row="2" Grid.Column="3"
+                                             Margin="12,8,0,0"
+                                             Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}"
+                                             Background="#152032"
+                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                             BorderThickness="1"
+                                             Padding="8,6"
+                                             AcceptsReturn="True"
+                                             TextWrapping="Wrap"
+                                             MinHeight="50" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <StackPanel Grid.Row="1"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right">
+                    <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding AddPlayerCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Add shortlist player">
+                        <AccessText Text="_Add Player" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding RemovePlayerCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Remove shortlist player">
+                        <AccessText Text="_Remove" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveUpCommand}"
+                            Margin="0,0,12,0"
+                            AutomationProperties.Name="Move player up">
+                        <AccessText Text="Move _Up" />
+                    </Button>
+                    <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding MoveDownCommand}"
+                            AutomationProperties.Name="Move player down">
+                        <AccessText Text="Move _Down" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:TrainingWorkloadEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ScrollViewer Grid.Row="0"
+                              VerticalScrollBarVisibility="Auto"
+                              Margin="0,0,0,16">
+                    <StackPanel>
+                        <TextBlock Text="Legend Title"
+                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                        <TextBox Text="{Binding LegendTitle, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,6,0,12"
+                                 Background="#152032"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 BorderThickness="1"
+                                 Padding="8,6" />
+
+                        <TextBlock Text="Legend Subtitle"
+                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                        <TextBox Text="{Binding LegendSubtitle, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,6,0,20"
+                                 Background="#152032"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 BorderThickness="1"
+                                 Padding="8,6"
+                                 AcceptsReturn="True"
+                                 TextWrapping="Wrap"
+                                 MinHeight="60" />
+
+                        <ItemsControl ItemsSource="{Binding Rows}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type editors:TrainingWorkloadEditorRowViewModel}">
+                                    <Border Margin="0,0,0,18"
+                                            Padding="16"
+                                            Background="{StaticResource OverlayListBackgroundBrush}"
+                                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="16">
+                                        <StackPanel>
+                                            <TextBlock Text="Unit"
+                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                            <TextBox Text="{Binding Label, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,6,0,12"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     BorderThickness="1"
+                                                     Padding="8,6" />
+
+                                            <ItemsControl ItemsSource="{Binding Cells}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type editors:TrainingWorkloadEditorCellViewModel}">
+                                                        <Border Margin="0,0,0,14"
+                                                                Padding="12"
+                                                                Background="#101723"
+                                                                BorderBrush="#1F2B3A"
+                                                                BorderThickness="1"
+                                                                CornerRadius="12">
+                                                            <StackPanel>
+                                                                <TextBlock Text="{Binding Column}"
+                                                                           Foreground="{StaticResource NeutralTextBrush}" />
+                                                                <ComboBox ItemsSource="{Binding IntensityOptions}"
+                                                                          SelectedItem="{Binding SelectedIntensity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                          DisplayMemberPath="DisplayName"
+                                                                          Margin="0,6,0,12"
+                                                                          Background="#152032"
+                                                                          Foreground="{StaticResource PrimaryTextBrush}"
+                                                                          BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                          BorderThickness="1"
+                                                                          Padding="8,4" />
+
+                                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                                    <TextBlock Text="Load"
+                                                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                                                    <TextBlock Text="{Binding Load, StringFormat={}{0:0}}"
+                                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                                               FontWeight="SemiBold"
+                                                                               Margin="8,0,0,0" />
+                                                                </StackPanel>
+
+                                                                <Slider Minimum="0"
+                                                                        Maximum="120"
+                                                                        SmallChange="5"
+                                                                        LargeChange="5"
+                                                                        Value="{Binding Load, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                        Margin="0,6,0,10" />
+
+                                                                <TextBlock Text="Detail"
+                                                                           Foreground="{StaticResource NeutralTextBrush}" />
+                                                                <TextBox Text="{Binding Detail, UpdateSourceTrigger=PropertyChanged}"
+                                                                         Margin="0,6,0,0"
+                                                                         Background="#152032"
+                                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                         BorderThickness="1"
+                                                                         Padding="8,6"
+                                                                         AcceptsReturn="True"
+                                                                         TextWrapping="Wrap"
+                                                                         MinHeight="48" />
+                                                            </StackPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <Grid Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding ValidationMessage}"
+                               Foreground="{StaticResource AlertTextBrush}"
+                               VerticalAlignment="Center"
+                               Margin="0,0,16,0"
+                               Visibility="{Binding HasValidationMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                    <Button Grid.Column="1"
+                            Margin="0,0,12,0"
+                            Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding CancelCommand}"
+                            Content="Cancel" />
+
+                    <Button Grid.Column="2"
+                            Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding SaveCommand}"
+                            Content="Save Changes" />
+                </Grid>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:TrainingUnitBoardEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <StackPanel Grid.Row="0" Margin="0,0,0,16">
+                    <TextBlock Text="Coaching Assignments"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               FontWeight="SemiBold"
+                               Margin="0,0,0,8" />
+                    <ItemsControl ItemsSource="{Binding Units}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type editors:TrainingUnitCoachAssignmentViewModel}">
+                                <Border Margin="0,0,0,10"
+                                        Padding="12"
+                                        Background="{StaticResource OverlayListBackgroundBrush}"
+                                        BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="12">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="2*" />
+                                            <ColumnDefinition Width="3*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="{Binding Name}"
+                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                   VerticalAlignment="Center"
+                                                   FontWeight="SemiBold" />
+                                        <ComboBox Grid.Column="1"
+                                                  ItemsSource="{Binding CoachOptions}"
+                                                  SelectedValue="{Binding SelectedCoachId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                  SelectedValuePath="Id"
+                                                  DisplayMemberPath="Name"
+                                                  Background="#152032"
+                                                  Foreground="{StaticResource PrimaryTextBrush}"
+                                                  BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                  BorderThickness="1"
+                                                  Padding="8,4"
+                                                  HorizontalContentAlignment="Stretch"
+                                                  AutomationProperties.Name="Assign lead coach" />
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <ListView Grid.Row="1"
+                          ItemsSource="{Binding Players}"
+                          SelectedItem="{Binding SelectedPlayer}"
+                          Margin="0,0,0,16"
+                          BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                          BorderThickness="1"
+                          Background="{StaticResource OverlayListBackgroundBrush}"
+                          Foreground="{StaticResource PrimaryTextBrush}"
+                          ScrollViewer.VerticalScrollBarVisibility="Auto">
+                    <ListView.Resources>
+                        <Style TargetType="GridViewColumnHeader">
+                            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+                            <Setter Property="FontWeight" Value="SemiBold" />
+                            <Setter Property="FontSize" Value="12" />
+                        </Style>
+                    </ListView.Resources>
+                    <ListView.View>
+                        <GridView AllowsColumnReorder="False">
+                            <GridViewColumn Header="Player" Width="200">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type editors:TrainingUnitAssignmentRowViewModel}">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+                                            <TextBlock Text="{Binding Position}" Foreground="{StaticResource NeutralTextBrush}" FontSize="12" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn Header="Role" Width="140" DisplayMemberBinding="{Binding Role}" />
+                            <GridViewColumn Header="Status" Width="140" DisplayMemberBinding="{Binding Status}" />
+                            <GridViewColumn Header="Assign To" Width="200">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type editors:TrainingUnitAssignmentRowViewModel}">
+                                        <ComboBox ItemsSource="{Binding UnitOptions}"
+                                                  SelectedValuePath="Id"
+                                                  DisplayMemberPath="Name"
+                                                  SelectedValue="{Binding SelectedUnitId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                  Background="#152032"
+                                                  Foreground="{StaticResource PrimaryTextBrush}"
+                                                  BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                  BorderThickness="1"
+                                                  Padding="8,4"
+                                                  HorizontalContentAlignment="Stretch"
+                                                  AutomationProperties.Name="Training unit selection" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+
+                <TextBlock Grid.Row="2"
+                           Text="{Binding ValidationMessage}"
+                           Foreground="{StaticResource WarningTextBrush}"
+                           Visibility="{Binding HasValidationMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:TrainingProgressionEditorViewModel}">
+            <Grid x:Name="TrainingProgressionEditorRoot">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0" Margin="0,0,0,16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Margin="0,0,24,0">
+                        <TextBlock Text="Headline value"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                        <TextBox Text="{Binding MetricValue, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,6,0,10"
+                                 Background="#152032"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 BorderThickness="1"
+                                 Padding="8,4" />
+
+                        <TextBlock Text="Headline label"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                        <TextBox Text="{Binding MetricLabel, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,6,0,10"
+                                 Background="#152032"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 BorderThickness="1"
+                                 Padding="8,4" />
+
+                        <TextBlock Text="Summary"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                        <TextBox Text="{Binding Summary, UpdateSourceTrigger=PropertyChanged}"
+                                 Margin="0,6,0,0"
+                                 Background="#152032"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 BorderThickness="1"
+                                 Padding="8,6"
+                                 AcceptsReturn="True"
+                                 TextWrapping="Wrap"
+                                 MinHeight="92" />
+
+                        <TextBlock Text="Timeline buckets"
+                                   Margin="0,18,0,0"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}" />
+
+                        <ItemsControl ItemsSource="{Binding PeriodEntries}"
+                                      Margin="0,6,0,12">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type editors:TrainingProgressionPeriodEditorViewModel}">
+                                    <Border Background="{StaticResource OverlayListItemBrush}"
+                                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="12"
+                                            Margin="0,0,0,8">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBox Grid.Column="0"
+                                                     Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     BorderThickness="1"
+                                                     Padding="8,4" />
+
+                                            <Button Grid.Column="1"
+                                                    Content="Remove"
+                                                    Margin="12,0,0,0"
+                                                    Padding="14,6"
+                                                    Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                                    Command="{Binding DataContext.RemovePeriodCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    IsEnabled="{Binding DataContext.CanRemovePeriods, RelativeSource={RelativeSource AncestorType=ItemsControl}}" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <Button Content="Add period"
+                                Command="{Binding AddPeriodCommand}"
+                                Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Padding="16,6"
+                                HorizontalAlignment="Left"
+                                Margin="0,0,0,12" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1">
+                        <TextBlock Text="Minimum range"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                        <TextBox Text="{Binding Minimum, UpdateSourceTrigger=PropertyChanged, StringFormat=F1}"
+                                 Margin="0,6,0,10"
+                                 Background="#152032"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 BorderThickness="1"
+                                 Padding="8,4" />
+
+                        <TextBlock Text="Maximum range"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                        <TextBox Text="{Binding Maximum, UpdateSourceTrigger=PropertyChanged, StringFormat=F1}"
+                                 Margin="0,6,0,10"
+                                 Background="#152032"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 BorderThickness="1"
+                                 Padding="8,4" />
+                    </StackPanel>
+                </Grid>
+
+                <Grid Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1.4*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Margin="0,0,24,0">
+                        <TextBlock Text="Progression series"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}" />
+
+                        <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
+                            <Button Content="Add series"
+                                    Command="{Binding AddSeriesCommand}"
+                                    Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                    Padding="16,6" />
+                            <Button Content="Remove"
+                                    Command="{Binding RemoveSeriesCommand}"
+                                    CommandParameter="{Binding SelectedSeries}"
+                                    Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                    Padding="16,6"
+                                    Margin="8,0,0,0" />
+                        </StackPanel>
+
+                        <ListBox ItemsSource="{Binding Series}"
+                                 SelectedItem="{Binding SelectedSeries}"
+                                 behaviors:ListBoxDragReorderBehavior.EnableReorder="True"
+                                 BorderThickness="1"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 Background="{StaticResource OverlayListBackgroundBrush}"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 Height="220"
+                                 ScrollViewer.VerticalScrollBarVisibility="Auto">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type editors:TrainingProgressionSeriesEditorViewModel}">
+                                    <Border Background="{StaticResource OverlayListItemBrush}"
+                                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="12"
+                                            Margin="0,0,0,10">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Name}"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontWeight="SemiBold" />
+                                            <TextBlock Text="{Binding Color}"
+                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                       Margin="0,4,0,0" />
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+
+                        <TextBlock Text="Highlights"
+                                   Style="{StaticResource OverlayFieldLabelTextStyle}"
+                                   Margin="0,20,0,8" />
+
+                        <ListBox ItemsSource="{Binding Highlights}"
+                                 behaviors:ListBoxDragReorderBehavior.EnableReorder="True"
+                                 BorderThickness="1"
+                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                 Background="{StaticResource OverlayListBackgroundBrush}"
+                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                 Margin="0,0,0,8">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type editors:TrainingProgressionHighlightEditorViewModel}">
+                                    <Border Background="{StaticResource OverlayListItemBrush}"
+                                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="12"
+                                            Margin="0,0,0,10">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <StackPanel Grid.Column="0">
+                                                <TextBlock Text="Primary"
+                                                           Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                                <TextBox Text="{Binding Primary, UpdateSourceTrigger=PropertyChanged}"
+                                                         Margin="0,6,0,10"
+                                                         Background="#152032"
+                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                         BorderThickness="1"
+                                                         Padding="8,4" />
+
+                                                <TextBlock Text="Secondary"
+                                                           Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                                <TextBox Text="{Binding Secondary, UpdateSourceTrigger=PropertyChanged}"
+                                                         Margin="0,6,0,10"
+                                                         Background="#152032"
+                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                         BorderThickness="1"
+                                                         Padding="8,4" />
+
+                                                <TextBlock Text="Detail"
+                                                           Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                                <TextBox Text="{Binding Tertiary, UpdateSourceTrigger=PropertyChanged}"
+                                                         Margin="0,6,0,10"
+                                                         Background="#152032"
+                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                         BorderThickness="1"
+                                                         Padding="8,4" />
+
+                                                <TextBlock Text="Accent"
+                                                           Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                                <TextBox Text="{Binding Accent, UpdateSourceTrigger=PropertyChanged}"
+                                                         Margin="0,6,0,0"
+                                                         Background="#152032"
+                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                         BorderThickness="1"
+                                                         Padding="8,4" />
+                                            </StackPanel>
+
+                                            <Button Grid.Column="1"
+                                                    Content="Remove"
+                                                    Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                                    Padding="14,6"
+                                                    Margin="12,0,0,0"
+                                                    VerticalAlignment="Top"
+                                                    Command="{Binding DataContext.RemoveHighlightCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                                    CommandParameter="{Binding}" />
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+
+                        <Button Content="Add highlight"
+                                Command="{Binding AddHighlightCommand}"
+                                Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Padding="16,6" />
+                    </StackPanel>
+
+                    <Border Grid.Column="1"
+                            Background="{StaticResource OverlayListBackgroundBrush}"
+                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="14"
+                            Padding="16">
+                        <StackPanel>
+                            <ContentControl Content="{Binding SelectedSeries}">
+                                <ContentControl.ContentTemplate>
+                                    <DataTemplate DataType="{x:Type editors:TrainingProgressionSeriesEditorViewModel}">
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="*" />
+                                            </Grid.RowDefinitions>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBlock Grid.Row="0"
+                                                       Grid.Column="0"
+                                                       Grid.ColumnSpan="2"
+                                                       Text="Series name"
+                                                       Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                            <TextBox Grid.Row="1"
+                                                     Grid.Column="0"
+                                                     Grid.ColumnSpan="2"
+                                                     Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
+                                                     Margin="0,6,0,12"
+                                                     Background="#152032"
+                                                     Foreground="{StaticResource PrimaryTextBrush}"
+                                                     BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                     BorderThickness="1"
+                                                     Padding="8,4" />
+
+                                            <TextBlock Grid.Row="2"
+                                                       Grid.Column="0"
+                                                       Text="Colour"
+                                                       Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                            <Grid Grid.Row="3"
+                                                  Grid.Column="0"
+                                                  Margin="0,6,12,12">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <Border Grid.Column="0"
+                                                        Width="28"
+                                                        Height="28"
+                                                        CornerRadius="8"
+                                                        Background="{Binding Color, Converter={StaticResource HexColorBrushConverter}}"
+                                                        BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                        BorderThickness="1"
+                                                        Margin="0,0,8,0" />
+
+                                                <ComboBox Grid.Column="1"
+                                                          ItemsSource="{Binding DataContext.ColourOptions, RelativeSource={RelativeSource AncestorType=ContentControl}}"
+                                                          Text="{Binding Color, UpdateSourceTrigger=PropertyChanged}"
+                                                          IsEditable="True"
+                                                          IsTextSearchEnabled="False"
+                                                          StaysOpenOnEdit="True"
+                                                          Background="#152032"
+                                                          Foreground="{StaticResource PrimaryTextBrush}"
+                                                          BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                          BorderThickness="1"
+                                                          Padding="8,4">
+                                                    <ComboBox.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <Border Width="16"
+                                                                        Height="16"
+                                                                        CornerRadius="4"
+                                                                        Background="{Binding Converter={StaticResource HexColorBrushConverter}}"
+                                                                        BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                        BorderThickness="1"
+                                                                        Margin="0,0,8,0" />
+                                                                <TextBlock Text="{Binding}" />
+                                                            </StackPanel>
+                                                        </DataTemplate>
+                                                    </ComboBox.ItemTemplate>
+                                                </ComboBox>
+                                            </Grid>
+
+                                            <TextBlock Grid.Row="2"
+                                                       Grid.Column="1"
+                                                       Text="Accent pill"
+                                                       Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                            <Grid Grid.Row="3"
+                                                  Grid.Column="1"
+                                                  Margin="0,6,0,12">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <Border Grid.Column="0"
+                                                        Width="28"
+                                                        Height="28"
+                                                        CornerRadius="8"
+                                                        Background="{Binding Accent, Converter={StaticResource HexColorBrushConverter}}"
+                                                        BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                        BorderThickness="1"
+                                                        Margin="0,0,8,0" />
+
+                                                <ComboBox Grid.Column="1"
+                                                          ItemsSource="{Binding DataContext.ColourOptions, RelativeSource={RelativeSource AncestorType=ContentControl}}"
+                                                          Text="{Binding Accent, UpdateSourceTrigger=PropertyChanged}"
+                                                          IsEditable="True"
+                                                          IsTextSearchEnabled="False"
+                                                          StaysOpenOnEdit="True"
+                                                          Background="#152032"
+                                                          Foreground="{StaticResource PrimaryTextBrush}"
+                                                          BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                          BorderThickness="1"
+                                                          Padding="8,4">
+                                                    <ComboBox.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <Border Width="16"
+                                                                        Height="16"
+                                                                        CornerRadius="4"
+                                                                        Background="{Binding Converter={StaticResource HexColorBrushConverter}}"
+                                                                        BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                        BorderThickness="1"
+                                                                        Margin="0,0,8,0" />
+                                                                <TextBlock Text="{Binding}" />
+                                                            </StackPanel>
+                                                        </DataTemplate>
+                                                    </ComboBox.ItemTemplate>
+                                                </ComboBox>
+                                            </Grid>
+
+                                            <CheckBox Grid.Row="4"
+                                                      Grid.Column="0"
+                                                      Content="Emphasise series"
+                                                      IsChecked="{Binding IsHighlighted, Mode=TwoWay}"
+                                                      Foreground="{StaticResource PrimaryTextBrush}" />
+
+                                            <Button Grid.Row="4"
+                                                    Grid.Column="1"
+                                                    HorizontalAlignment="Right"
+                                                    Content="Add point"
+                                                    Command="{Binding AddPointCommand}"
+                                                    Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                                    Padding="14,6" />
+
+                                            <ItemsControl Grid.Row="5"
+                                                          Grid.Column="0"
+                                                          Grid.ColumnSpan="2"
+                                                          ItemsSource="{Binding Points}"
+                                                          Margin="0,12,0,0">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type editors:TrainingProgressionPointEditorViewModel}">
+                                                        <Border Background="{StaticResource OverlayListItemBrush}"
+                                                                BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                BorderThickness="1"
+                                                                CornerRadius="12"
+                                                                Padding="12"
+                                                                Margin="0,0,0,10">
+                                                            <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="2*" />
+                                                                    <ColumnDefinition Width="2*" />
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="Auto" />
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <StackPanel Grid.Column="0">
+                                                                    <TextBlock Text="Period"
+                                                                               Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                                                    <ComboBox ItemsSource="{Binding DataContext.PeriodEntries, RelativeSource={RelativeSource AncestorType=ContentControl}}"
+                                                                              DisplayMemberPath="Name"
+                                                                              SelectedValuePath="Name"
+                                                                              SelectedValue="{Binding Period, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                              Text="{Binding Period, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                              IsEditable="True"
+                                                                              IsTextSearchEnabled="False"
+                                                                              StaysOpenOnEdit="True"
+                                                                              Margin="0,6,0,0"
+                                                                              Background="#152032"
+                                                                              Foreground="{StaticResource PrimaryTextBrush}"
+                                                                              BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                              BorderThickness="1"
+                                                                              Padding="8,4" />
+                                                                </StackPanel>
+
+                                                                <StackPanel Grid.Column="1" Margin="12,0,0,0">
+                                                                    <TextBlock Text="Value"
+                                                                               Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                                                    <Slider Minimum="{Binding DataContext.Minimum, ElementName=TrainingProgressionEditorRoot}"
+                                                                            Maximum="{Binding DataContext.Maximum, ElementName=TrainingProgressionEditorRoot}"
+                                                                            Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                            Margin="0,6,0,0"
+                                                                            SmallChange="1"
+                                                                            LargeChange="5" />
+                                                                    <TextBlock Text="{Binding Value, StringFormat=F1}"
+                                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                                               FontWeight="SemiBold"
+                                                                               Margin="0,6,0,0" />
+                                                                </StackPanel>
+
+                                                                <StackPanel Grid.Column="2" Margin="12,0,0,0">
+                                                                    <TextBlock Text="Detail"
+                                                                               Style="{StaticResource OverlayFieldLabelTextStyle}" />
+                                                                    <TextBox Text="{Binding Detail, UpdateSourceTrigger=PropertyChanged}"
+                                                                             Margin="0,6,0,0"
+                                                                             Background="#152032"
+                                                                             Foreground="{StaticResource PrimaryTextBrush}"
+                                                                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                             BorderThickness="1"
+                                                                             Padding="8,4"
+                                                                             AcceptsReturn="True"
+                                                                             TextWrapping="Wrap"
+                                                                             MinHeight="48" />
+                                                                </StackPanel>
+
+                                                                <Button Grid.Column="3"
+                                                                        Content="Remove"
+                                                                        Command="{Binding DataContext.RemovePointCommand, RelativeSource={RelativeSource AncestorType=ContentPresenter}}"
+                                                                        CommandParameter="{Binding}"
+                                                                        Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                                                        Padding="12,4"
+                                                                        Margin="12,0,0,0" />
+                                                            </Grid>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ContentControl.ContentTemplate>
+                            </ContentControl>
+
+                            <TextBlock Text="Select a series to edit its details"
+                                       Foreground="{StaticResource NeutralTextBrush}"
+                                       FontStyle="Italic"
+                                       Margin="0,12,0,0">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SelectedSeries}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </StackPanel>
+                    </Border>
+
+                    <Grid Grid.Row="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0"
+                                   Text="{Binding ValidationMessage}"
+                                   Foreground="{StaticResource AlertTextBrush}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,16,0">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Style.Triggers>
+                                        <Trigger Property="Text" Value="">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </Trigger>
+                                        <Trigger Property="Text" Value="{x:Null}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+
+                        <Button Grid.Column="1"
+                                Margin="0,0,12,0"
+                                Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding CancelCommand}"
+                                Content="Cancel" />
+
+                        <Button Grid.Column="2"
+                                Style="{StaticResource PalettePrimaryButtonStyle}"
+                                Command="{Binding SaveCommand}"
+                                Content="Save Changes" />
+                    </Grid>
+                </Grid>
+
+                <Grid Grid.Row="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding ValidationMessage}"
+                               Foreground="{StaticResource AlertTextBrush}"
+                               VerticalAlignment="Center"
+                               Margin="0,0,16,0">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <Trigger Property="Text" Value="">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+                                    <Trigger Property="Text" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <Button Grid.Column="1"
+                            Margin="0,0,12,0"
+                            Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding CancelCommand}"
+                            Content="Cancel" />
+
+                    <Button Grid.Column="2"
+                            Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding SaveCommand}"
+                            Content="Save Changes" />
+                </Grid>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type editors:MoraleHeatmapEditorViewModel}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <ScrollViewer Grid.Row="0"
+                              VerticalScrollBarVisibility="Auto"
+                              Margin="0,0,0,12">
+                    <ItemsControl ItemsSource="{Binding Rows}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type editors:MoraleHeatmapEditorRowViewModel}">
+                                <Border Padding="16"
+                                        Margin="0,0,0,12"
+                                        Background="{StaticResource OverlayListItemBrush}"
+                                        BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="12">
+                                    <StackPanel>
+                                        <TextBlock Text="Group Name"
+                                                   Foreground="{StaticResource NeutralTextBrush}" />
+                                        <TextBox Text="{Binding Label, UpdateSourceTrigger=PropertyChanged}"
+                                                 Margin="0,6,0,12"
+                                                 Background="#152032"
+                                                 Foreground="{StaticResource PrimaryTextBrush}"
+                                                 BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                 BorderThickness="1"
+                                                 Padding="8,4" />
+
+                                        <ItemsControl ItemsSource="{Binding Cells}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <StackPanel />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type editors:MoraleHeatmapEditorCellViewModel}">
+                                                    <Border Padding="12"
+                                                            Margin="0,0,0,10"
+                                                            Background="#101A2A"
+                                                            BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                            BorderThickness="1"
+                                                            CornerRadius="12">
+                                                        <Grid>
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto" />
+                                                                <RowDefinition Height="Auto" />
+                                                                <RowDefinition Height="Auto" />
+                                                            </Grid.RowDefinitions>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="Auto" />
+                                                                <ColumnDefinition Width="*" />
+                                                            </Grid.ColumnDefinitions>
+
+                                                            <TextBlock Grid.Row="0"
+                                                                       Grid.Column="0"
+                                                                       Text="Column"
+                                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                                            <TextBlock Grid.Row="0"
+                                                                       Grid.Column="1"
+                                                                       Text="{Binding Column}"
+                                                                       Foreground="{StaticResource PrimaryTextBrush}" />
+
+                                                            <TextBlock Grid.Row="1"
+                                                                       Grid.Column="0"
+                                                                       Margin="0,8,12,0"
+                                                                       Text="Intensity"
+                                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                                            <ComboBox Grid.Row="1"
+                                                                      Grid.Column="1"
+                                                                      Margin="0,4,0,0"
+                                                                      ItemsSource="{Binding IntensityOptions}"
+                                                                      SelectedItem="{Binding SelectedIntensity, UpdateSourceTrigger=PropertyChanged}"
+                                                                      Background="#152032"
+                                                                      Foreground="{StaticResource PrimaryTextBrush}"
+                                                                      BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                      BorderThickness="1"
+                                                                      Padding="6,2"
+                                                                      MinWidth="180">
+                                                                <ComboBox.ItemTemplate>
+                                                                    <DataTemplate DataType="{x:Type editors:MoraleIntensityOptionViewModel}">
+                                                                        <StackPanel>
+                                                                            <TextBlock Text="{Binding DisplayName}"
+                                                                                       Foreground="{StaticResource PrimaryTextBrush}" />
+                                                                            <TextBlock Text="{Binding Description}"
+                                                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                                                       FontSize="11"
+                                                                                       TextWrapping="Wrap"
+                                                                                       Visibility="{Binding Description, Converter={StaticResource StringToVisibilityConverter}}" />
+                                                                        </StackPanel>
+                                                                    </DataTemplate>
+                                                                </ComboBox.ItemTemplate>
+                                                            </ComboBox>
+
+                                                            <TextBlock Grid.Row="2"
+                                                                       Grid.Column="0"
+                                                                       Margin="0,8,12,0"
+                                                                       Text="Label & Notes"
+                                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                                            <StackPanel Grid.Row="2"
+                                                                        Grid.Column="1">
+                                                                <TextBox Text="{Binding Label, UpdateSourceTrigger=PropertyChanged}"
+                                                                         Background="#152032"
+                                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                         BorderThickness="1"
+                                                                         Padding="6,3"
+                                                                         Margin="0,4,0,4" />
+                                                                <TextBox Text="{Binding Detail, UpdateSourceTrigger=PropertyChanged}"
+                                                                         Background="#152032"
+                                                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                                                         BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                                                                         BorderThickness="1"
+                                                                         Padding="6,3"
+                                                                         AcceptsReturn="True"
+                                                                         TextWrapping="Wrap"
+                                                                         Height="60" />
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <Grid Grid.Row="1">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding ValidationMessage}"
+                               Foreground="{StaticResource AlertTextBrush}"
+                               VerticalAlignment="Center"
+                               Margin="0,0,16,0"
+                               Visibility="{Binding HasValidationMessage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                    <Button Grid.Column="1"
+                            Margin="0,0,12,0"
+                            Style="{StaticResource PaletteSecondaryButtonStyle}"
+                            Command="{Binding CancelCommand}"
+                            Content="Cancel" />
+
+                    <Button Grid.Column="2"
+                            Style="{StaticResource PalettePrimaryButtonStyle}"
+                            Command="{Binding SaveCommand}"
+                            Content="Save Changes" />
+                </Grid>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="TransferNegotiationCardBodyTemplate">
+            <Grid>
+                <ItemsControl ItemsSource="{Binding Negotiations.Deals}">
+                    <ItemsControl.Style>
+                        <Style TargetType="ItemsControl">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasNegotiations}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ItemsControl.Style>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:TransferNegotiationDealCardViewModel}">
+                            <Border Padding="18"
+                                    Margin="0,0,0,16"
+                                    Background="{StaticResource SurfaceMediumBrush}"
+                                    BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="18">
+                                <StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Player}"
+                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       FontSize="18"
+                                                       FontWeight="SemiBold" />
+                                            <StackPanel Orientation="Horizontal"
+                                                        Margin="0,8,0,0">
+                                                <TextBlock Text="{Binding Position}"
+                                                           Foreground="{StaticResource NeutralTextBrush}" />
+                                                <TextBlock Text=" • "
+                                                           Foreground="{StaticResource NeutralTextBrush}"
+                                                           Margin="8,0" />
+                                                <TextBlock Text="{Binding Club}"
+                                                           Foreground="{StaticResource NeutralTextBrush}" />
+                                            </StackPanel>
+                                        </StackPanel>
+
+                                        <StackPanel Grid.Column="1"
+                                                    HorizontalAlignment="Right">
+                                            <TextBlock Text="{Binding Stage}"
+                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                       HorizontalAlignment="Right" />
+                                            <Border Background="#2EC4B622"
+                                                    Padding="12,4"
+                                                    CornerRadius="14"
+                                                    Margin="0,8,0,0"
+                                                    HorizontalAlignment="Right"
+                                                    Visibility="{Binding HasAccent, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <TextBlock Text="{Binding Accent}"
+                                                           Foreground="{StaticResource AccentPrimaryBrush}"
+                                                           FontWeight="SemiBold" />
+                                            </Border>
+                                            <TextBlock Text="{Binding Deadline}"
+                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                       HorizontalAlignment="Right"
+                                                       Margin="0,8,0,0" />
+                                            <Border Background="{StaticResource AccentPrimaryBrush}"
+                                                    Padding="14,4"
+                                                    CornerRadius="14"
+                                                    Margin="0,8,0,0"
+                                                    HorizontalAlignment="Right">
+                                                <TextBlock Text="{Binding Status}"
+                                                           Foreground="White"
+                                                           FontWeight="SemiBold" />
+                                            </Border>
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <ItemsControl Margin="0,18,0,0"
+                                                  ItemsSource="{Binding Terms}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate DataType="{x:Type vm:TransferNegotiationTermCardViewModel}">
+                                                <Border Width="220"
+                                                        Margin="0,0,16,16"
+                                                        Background="#152032"
+                                                        BorderBrush="#233246"
+                                                        BorderThickness="1"
+                                                        CornerRadius="16"
+                                                        Padding="14">
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Label}"
+                                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                                   FontWeight="SemiBold" />
+                                                        <ProgressBar Value="{Binding Progress}"
+                                                                     Maximum="1"
+                                                                     Height="6"
+                                                                     Margin="0,10,0,0"
+                                                                     Foreground="{StaticResource AccentSecondaryBrush}"
+                                                                     Background="#101623" />
+                                                        <StackPanel Orientation="Horizontal"
+                                                                    Margin="0,10,0,0">
+                                                            <TextBlock Text="{Binding DisplayValue}"
+                                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                                       FontWeight="SemiBold" />
+                                                            <TextBlock Text="/"
+                                                                       Margin="8,0"
+                                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                                            <TextBlock Text="{Binding TargetDisplay}"
+                                                                       Foreground="{StaticResource NeutralTextBrush}" />
+                                                        </StackPanel>
+                                                        <TextBlock Text="{Binding DeltaDisplay}"
+                                                                   Margin="0,8,0,0">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Foreground" Value="{StaticResource AccentSecondaryBrush}" />
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsTargetMet}" Value="False">
+                                                                            <Setter Property="Foreground" Value="{StaticResource AlertTextBrush}" />
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                        <TextBlock Text="{Binding Tooltip}"
+                                                                   Foreground="{StaticResource NeutralTextBrush}"
+                                                                   FontSize="11"
+                                                                   Margin="0,8,0,0"
+                                                                   TextWrapping="Wrap"
+                                                                   Visibility="{Binding Tooltip, Converter={StaticResource NullToVisibilityConverter}}" />
+                                                    </StackPanel>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+
+                                    <TextBlock Text="{Binding Summary}"
+                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               Margin="0,6,0,0"
+                                               TextWrapping="Wrap"
+                                               Visibility="{Binding HasSummary, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                    <TextBlock Text="{Binding Agent}"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,4,0,0"
+                                               TextWrapping="Wrap"
+                                               Visibility="{Binding HasAgent, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                    <Border Background="#1B2435"
+                                            CornerRadius="14"
+                                            Padding="14"
+                                            Margin="0,8,0,0"
+                                            Visibility="{Binding HasResponse, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        <TextBlock Text="{Binding Response}"
+                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                   TextWrapping="Wrap" />
+                                    </Border>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <TextBlock Text="No active negotiations configured"
+                           Foreground="{StaticResource NeutralTextBrush}"
+                           FontStyle="Italic"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Margin="0,24,0,0">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding HasNegotiations}" Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+            </Grid>
+        </DataTemplate>
+
+        <views:CardBodyTemplateSelector x:Key="CardBodyTemplateSelector"
+                                        MetricTemplate="{StaticResource MetricCardBodyTemplate}"
+                                        ListTemplate="{StaticResource ListCardBodyTemplate}"
+                                        FormationTemplate="{StaticResource FormationCardBodyTemplate}"
+                                        FixtureTemplate="{StaticResource FixtureCardBodyTemplate}"
+                                        StatusTemplate="{StaticResource StatusCardBodyTemplate}"
+                                        LineChartTemplate="{StaticResource LineChartCardBodyTemplate}"
+                                        GaugeTemplate="{StaticResource GaugeCardBodyTemplate}"
+                                        TimelineTemplate="{StaticResource TimelineCardBodyTemplate}"
+                                        TrainingCalendarTemplate="{StaticResource TrainingCalendarCardBodyTemplate}"
+                                        FixtureCalendarTemplate="{StaticResource FixtureCalendarCardBodyTemplate}"
+                                        ForecastTemplate="{StaticResource ForecastCardBodyTemplate}"
+                                        WorkloadHeatmapTemplate="{StaticResource WorkloadHeatmapCardBodyTemplate}"
+                                        MoraleHeatmapTemplate="{StaticResource MoraleHeatmapCardBodyTemplate}"
+                                        SquadTableTemplate="{StaticResource SquadTableCardBodyTemplate}"
+                                        FinanceCashflowTemplate="{StaticResource FinanceCashflowCardBodyTemplate}"
+                                        FinanceBudgetAllocatorTemplate="{StaticResource FinanceBudgetAllocatorCardBodyTemplate}"
+                                        FinanceScenarioTemplate="{StaticResource FinanceScenarioCardBodyTemplate}"
+                                        TransferNegotiationTemplate="{StaticResource TransferNegotiationCardBodyTemplate}"
+                                        ScoutAssignmentsTemplate="{StaticResource ScoutAssignmentsCardBodyTemplate}"
+                                        ShortlistBoardTemplate="{StaticResource ShortlistBoardCardBodyTemplate}"
+                                        TrainingUnitBoardTemplate="{StaticResource TrainingUnitBoardCardBodyTemplate}"
+                                        TrainingProgressionTemplate="{StaticResource TrainingProgressionCardBodyTemplate}"
+                                        ShotMapTemplate="{StaticResource ShotMapCardBodyTemplate}"
+                                        MedicalTimelineTemplate="{StaticResource MedicalTimelineCardBodyTemplate}"
+                                        ClubVisionRoadmapTemplate="{StaticResource ClubVisionRoadmapCardBodyTemplate}"
+                                        ClubVisionExpectationsTemplate="{StaticResource ClubVisionExpectationBoardCardBodyTemplate}" />
+
+        <DataTemplate DataType="{x:Type vm:CardViewModel}">
+            <Grid Width="{Binding Width}" Height="{Binding Height}">
+                <Border Style="{StaticResource CardBorderStyle}"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Title}" Style="{StaticResource CardTitleTextStyle}" />
+                                <Border Margin="12,0,0,0"
+                                        Padding="10,4"
+                                        Background="#2EC4B622"
+                                        CornerRadius="12"
+                                        Visibility="{Binding HasPill, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                    <TextBlock Text="{Binding PillText}"
+                                               Foreground="{StaticResource AccentPrimaryBrush}"
+                                               FontSize="12"
+                                               FontWeight="SemiBold" />
+                                </Border>
+                            </StackPanel>
+
+                            <StackPanel Grid.Column="1"
+                                        Orientation="Horizontal"
+                                        HorizontalAlignment="Right">
+                                <Button Style="{StaticResource CardHeaderButtonStyle}"
+                                        Command="{Binding OpenEditorCommand}"
+                                        Visibility="{Binding IsEditorAvailable, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        AutomationProperties.Name="Edit card content">
+                                    <AccessText Text="_Edit" />
+                                </Button>
+                            </StackPanel>
+                        </Grid>
+
+                        <TextBlock Grid.Row="1"
+                                   Margin="0,8,0,0"
+                                   Text="{Binding Subtitle}"
+                                   Style="{StaticResource CardSubtitleTextStyle}"
+                                   Visibility="{Binding HasSubtitle, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                        <StackPanel Grid.Row="2" Margin="0,16,0,0">
+                            <TextBlock Text="{Binding Description}"
+                                       Foreground="{StaticResource NeutralTextBrush}"
+                                       FontSize="13"
+                                       TextWrapping="Wrap"
+                                       Visibility="{Binding HasDescription, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            <ContentControl Content="{Binding}"
+                                            ContentTemplateSelector="{StaticResource CardBodyTemplateSelector}">
+                                <ContentControl.Style>
+                                    <Style TargetType="ContentControl">
+                                        <Setter Property="Margin" Value="0,12,0,0" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding HasDescription}" Value="False">
+                                                <Setter Property="Margin" Value="0" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </ContentControl.Style>
+                            </ContentControl>
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <controls:CardDragThumb DragStartedCommand="{Binding BeginDragCommand}"
+                                        DragDeltaCommand="{Binding DragDeltaCommand}"
+                                        DragCompletedCommand="{Binding CompleteDragCommand}"
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch"
+                                        Cursor="SizeAll"
+                                        Focusable="True" />
+
+                <controls:CardResizeThumb Handle="East"
+                                          DragStartedCommand="{Binding BeginResizeCommand}"
+                                          DragDeltaCommand="{Binding ResizeDeltaCommand}"
+                                          DragCompletedCommand="{Binding CompleteResizeCommand}"
+                                          HorizontalAlignment="Right"
+                                          VerticalAlignment="Stretch"
+                                          Width="8"
+                                          Cursor="SizeWE"
+                                          Focusable="False" />
+
+                <controls:CardResizeThumb Handle="South"
+                                          DragStartedCommand="{Binding BeginResizeCommand}"
+                                          DragDeltaCommand="{Binding ResizeDeltaCommand}"
+                                          DragCompletedCommand="{Binding CompleteResizeCommand}"
+                                          HorizontalAlignment="Stretch"
+                                          VerticalAlignment="Bottom"
+                                          Height="8"
+                                          Cursor="SizeNS"
+                                          Focusable="False" />
+
+                <controls:CardResizeThumb Handle="SouthEast"
+                                          DragStartedCommand="{Binding BeginResizeCommand}"
+                                          DragDeltaCommand="{Binding ResizeDeltaCommand}"
+                                          DragCompletedCommand="{Binding CompleteResizeCommand}"
+                                          HorizontalAlignment="Right"
+                                          VerticalAlignment="Bottom"
+                                          Width="14"
+                                          Height="14"
+                                          Cursor="SizeNWSE"
+                                          Background="#33FFFFFF"
+                                          Focusable="False" />
+            </Grid>
+        </DataTemplate>
+    </UserControl.Resources>
+
+    <Border Background="#111622"
+            CornerRadius="18"
+            SnapsToDevicePixels="True">
+        <Grid>
+            <Grid.Background>
+                <DrawingBrush TileMode="Tile"
+                              Viewport="0,0,32,32"
+                              ViewportUnits="Absolute"
+                              Stretch="None">
+                    <DrawingBrush.Drawing>
+                        <GeometryDrawing Brush="Transparent">
+                            <GeometryDrawing.Pen>
+                                <Pen Brush="#112EC4B6" Thickness="1" />
+                            </GeometryDrawing.Pen>
+                            <GeometryDrawing.Geometry>
+                                <RectangleGeometry Rect="0,0,32,32" />
+                            </GeometryDrawing.Geometry>
+                        </GeometryDrawing>
+                    </DrawingBrush.Drawing>
+                </DrawingBrush>
+            </Grid.Background>
+
+            <ScrollViewer x:Name="SurfaceScrollViewer"
+                          HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Auto"
+                          CanContentScroll="True"
+                          Loaded="OnSurfaceLoaded"
+                          ScrollChanged="OnSurfaceScrollChanged"
+                          SizeChanged="OnSurfaceSizeChanged">
+                <Grid Width="{Binding SurfaceWidth}"
+                      Height="{Binding SurfaceHeight}">
+                    <ItemsControl ItemsSource="{Binding Cards}"
+                                  VirtualizingPanel.IsVirtualizing="True"
+                                  VirtualizingPanel.VirtualizationMode="Recycling"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Top">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <controls:VirtualizingCardPanel SurfaceWidth="{Binding SurfaceWidth}"
+                                                               SurfaceHeight="{Binding SurfaceHeight}" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Visibility" Value="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                    </ItemsControl>
+
+                    <ItemsControl ItemsSource="{Binding Previews}"
+                                  ItemTemplate="{StaticResource CardPreviewTemplate}"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Top"
+                                  IsHitTestVisible="False">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Canvas />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Panel.ZIndex" Value="10" />
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                    </ItemsControl>
+                </Grid>
+            </ScrollViewer>
+
+            <Border HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Margin="24"
+                    Padding="12"
+                    Background="{StaticResource SurfaceToolbarBackgroundBrush}"
+                    BorderBrush="{StaticResource SurfaceToolbarBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="18"
+                    Panel.ZIndex="15">
+                <StackPanel Orientation="Horizontal"
+                            HorizontalAlignment="Right">
+                    <Button Style="{StaticResource SurfaceToolbarButtonStyle}"
+                            Command="{Binding OpenPaletteCommand}"
+                            AutomationProperties.Name="Open card catalog">
+                        <AccessText Text="_Add Card" />
+                    </Button>
+                    <Button Style="{StaticResource SurfaceToolbarButtonStyle}"
+                            Command="{Binding RemoveSelectedCardsCommand}"
+                            Margin="12,0,0,0"
+                            AutomationProperties.Name="Remove selected cards">
+                        <AccessText Text="_Remove Selected" />
+                    </Button>
+                </StackPanel>
+            </Border>
+
+            <Rectangle Visibility="{Binding IsPaletteOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
+                       Fill="{StaticResource OverlayBackdropBrush}"
+                       Panel.ZIndex="19"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       MouseLeftButtonDown="OnPaletteBackdropClicked" />
+
+            <Border Visibility="{Binding IsPaletteOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    CornerRadius="20"
+                    Background="{StaticResource OverlaySurfaceBrush}"
+                    BorderThickness="1"
+                    BorderBrush="{StaticResource OverlayBorderBrush}"
+                    Padding="24"
+                    Panel.ZIndex="20"
+                    Width="520"
+                    MaxHeight="560"
+                    FocusManager.IsFocusScope="True"
+                    FocusManager.FocusedElement="{Binding ElementName=PaletteListBox}"
+                    KeyboardNavigation.TabNavigation="Cycle"
+                    KeyboardNavigation.ControlTabNavigation="Cycle"
+                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                    AutomationProperties.Name="Card catalog overlay">
+                <Border.InputBindings>
+                    <KeyBinding Key="Escape" Command="{Binding ClosePaletteCommand}" />
+                    <KeyBinding Key="Enter" Command="{Binding CreateCardCommand}" />
+                </Border.InputBindings>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="PaletteHeading"
+                                   Text="Card Catalog"
+                                   FontSize="20"
+                                   FontWeight="Bold"
+                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   AutomationProperties.HeadingLevel="Level2" />
+                        <Button Grid.Column="1"
+                                Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding ClosePaletteCommand}"
+                                Margin="12,0,0,0"
+                                AutomationProperties.Name="Close card catalog">
+                            <AccessText Text="_Close" />
+                        </Button>
+                    </Grid>
+
+                    <ListBox x:Name="PaletteListBox"
+                             Grid.Row="1"
+                             ItemsSource="{Binding Palette}"
+                             SelectedItem="{Binding SelectedPreset}"
+                             Margin="0,18"
+                             BorderThickness="1"
+                             BorderBrush="{StaticResource OverlayListItemBorderBrush}"
+                             Background="{StaticResource OverlayListBackgroundBrush}"
+                             Foreground="{StaticResource PrimaryTextBrush}"
+                             SelectionMode="Single"
+                             HorizontalContentAlignment="Stretch"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             KeyboardNavigation.TabNavigation="Cycle"
+                             KeyboardNavigation.DirectionalNavigation="Cycle"
+                             AutomationProperties.Name="Card catalog presets"
+                             ItemContainerStyle="{StaticResource PaletteListBoxItemStyle}">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:CardPresetViewModel}">
+                                <Border>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding DisplayName}"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="16"
+                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                   TextWrapping="Wrap" />
+                                        <TextBlock Text="{Binding Description}"
+                                                   Foreground="{StaticResource NeutralTextBrush}"
+                                                   TextWrapping="Wrap"
+                                                   Margin="0,4,0,0" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <StackPanel Grid.Row="2"
+                                Orientation="Horizontal"
+                                HorizontalAlignment="Right">
+                        <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                                Command="{Binding CreateCardCommand}"
+                                Margin="0,0,12,0"
+                                IsDefault="True"
+                                AutomationProperties.Name="Add selected card to surface">
+                            <AccessText Text="_Add Card" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding ClosePaletteCommand}"
+                                AutomationProperties.Name="Cancel card addition">
+                            <AccessText Text="_Cancel" />
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <Rectangle Visibility="{Binding IsEditorOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
+                       Fill="{StaticResource OverlayBackdropBrush}"
+                       Panel.ZIndex="23"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       MouseLeftButtonDown="OnEditorBackdropClicked" />
+
+            <Border x:Name="EditorOverlayRoot"
+                    Visibility="{Binding IsEditorOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    CornerRadius="20"
+                    Background="{StaticResource OverlaySurfaceBrush}"
+                    BorderThickness="1"
+                    BorderBrush="{StaticResource OverlayBorderBrush}"
+                    Padding="24"
+                    Panel.ZIndex="24"
+                    Width="560"
+                    MaxHeight="620"
+                    FocusManager.IsFocusScope="True"
+                    KeyboardNavigation.TabNavigation="Cycle"
+                    KeyboardNavigation.ControlTabNavigation="Cycle"
+                    KeyboardNavigation.DirectionalNavigation="Cycle"
+                    AutomationProperties.Name="Card editor overlay">
+                <Border.InputBindings>
+                    <KeyBinding Key="Escape" Command="{Binding CloseEditorCommand}" />
+                </Border.InputBindings>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{Binding ActiveEditor.Title}"
+                                   FontSize="20"
+                                   FontWeight="Bold"
+                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   AutomationProperties.HeadingLevel="Level2" />
+                        <Button Grid.Column="1"
+                                Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding CloseEditorCommand}"
+                                Margin="12,0,0,0"
+                                AutomationProperties.Name="Close editor overlay">
+                            <AccessText Text="_Close" />
+                        </Button>
+                    </Grid>
+
+                    <TextBlock Grid.Row="1"
+                               Text="{Binding ActiveEditor.Subtitle}"
+                               Foreground="{StaticResource NeutralTextBrush}"
+                               Margin="0,12,0,0">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ActiveEditor.HasSubtitle}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <ContentPresenter x:Name="EditorContentPresenter"
+                                      Grid.Row="2"
+                                      Margin="0,20,0,24"
+                                      Content="{Binding ActiveEditor}" />
+
+                    <StackPanel Grid.Row="3"
+                                Orientation="Horizontal"
+                                HorizontalAlignment="Right">
+                        <Button Style="{StaticResource PalettePrimaryButtonStyle}"
+                                Command="{Binding ActiveEditor.SaveCommand}"
+                                Margin="0,0,12,0"
+                                AutomationProperties.Name="Save editor changes">
+                            <AccessText Text="_Save Changes" />
+                        </Button>
+                        <Button Style="{StaticResource PaletteSecondaryButtonStyle}"
+                                Command="{Binding ActiveEditor.CancelCommand}"
+                                AutomationProperties.Name="Cancel editor changes">
+                            <AccessText Text="_Cancel" />
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <StackPanel HorizontalAlignment="Center"
+                        VerticalAlignment="Center">
+                <StackPanel.Style>
+                    <Style TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasCards}" Value="False">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Style>
+                <TextBlock Text="{Binding EmptyMessage}"
+                           Foreground="{StaticResource NeutralTextBrush}"
+                           FontSize="16"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           MaxWidth="520" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/CardSurfaceView.xaml.cs
@@ -1,0 +1,166 @@
+using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Views;
+
+public partial class CardSurfaceView : UserControl
+{
+    private CardSurfaceViewModel? _viewModel;
+
+    public CardSurfaceView()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        Focus();
+        UpdateViewport();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _viewModel = null;
+        }
+    }
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        _viewModel = e.NewValue as CardSurfaceViewModel;
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        }
+
+        UpdateViewport();
+    }
+
+    private void OnSurfaceLoaded(object sender, RoutedEventArgs e)
+    {
+        UpdateViewport();
+    }
+
+    private void OnSurfaceScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        UpdateViewport();
+    }
+
+    private void OnSurfaceSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateViewport();
+    }
+
+    private void UpdateViewport()
+    {
+        if (DataContext is not CardSurfaceViewModel viewModel)
+        {
+            return;
+        }
+
+        if (SurfaceScrollViewer is null)
+        {
+            return;
+        }
+
+        var viewport = new Rect(
+            SurfaceScrollViewer.HorizontalOffset,
+            SurfaceScrollViewer.VerticalOffset,
+            SurfaceScrollViewer.ViewportWidth,
+            SurfaceScrollViewer.ViewportHeight);
+
+        viewModel.UpdateViewport(viewport);
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (string.Equals(e.PropertyName, nameof(CardSurfaceViewModel.IsPaletteOpen), StringComparison.Ordinal))
+        {
+            if (_viewModel?.IsPaletteOpen == true)
+            {
+                Dispatcher.BeginInvoke(DispatcherPriority.Input, new Action(() =>
+                {
+                    if (PaletteListBox is null)
+                    {
+                        return;
+                    }
+
+                    if (PaletteListBox.SelectedIndex < 0 && PaletteListBox.Items.Count > 0)
+                    {
+                        PaletteListBox.SelectedIndex = 0;
+                    }
+
+                    PaletteListBox.Focus();
+                    if (PaletteListBox.SelectedItem is not null)
+                    {
+                        PaletteListBox.ScrollIntoView(PaletteListBox.SelectedItem);
+                    }
+                }));
+            }
+            else
+            {
+                Dispatcher.BeginInvoke(DispatcherPriority.Input, new Action(() =>
+                {
+                    SurfaceScrollViewer?.Focus();
+                }));
+            }
+
+            return;
+        }
+
+        if (string.Equals(e.PropertyName, nameof(CardSurfaceViewModel.IsEditorOpen), StringComparison.Ordinal))
+        {
+            if (_viewModel?.IsEditorOpen == true)
+            {
+                Dispatcher.BeginInvoke(DispatcherPriority.Input, new Action(() =>
+                {
+                    if (EditorOverlayRoot is not null)
+                    {
+                        EditorOverlayRoot.Focus();
+                        EditorOverlayRoot.MoveFocus(new TraversalRequest(FocusNavigationDirection.First));
+                    }
+                }));
+            }
+            else
+            {
+                Dispatcher.BeginInvoke(DispatcherPriority.Input, new Action(() =>
+                {
+                    SurfaceScrollViewer?.Focus();
+                }));
+            }
+        }
+    }
+
+    private void OnPaletteBackdropClicked(object sender, MouseButtonEventArgs e)
+    {
+        if (_viewModel?.ClosePaletteCommand is ICommand command && command.CanExecute(null))
+        {
+            command.Execute(null);
+            e.Handled = true;
+        }
+    }
+
+    private void OnEditorBackdropClicked(object sender, MouseButtonEventArgs e)
+    {
+        if (_viewModel?.CloseEditorCommand is ICommand command && command.CanExecute(null))
+        {
+            command.Execute(null);
+            e.Handled = true;
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/Views/ClubVisionExpectationBoardView.xaml
+++ b/WPF/FMUI.Wpf/Views/ClubVisionExpectationBoardView.xaml
@@ -1,0 +1,180 @@
+<UserControl x:Class="FMUI.Wpf.Views.ClubVisionExpectationBoardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:views="clr-namespace:FMUI.Wpf.Views"
+             mc:Ignorable="d"
+             d:DesignHeight="320"
+             d:DesignWidth="420">
+    <UserControl.Resources>
+        <views:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+        <views:AccentToBrushConverter x:Key="AccentToBrushConverter" />
+        <views:InverseBooleanConverter x:Key="InverseBooleanConverter" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+        <Style x:Key="CardFilterButtonStyle" TargetType="Button">
+            <Setter Property="Padding" Value="12,6" />
+            <Setter Property="Margin" Value="0,0,8,8" />
+            <Setter Property="Background" Value="#152032" />
+            <Setter Property="BorderBrush" Value="#233246" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Chrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="14">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Chrome" Property="Opacity" Value="0.55" />
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Chrome" Property="BorderBrush" Value="#2EC4B6" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Chrome" Property="Background" Value="#1E2C3F" />
+                                <Setter TargetName="Chrome" Property="BorderBrush" Value="#3AA0FF" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <ItemsControl Grid.Row="0"
+                      ItemsSource="{Binding StatusFilters}"
+                      Margin="0,0,0,16">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel IsItemsHost="True" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Button Content="{Binding Label}"
+                            Command="{Binding DataContext.SelectStatusCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                            CommandParameter="{Binding}"
+                            Style="{StaticResource CardFilterButtonStyle}"
+                            IsEnabled="{Binding IsSelected, Converter={StaticResource InverseBooleanConverter}}" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <TextBlock Grid.Row="1"
+                   Text="{Binding Summary}"
+                   Style="{StaticResource CardListSecondaryTextStyle}"
+                   Margin="0,0,0,16" />
+
+        <Border Grid.Row="2"
+                Background="#141F2E"
+                BorderBrush="#233246"
+                BorderThickness="1"
+                CornerRadius="12">
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Padding="16">
+                <ItemsControl ItemsSource="{Binding Objectives}">
+                    <ItemsControl.Resources>
+                        <Style TargetType="ContentPresenter">
+                            <Setter Property="Margin" Value="0,0,0,12" />
+                        </Style>
+                    </ItemsControl.Resources>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="#182436"
+                                    BorderBrush="#233246"
+                                    BorderThickness="1"
+                                    CornerRadius="10"
+                                    Padding="12"
+                                    Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="2*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <StackPanel Orientation="Horizontal" Grid.ColumnSpan="3">
+                                        <TextBlock Text="{Binding Objective}"
+                                                   Style="{StaticResource CardListPrimaryTextStyle}"
+                                                   FontSize="15"
+                                                   FontWeight="SemiBold" />
+                                        <Border Background="{Binding Accent, Converter={StaticResource AccentToBrushConverter}}"
+                                                Visibility="{Binding Accent, Converter={StaticResource NullToVisibilityConverter}}"
+                                                Margin="12,0,0,0"
+                                                CornerRadius="8"
+                                                Padding="8,2">
+                                            <TextBlock Text="{Binding Priority}"
+                                                       Style="{StaticResource CardListPrimaryTextStyle}"
+                                                       FontSize="12" />
+                                        </Border>
+                                    </StackPanel>
+
+                                    <TextBlock Grid.Row="1"
+                                               Grid.Column="0"
+                                               Text="{Binding Competition}"
+                                               Style="{StaticResource CardListSecondaryTextStyle}"
+                                               Margin="0,6,12,0" />
+
+                                    <StackPanel Grid.Row="1"
+                                                Grid.Column="1"
+                                                Orientation="Horizontal"
+                                                Margin="0,6,12,0">
+                                        <TextBlock Text="Deadline:"
+                                                   Style="{StaticResource CardListSecondaryTextStyle}" />
+                                        <TextBlock Text="{Binding Deadline}"
+                                                   Style="{StaticResource CardListPrimaryTextStyle}"
+                                                   Margin="6,0,0,0" />
+                                    </StackPanel>
+
+                                    <Border Grid.Row="1"
+                                            Grid.Column="2"
+                                            Background="#1F2C3D"
+                                            BorderBrush="#2EC4B6"
+                                            BorderThickness="1"
+                                            CornerRadius="8"
+                                            Padding="10,4"
+                                            HorizontalAlignment="Right">
+                                        <TextBlock Text="{Binding Status}"
+                                                   Style="{StaticResource CardStatusTextStyle}" />
+                                    </Border>
+
+                                    <TextBlock Grid.Row="2"
+                                               Grid.ColumnSpan="3"
+                                               Text="{Binding Notes}"
+                                               Style="{StaticResource CardListSecondaryTextStyle}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,8,0,0"
+                                               Visibility="{Binding Notes, Converter={StaticResource NullToVisibilityConverter}}" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/ClubVisionExpectationBoardView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/ClubVisionExpectationBoardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class ClubVisionExpectationBoardView : UserControl
+{
+    public ClubVisionExpectationBoardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/ClubVisionRoadmapView.xaml
+++ b/WPF/FMUI.Wpf/Views/ClubVisionRoadmapView.xaml
@@ -1,0 +1,157 @@
+<UserControl x:Class="FMUI.Wpf.Views.ClubVisionRoadmapView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:views="clr-namespace:FMUI.Wpf.Views"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+    <UserControl.Resources>
+        <views:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+        <views:AccentToBrushConverter x:Key="AccentToBrushConverter" />
+        <views:InverseBooleanConverter x:Key="InverseBooleanConverter" />
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+        <Style x:Key="CardFilterButtonStyle" TargetType="Button">
+            <Setter Property="Padding" Value="12,6" />
+            <Setter Property="Margin" Value="0,0,8,8" />
+            <Setter Property="Background" Value="#152032" />
+            <Setter Property="BorderBrush" Value="#233246" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Chrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="14">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Chrome" Property="Opacity" Value="0.55" />
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Chrome" Property="BorderBrush" Value="#2EC4B6" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="Chrome" Property="Background" Value="#1E2C3F" />
+                                <Setter TargetName="Chrome" Property="BorderBrush" Value="#3AA0FF" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <ItemsControl Grid.Row="0"
+                      ItemsSource="{Binding StatusFilters}"
+                      Margin="0,0,0,16">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <WrapPanel IsItemsHost="True" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Button Content="{Binding Label}"
+                            Command="{Binding DataContext.SelectStatusCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                            CommandParameter="{Binding}"
+                            Style="{StaticResource CardFilterButtonStyle}"
+                            IsEnabled="{Binding IsSelected, Converter={StaticResource InverseBooleanConverter}}" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <TextBlock Grid.Row="1"
+                   Text="{Binding Summary}"
+                   Style="{StaticResource CardListSecondaryTextStyle}"
+                   Margin="0,0,0,16" />
+
+        <ScrollViewer Grid.Row="2"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled">
+            <ItemsControl ItemsSource="{Binding Phases}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="Margin" Value="0,0,0,12" />
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="#142031"
+                                BorderBrush="#233246"
+                                BorderThickness="1"
+                                CornerRadius="12"
+                                Padding="16"
+                                Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+
+                                <StackPanel Orientation="Horizontal"
+                                            Grid.Row="0"
+                                            Margin="0,0,0,8">
+                                    <TextBlock Text="{Binding Title}"
+                                               Style="{StaticResource CardListPrimaryTextStyle}"
+                                               FontSize="16"
+                                               FontWeight="SemiBold" />
+                                    <Border Background="{Binding Accent, Converter={StaticResource AccentToBrushConverter}}"
+                                            Visibility="{Binding Accent, Converter={StaticResource NullToVisibilityConverter}}"
+                                            CornerRadius="8"
+                                            Margin="12,0,0,0"
+                                            Padding="8,2">
+                                        <TextBlock Text="{Binding Pill}"
+                                                   Style="{StaticResource CardListPrimaryTextStyle}"
+                                                   FontSize="12" />
+                                    </Border>
+                                </StackPanel>
+
+                                <TextBlock Grid.Row="1"
+                                           Text="{Binding Timeline}"
+                                           Style="{StaticResource CardListSecondaryTextStyle}"
+                                           Margin="0,0,0,8" />
+
+                                <TextBlock Grid.Row="2"
+                                           Text="{Binding Description}"
+                                           Style="{StaticResource CardListSecondaryTextStyle}"
+                                           TextWrapping="Wrap"
+                                           Visibility="{Binding Description, Converter={StaticResource NullToVisibilityConverter}}" />
+
+                                <TextBlock Grid.Row="3"
+                                           Margin="0,8,0,0"
+                                           Text="{Binding Status}"
+                                           Style="{StaticResource CardStatusTextStyle}"
+                                           Foreground="{Binding Accent, Converter={StaticResource AccentToBrushConverter}, FallbackValue={StaticResource AccentPrimaryBrush}}" />
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/ClubVisionRoadmapView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/ClubVisionRoadmapView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class ClubVisionRoadmapView : UserControl
+{
+    public ClubVisionRoadmapView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/FinanceBudgetAllocatorView.xaml
+++ b/WPF/FMUI.Wpf/Views/FinanceBudgetAllocatorView.xaml
@@ -1,0 +1,129 @@
+<UserControl x:Class="FMUI.Wpf.Views.FinanceBudgetAllocatorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:local="clr-namespace:FMUI.Wpf.Views"
+             mc:Ignorable="d"
+             d:DesignHeight="320"
+             d:DesignWidth="520">
+    <UserControl.Resources>
+        <local:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal"
+                    Margin="0,0,0,12">
+            <TextBlock Text="{Binding SummaryText}"
+                       Style="{DynamicResource CardListSecondaryTextStyle}" />
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Lines}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type vm:FinanceBudgetAllocationLineViewModel}">
+                        <Border Margin="0,6"
+                                Padding="14"
+                                Background="#131D2C"
+                                BorderBrush="#1E2A3D"
+                                BorderThickness="1"
+                                CornerRadius="12">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="140" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Row="0"
+                                           Grid.Column="0"
+                                           Text="{Binding Label}"
+                                           FontSize="16"
+                                           FontWeight="SemiBold" />
+
+                                <TextBlock Grid.Row="0"
+                                           Grid.Column="1"
+                                           Text="{Binding DisplayValue}"
+                                           Style="{DynamicResource CardListPrimaryTextStyle}"
+                                           HorizontalAlignment="Right" />
+
+                                <TextBlock Grid.Row="1"
+                                           Grid.ColumnSpan="2"
+                                           Text="{Binding Description}"
+                                           Style="{DynamicResource CardSubtitleTextStyle}"
+                                           Margin="0,4,0,12">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Description, Converter={StaticResource NullToVisibilityConverter}}" Value="Visible">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+
+                                <Slider Grid.Row="2"
+                                        Grid.ColumnSpan="2"
+                                        Minimum="{Binding Minimum}"
+                                        Maximum="{Binding Maximum}"
+                                        Value="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                        TickFrequency="{Binding TickFrequency}"
+                                        IsSnapToTickEnabled="{Binding UseTicks}"
+                                        AutomationProperties.Name="Finance budget allocation slider" />
+
+                                <TextBlock Grid.Row="2"
+                                           Grid.Column="1"
+                                           Text="{Binding RangeDisplay}"
+                                           Style="{DynamicResource CardSubtitleTextStyle}"
+                                           HorizontalAlignment="Right"
+                                           Margin="0,8,0,0" />
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    Margin="0,16,0,0"
+                    HorizontalAlignment="Left">
+            <Button Content="{Binding CommitLabel}"
+                    Command="{Binding SaveCommand}"
+                    IsEnabled="{Binding CanSave}"
+                    Style="{StaticResource CardHeaderButtonStyle}" />
+            <Button Content="{Binding ResetLabel}"
+                    Command="{Binding ResetCommand}"
+                    IsEnabled="{Binding IsDirty}"
+                    Margin="12,0,0,0"
+                    Style="{StaticResource CardHeaderSecondaryButtonStyle}" />
+            <TextBlock Text="{Binding StatusMessage}"
+                       Foreground="{StaticResource NeutralTextBrush}"
+                       Margin="16,4,0,0">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasStatusMessage}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/FinanceBudgetAllocatorView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/FinanceBudgetAllocatorView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class FinanceBudgetAllocatorView : UserControl
+{
+    public FinanceBudgetAllocatorView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/FinanceCashflowView.xaml
+++ b/WPF/FMUI.Wpf/Views/FinanceCashflowView.xaml
@@ -1,0 +1,267 @@
+<UserControl x:Class="FMUI.Wpf.Views.FinanceCashflowView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:local="clr-namespace:FMUI.Wpf.Views"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="560">
+    <UserControl.Resources>
+        <local:AccentToBrushConverter x:Key="AccentToBrushConverter" />
+        <local:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal"
+                    Margin="0,0,0,12">
+            <TextBlock Text="{Binding SummaryLabel}"
+                       Style="{DynamicResource CardListSecondaryTextStyle}" />
+            <TextBlock Text="{Binding SummaryValue}"
+                       Margin="12,0,0,0"
+                       Style="{DynamicResource CardMetricValueTextStyle}" />
+        </StackPanel>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="240" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Margin="0,0,16,0"
+                    Background="{DynamicResource OverlayListBackgroundBrush}"
+                    BorderBrush="{DynamicResource OverlayListItemBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="12">
+                <ListBox ItemsSource="{Binding Categories}"
+                         SelectedItem="{Binding SelectedCategory, Mode=TwoWay}"
+                         BorderThickness="0"
+                         Background="Transparent"
+                         Foreground="{DynamicResource PrimaryTextBrush}">
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel />
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="ListBoxItem">
+                            <Setter Property="Padding" Value="8" />
+                            <Setter Property="Margin" Value="0,4" />
+                            <Setter Property="Background" Value="Transparent" />
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="VerticalContentAlignment" Value="Center" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="ListBoxItem">
+                                        <Border x:Name="Border"
+                                                Background="{TemplateBinding Background}"
+                                                CornerRadius="10">
+                                            <ContentPresenter />
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Border"
+                                                        Property="Background"
+                                                        Value="{DynamicResource OverlayListItemHoverBrush}" />
+                                            </Trigger>
+                                            <Trigger Property="IsSelected" Value="True">
+                                                <Setter TargetName="Border"
+                                                        Property="Background"
+                                                        Value="{DynamicResource OverlayListItemSelectedBrush}" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:FinanceCashflowCategoryViewModel}">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Name}"
+                                               FontWeight="SemiBold"
+                                               FontSize="16"
+                                               TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Text="{Binding Description}"
+                                               Style="{DynamicResource CardSubtitleTextStyle}"
+                                               TextTrimming="CharacterEllipsis">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Description, Converter={StaticResource NullToVisibilityConverter}}" Value="Visible">
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                                <Border Grid.Column="1"
+                                        Background="{Binding Accent, Converter={StaticResource AccentToBrushConverter}}"
+                                        CornerRadius="8"
+                                        Padding="10,4"
+                                        Margin="12,0,0,0"
+                                        VerticalAlignment="Center">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Accent, Converter={StaticResource NullToVisibilityConverter}}" Value="Visible">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <TextBlock Text="{Binding DisplayAmount}"
+                                               Foreground="White"
+                                               FontSize="13"
+                                               FontWeight="SemiBold" />
+                                </Border>
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding DisplayAmount}"
+                                           Style="{DynamicResource CardListPrimaryTextStyle}"
+                                           VerticalAlignment="Center">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Accent, Converter={StaticResource NullToVisibilityConverter}}" Value="Visible">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Grid>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+
+            <Border Grid.Column="1"
+                    Background="{DynamicResource OverlayListBackgroundBrush}"
+                    BorderBrush="{DynamicResource OverlayListItemBorderBrush}"
+                    BorderThickness="1"
+                    CornerRadius="12"
+                    Padding="16">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Text="{Binding SelectedCategoryName}"
+                               Style="{DynamicResource CardMetricValueTextStyle}" />
+
+                    <TextBlock Grid.Row="1"
+                               Text="{Binding SelectedCategoryDescription}"
+                               Style="{DynamicResource CardSubtitleTextStyle}"
+                               Margin="0,6,0,10"
+                               TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasSelectedCategoryDescription}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <ScrollViewer Grid.Row="2"
+                                  VerticalScrollBarVisibility="Auto">
+                        <ItemsControl ItemsSource="{Binding Items}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type vm:FinanceCashflowItemViewModel}">
+                                    <Border Margin="0,4"
+                                            Padding="12"
+                                            Background="#151F31"
+                                            CornerRadius="10"
+                                            BorderBrush="#213049"
+                                            BorderThickness="1">
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Name}"
+                                                           FontWeight="SemiBold"
+                                                           TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Text="{Binding Detail}"
+                                                           Style="{DynamicResource CardSubtitleTextStyle}"
+                                                           TextWrapping="Wrap">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding Detail, Converter={StaticResource NullToVisibilityConverter}}" Value="Visible">
+                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </StackPanel>
+                                            <Border Grid.Column="1"
+                                                    Background="{Binding Accent, Converter={StaticResource AccentToBrushConverter}}"
+                                                    CornerRadius="8"
+                                                    Padding="10,4"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Center">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Accent, Converter={StaticResource NullToVisibilityConverter}}" Value="Visible">
+                                                                <Setter Property="Visibility" Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                                <TextBlock Text="{Binding DisplayAmount}"
+                                                           Foreground="White"
+                                                           FontWeight="SemiBold" />
+                                            </Border>
+                                            <TextBlock Grid.Column="1"
+                                                       Text="{Binding DisplayAmount}"
+                                                       Style="{DynamicResource CardListPrimaryTextStyle}"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Accent, Converter={StaticResource NullToVisibilityConverter}}" Value="Visible">
+                                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/FinanceCashflowView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/FinanceCashflowView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class FinanceCashflowView : UserControl
+{
+    public FinanceCashflowView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/FinanceScenarioBoardView.xaml
+++ b/WPF/FMUI.Wpf/Views/FinanceScenarioBoardView.xaml
@@ -1,0 +1,105 @@
+<UserControl x:Class="FMUI.Wpf.Views.FinanceScenarioBoardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:local="clr-namespace:FMUI.Wpf.Views"
+             mc:Ignorable="d"
+             d:DesignHeight="320"
+             d:DesignWidth="520">
+    <UserControl.Resources>
+        <local:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal"
+                    Margin="0,0,0,12">
+            <TextBlock Text="{Binding SummaryLabel}"
+                       Style="{DynamicResource CardListSecondaryTextStyle}" />
+            <TextBlock Text="{Binding SummaryValue}"
+                       Margin="12,0,0,0"
+                       Style="{DynamicResource CardListPrimaryTextStyle}" />
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
+            <ItemsControl ItemsSource="{Binding Options}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type vm:FinanceScenarioOptionViewModel}">
+                        <Border Margin="0,6"
+                                Padding="14"
+                                Background="#141F2E"
+                                BorderBrush="#1E2B3F"
+                                BorderThickness="1"
+                                CornerRadius="12">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Title}"
+                                               FontSize="16"
+                                               FontWeight="SemiBold"
+                                               TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Text="{Binding Detail}"
+                                               Style="{DynamicResource CardSubtitleTextStyle}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,4,0,0"
+                                               Visibility="{Binding Detail, Converter={StaticResource NullToVisibilityConverter}}" />
+                                </StackPanel>
+                                <StackPanel Grid.Column="1"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding DisplayImpact}"
+                                               Style="{DynamicResource CardListPrimaryTextStyle}"
+                                               HorizontalAlignment="Right" />
+                                    <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                              Margin="0,6,0,0"
+                                              Content="Activate"
+                                              HorizontalAlignment="Right" />
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    Margin="0,16,0,0"
+                    HorizontalAlignment="Left">
+            <Button Content="{Binding CommitLabel}"
+                    Command="{Binding SaveCommand}"
+                    IsEnabled="{Binding CanSave}"
+                    Style="{StaticResource CardHeaderButtonStyle}" />
+            <Button Content="{Binding ResetLabel}"
+                    Command="{Binding ResetCommand}"
+                    IsEnabled="{Binding IsDirty}"
+                    Margin="12,0,0,0"
+                    Style="{StaticResource CardHeaderSecondaryButtonStyle}" />
+            <TextBlock Text="{Binding StatusMessage}"
+                       Foreground="{StaticResource NeutralTextBrush}"
+                       Margin="16,4,0,0">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasStatusMessage}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/FinanceScenarioBoardView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/FinanceScenarioBoardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class FinanceScenarioBoardView : UserControl
+{
+    public FinanceScenarioBoardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/FixtureCalendarView.xaml
+++ b/WPF/FMUI.Wpf/Views/FixtureCalendarView.xaml
@@ -1,0 +1,366 @@
+<UserControl x:Class="FMUI.Wpf.Views.FixtureCalendarView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:local="clr-namespace:FMUI.Wpf.Views"
+             Focusable="False">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <local:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+
+        <Style x:Key="FilterToggleButtonStyle" TargetType="ToggleButton">
+            <Setter Property="Background" Value="#1B2534" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+            <Setter Property="BorderBrush" Value="#2E394B" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="12,6" />
+            <Setter Property="Margin" Value="0,0,8,0" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="12"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsChecked" Value="True">
+                    <Setter Property="Background" Value="#2EC4B6" />
+                    <Setter Property="Foreground" Value="#0D131C" />
+                    <Setter Property="BorderBrush" Value="#2EC4B6" />
+                </Trigger>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="BorderBrush" Value="#2EC4B6" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="FixtureTileStyle" TargetType="Border">
+            <Setter Property="Background" Value="#1B2534" />
+            <Setter Property="BorderBrush" Value="#273346" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="14" />
+            <Setter Property="Padding" Value="14" />
+            <Setter Property="Margin" Value="0,10,0,0" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+            <Setter Property="Opacity" Value="0.9" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#233042" />
+                    <Setter Property="BorderBrush" Value="#2EC4B6" />
+                    <Setter Property="Opacity" Value="1" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="DetailOverlayBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="#111824" />
+            <Setter Property="CornerRadius" Value="18" />
+            <Setter Property="Padding" Value="24" />
+            <Setter Property="MaxWidth" Value="520" />
+            <Setter Property="Effect">
+                <Setter.Value>
+                    <DropShadowEffect BlurRadius="28" ShadowDepth="0" Opacity="0.45" Color="#000000" />
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <ItemsControl ItemsSource="{Binding Filters}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:FixtureCalendarFilterViewModel}">
+                            <ToggleButton Style="{StaticResource FilterToggleButtonStyle}"
+                                          Content="{Binding DisplayName}"
+                                          IsChecked="{Binding IsActive, Mode=OneWay}"
+                                          Command="{Binding ToggleCommand}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <ItemsControl Margin="0,20,0,0"
+                              ItemsSource="{Binding Weeks}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:FixtureCalendarWeekViewModel}">
+                            <StackPanel Margin="0,0,0,24">
+                                <TextBlock Text="{Binding Label}"
+                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                           FontSize="16"
+                                           FontWeight="SemiBold" />
+
+                                <ItemsControl Margin="0,12,0,0"
+                                              ItemsSource="{Binding Days}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <UniformGrid Columns="7" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="{x:Type vm:FixtureCalendarDayViewModel}">
+                                            <StackPanel Margin="0,0,16,0">
+                                                <Border Background="#1F2735"
+                                                        BorderBrush="#2E394B"
+                                                        BorderThickness="1"
+                                                        CornerRadius="12"
+                                                        Padding="12">
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Label}"
+                                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                                   FontWeight="SemiBold"
+                                                                   FontSize="14" />
+                                                        <TextBlock Text="{Binding Date}"
+                                                                   Foreground="{StaticResource NeutralTextBrush}"
+                                                                   FontSize="11" />
+                                                    </StackPanel>
+                                                </Border>
+
+                                                <ItemsControl ItemsSource="{Binding Matches}">
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate DataType="{x:Type vm:FixtureCalendarMatchViewModel}">
+                                                            <Border Style="{StaticResource FixtureTileStyle}"
+                                                                    Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                                <Button Command="{Binding ShowDetailCommand}"
+                                                                        Background="Transparent"
+                                                                        BorderThickness="0"
+                                                                        HorizontalAlignment="Stretch"
+                                                                        VerticalAlignment="Stretch">
+                                                                    <Button.Template>
+                                                                        <ControlTemplate TargetType="Button">
+                                                                            <ContentPresenter />
+                                                                        </ControlTemplate>
+                                                                    </Button.Template>
+                                                                    <Grid>
+                                                                        <Grid.ColumnDefinitions>
+                                                                            <ColumnDefinition Width="Auto" />
+                                                                            <ColumnDefinition Width="*" />
+                                                                        </Grid.ColumnDefinitions>
+                                                                        <StackPanel Orientation="Vertical">
+                                                                            <TextBlock Text="{Binding KickOff}"
+                                                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                                                       FontSize="12"
+                                                                                       FontWeight="SemiBold" />
+                                                                            <TextBlock Text="{Binding Venue}"
+                                                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                                                       FontSize="11"
+                                                                                       Margin="0,2,0,0" />
+                                                                        </StackPanel>
+                                                                        <StackPanel Grid.Column="1"
+                                                                                    Margin="12,0,0,0">
+                                                                            <TextBlock Text="{Binding Opponent}"
+                                                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                                                       FontSize="14"
+                                                                                       FontWeight="SemiBold" />
+                                                                            <TextBlock Text="{Binding Competition}"
+                                                                                       Foreground="{Binding CompetitionAccent, TargetNullValue={StaticResource AccentPrimaryBrush}, FallbackValue={StaticResource AccentPrimaryBrush}}"
+                                                                                       FontSize="12"
+                                                                                       Margin="0,2,0,0" />
+                                                                            <TextBlock Text="{Binding Status}"
+                                                                                       Foreground="{StaticResource AccentSecondaryBrush}"
+                                                                                       FontSize="11"
+                                                                                       Visibility="{Binding Status, Converter={StaticResource NullToVisibilityConverter}}" />
+                                                                        </StackPanel>
+                                                                    </Grid>
+                                                                </Button>
+                                                            </Border>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ScrollViewer>
+
+        <Grid Grid.RowSpan="2"
+              Background="#BF0B1729"
+              Visibility="{Binding IsDetailOpen, Converter={StaticResource BooleanToVisibilityConverter}}"
+              MouseDown="OnOverlayBackgroundMouseDown">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+            </Grid.RowDefinitions>
+
+            <Border Style="{StaticResource DetailOverlayBorderStyle}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    DataContext="{Binding ActiveDetail}">
+                <Border.Style>
+                    <Style TargetType="Border" BasedOn="{StaticResource DetailOverlayBorderStyle}">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                        <StackPanel>
+                            <TextBlock Text="{Binding Opponent}"
+                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       FontSize="20"
+                                       FontWeight="Bold" />
+                            <TextBlock Text="{Binding Competition}"
+                                       Foreground="{StaticResource NeutralTextBrush}" />
+                        </StackPanel>
+                        <Button Content="Close"
+                                Margin="16,0,0,0"
+                                Command="{Binding CloseCommand}"
+                                Style="{StaticResource PaletteSecondaryButtonStyle}" />
+                    </StackPanel>
+
+                    <Grid Margin="0,0,0,18">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="Kick Off"
+                                   Foreground="{StaticResource NeutralTextBrush}" />
+                        <TextBlock Grid.Column="1"
+                                   Text="{Binding KickOff}"
+                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                        <TextBlock Grid.Row="1"
+                                   Text="Venue"
+                                   Foreground="{StaticResource NeutralTextBrush}" />
+                        <TextBlock Grid.Row="1"
+                                   Grid.Column="1"
+                                   Text="{Binding Venue}"
+                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                    </Grid>
+
+                    <TextBlock Text="Result"
+                               Foreground="{StaticResource NeutralTextBrush}"
+                               Visibility="{Binding Result, Converter={StaticResource NullToVisibilityConverter}}" />
+                    <TextBlock Text="{Binding Result}"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               FontWeight="SemiBold"
+                               Margin="0,4,0,16"
+                               Visibility="{Binding Result, Converter={StaticResource NullToVisibilityConverter}}" />
+
+                    <StackPanel Margin="0,0,0,16">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ElementName=KeyPeopleList, Path=HasItems}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                        <TextBlock Text="Key People"
+                                   Foreground="{StaticResource NeutralTextBrush}" />
+                        <ItemsControl x:Name="KeyPeopleList"
+                                      Margin="0,6,0,0"
+                                      ItemsSource="{Binding KeyPeople}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type vm:CardListItemViewModel}">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Primary}" Foreground="{StaticResource PrimaryTextBrush}" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Secondary}" Foreground="{StaticResource NeutralTextBrush}" Visibility="{Binding Secondary, Converter={StaticResource NullToVisibilityConverter}}" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+
+                    <StackPanel Margin="0,0,0,16">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ElementName=PreparationList, Path=HasItems}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                        <TextBlock Text="Preparation Checklist"
+                                   Foreground="{StaticResource NeutralTextBrush}" />
+                        <ItemsControl x:Name="PreparationList"
+                                      Margin="0,6,0,0"
+                                      ItemsSource="{Binding Preparation}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type vm:CardListItemViewModel}">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Primary}" Foreground="{StaticResource PrimaryTextBrush}" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Secondary}" Foreground="{StaticResource NeutralTextBrush}" Visibility="{Binding Secondary, Converter={StaticResource NullToVisibilityConverter}}" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+
+                    <TextBlock Text="Preparation Note"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+                    <TextBox Text="{Binding PreparationNote, UpdateSourceTrigger=PropertyChanged}"
+                             Margin="0,6,0,14"
+                             MinHeight="64"
+                             TextWrapping="Wrap"
+                             Background="#1B2534"
+                             BorderBrush="#2E394B" />
+
+                    <TextBlock Text="Travel Note"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+                    <TextBox Text="{Binding TravelNote, UpdateSourceTrigger=PropertyChanged}"
+                             Margin="0,6,0,14"
+                             Background="#1B2534"
+                             BorderBrush="#2E394B" />
+
+                    <TextBlock Text="Status"
+                               Foreground="{StaticResource NeutralTextBrush}" />
+                    <TextBox Text="{Binding Status, UpdateSourceTrigger=PropertyChanged}"
+                             Margin="0,6,0,18"
+                             Background="#1B2534"
+                             BorderBrush="#2E394B" />
+
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Content="Save Changes"
+                                Command="{Binding SaveCommand}"
+                                Style="{StaticResource PalettePrimaryButtonStyle}"
+                                Margin="0,0,0,0" />
+                    </StackPanel>
+
+                    <TextBlock Text="{Binding StatusMessage}"
+                               Foreground="{StaticResource AccentSecondaryBrush}"
+                               Margin="0,12,0,0"
+                               Visibility="{Binding StatusMessage, Converter={StaticResource NullToVisibilityConverter}}" />
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/FixtureCalendarView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/FixtureCalendarView.xaml.cs
@@ -1,0 +1,45 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Views;
+
+public partial class FixtureCalendarView : UserControl
+{
+    public FixtureCalendarView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnOverlayBackgroundMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is not FixtureCalendarViewModel viewModel)
+        {
+            return;
+        }
+
+        if (FindAncestor<Border>(e.OriginalSource as DependencyObject) is { DataContext: FixtureMatchDetailViewModel })
+        {
+            return;
+        }
+
+        viewModel.CloseDetail();
+    }
+
+    private static T? FindAncestor<T>(DependencyObject? source) where T : DependencyObject
+    {
+        while (source is not null)
+        {
+            if (source is T typed)
+            {
+                return typed;
+            }
+
+            source = VisualTreeHelper.GetParent(source);
+        }
+
+        return null;
+    }
+}

--- a/WPF/FMUI.Wpf/Views/HexColorBrushConverter.cs
+++ b/WPF/FMUI.Wpf/Views/HexColorBrushConverter.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace FMUI.Wpf.Views;
+
+public sealed class HexColorBrushConverter : IValueConverter
+{
+    private static readonly ConcurrentDictionary<string, SolidColorBrush> Cache = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly SolidColorBrush TransparentBrush;
+
+    static HexColorBrushConverter()
+    {
+        TransparentBrush = new SolidColorBrush(Colors.Transparent);
+        TransparentBrush.Freeze();
+    }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string text && TryCreateBrush(text, out var brush))
+        {
+            return brush;
+        }
+
+        return TransparentBrush;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return Binding.DoNothing;
+    }
+
+    private static bool TryCreateBrush(string value, out SolidColorBrush brush)
+    {
+        var key = value?.Trim();
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            brush = TransparentBrush;
+            return false;
+        }
+
+        brush = Cache.GetOrAdd(key, static colour =>
+        {
+            try
+            {
+                var color = (Color)ColorConverter.ConvertFromString(colour)!;
+                var solidColorBrush = new SolidColorBrush(color);
+                solidColorBrush.Freeze();
+                return solidColorBrush;
+            }
+            catch
+            {
+                return TransparentBrush;
+            }
+        });
+
+        return !ReferenceEquals(brush, TransparentBrush);
+    }
+}

--- a/WPF/FMUI.Wpf/Views/InverseBooleanConverter.cs
+++ b/WPF/FMUI.Wpf/Views/InverseBooleanConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace FMUI.Wpf.Views;
+
+public sealed class InverseBooleanConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool flag)
+        {
+            return !flag;
+        }
+
+        return true;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException("InverseBooleanConverter does not support ConvertBack.");
+    }
+}

--- a/WPF/FMUI.Wpf/Views/MainWindow.xaml
+++ b/WPF/FMUI.Wpf/Views/MainWindow.xaml
@@ -1,0 +1,444 @@
+<Window x:Class="FMUI.Wpf.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+        xmlns:views="clr-namespace:FMUI.Wpf.Views"
+        xmlns:models="clr-namespace:FMUI.Wpf.Models"
+        mc:Ignorable="d"
+        Title="Football Manager UI"
+        Height="900"
+        Width="1600"
+        WindowStartupLocation="CenterScreen"
+        Background="{StaticResource SurfaceDarkBrush}">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <Storyboard x:Key="BadgePulseStoryboard" RepeatBehavior="Forever" AutoReverse="True">
+            <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                             From="1"
+                             To="0.7"
+                             Duration="0:0:1.4" />
+        </Storyboard>
+        <Style x:Key="NavigationBadgeStyle" TargetType="Border">
+            <Setter Property="Background" Value="{StaticResource NavigationBadgeInfoBrush}" />
+            <Setter Property="CornerRadius" Value="12" />
+            <Setter Property="Padding" Value="6,2" />
+            <Setter Property="Margin" Value="12,0,0,0" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="Visibility" Value="Collapsed" />
+            <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
+            <Setter Property="RenderTransform">
+                <Setter.Value>
+                    <ScaleTransform ScaleX="1" ScaleY="1" />
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding HasAlert}" Value="True">
+                    <Setter Property="Visibility" Value="Visible" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Severity}" Value="{x:Static models:NavigationIndicatorSeverity.Warning}">
+                    <Setter Property="Background" Value="{StaticResource NavigationBadgeWarningBrush}" />
+                    <DataTrigger.EnterActions>
+                        <BeginStoryboard x:Name="WarningPulse" Storyboard="{StaticResource BadgePulseStoryboard}" />
+                    </DataTrigger.EnterActions>
+                    <DataTrigger.ExitActions>
+                        <StopStoryboard BeginStoryboardName="WarningPulse" />
+                    </DataTrigger.ExitActions>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding Severity}" Value="{x:Static models:NavigationIndicatorSeverity.Critical}">
+                    <Setter Property="Background" Value="{StaticResource NavigationBadgeCriticalBrush}" />
+                    <Setter Property="RenderTransform">
+                        <Setter.Value>
+                            <ScaleTransform ScaleX="1.05" ScaleY="1.05" />
+                        </Setter.Value>
+                    </Setter>
+                    <DataTrigger.EnterActions>
+                        <BeginStoryboard x:Name="CriticalPulse" Storyboard="{StaticResource BadgePulseStoryboard}" />
+                    </DataTrigger.EnterActions>
+                    <DataTrigger.ExitActions>
+                        <StopStoryboard BeginStoryboardName="CriticalPulse" />
+                    </DataTrigger.ExitActions>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="NavigationTabAlertDotStyle" TargetType="Border">
+            <Setter Property="Width" Value="10" />
+            <Setter Property="Height" Value="10" />
+            <Setter Property="CornerRadius" Value="5" />
+            <Setter Property="Background" Value="{StaticResource NavigationBadgeInfoBrush}" />
+            <Setter Property="HorizontalAlignment" Value="Right" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Margin" Value="0,-6,-6,0" />
+            <Setter Property="Visibility" Value="Collapsed" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding HasAlerts}" Value="True">
+                    <Setter Property="Visibility" Value="Visible" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding HighestSeverity}" Value="{x:Static models:NavigationIndicatorSeverity.Warning}">
+                    <Setter Property="Background" Value="{StaticResource NavigationBadgeWarningBrush}" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding HighestSeverity}" Value="{x:Static models:NavigationIndicatorSeverity.Critical}">
+                    <Setter Property="Background" Value="{StaticResource NavigationBadgeCriticalBrush}" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="ResponsiveHeaderGridStyle" TargetType="Grid">
+            <Setter Property="Margin" Value="32,28,32,16" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsCompactHeader}" Value="True">
+                    <DataTrigger.EnterActions>
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <ThicknessAnimation Storyboard.TargetProperty="Margin"
+                                                    To="24,16,24,12"
+                                                    Duration="0:0:0.25"
+                                                    FillBehavior="HoldEnd" />
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </DataTrigger.EnterActions>
+                    <DataTrigger.ExitActions>
+                        <BeginStoryboard>
+                            <Storyboard>
+                                <ThicknessAnimation Storyboard.TargetProperty="Margin"
+                                                    To="32,28,32,16"
+                                                    Duration="0:0:0.25"
+                                                    FillBehavior="HoldEnd" />
+                            </Storyboard>
+                        </BeginStoryboard>
+                    </DataTrigger.ExitActions>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="NavigationScrollViewerStyle" TargetType="ScrollViewer">
+            <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
+            <Setter Property="VerticalScrollBarVisibility" Value="Disabled" />
+            <Setter Property="CanContentScroll" Value="False" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding UseCompactNavigation}" Value="True">
+                    <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="CompactNavigationStackStyle" TargetType="StackPanel">
+            <Setter Property="Orientation" Value="Horizontal" />
+            <Setter Property="Spacing" Value="8" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding UseCompactNavigation}" Value="True">
+                    <Setter Property="Spacing" Value="4" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0"
+                Background="{StaticResource HeaderGradientBrush}">
+            <Grid Style="{StaticResource ResponsiveHeaderGridStyle}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="16" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <Border Width="68" Height="68" Background="{StaticResource SurfaceLightBrush}" CornerRadius="18">
+                        <Ellipse Fill="{StaticResource AccentPrimaryBrush}" />
+                    </Border>
+
+                    <StackPanel Grid.Column="2" Orientation="Vertical" VerticalAlignment="Center">
+                        <TextBlock Text="AFC Richmond"
+                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   FontSize="28"
+                                   FontWeight="Bold" />
+                        <TextBlock Text="Premier League – 1st"
+                                   Margin="0,4,0,0"
+                                   Foreground="{StaticResource NeutralTextBrush}"
+                                   FontSize="15" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="3" Orientation="Horizontal" VerticalAlignment="Center">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Spacing" Value="20" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsCompactHeader}" Value="True">
+                                        <Setter Property="Spacing" Value="12" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+                        <StackPanel Orientation="Vertical" VerticalAlignment="Center">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsCompactHeader}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+                            <TextBlock Text="Next Match"
+                                       Foreground="{StaticResource NeutralTextBrush}"
+                                       FontSize="12"
+                                       FontWeight="SemiBold"
+                                       TextAlignment="Right" />
+                            <TextBlock Text="Sat 18:00 vs Man City"
+                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       FontSize="16"
+                                       FontWeight="SemiBold" />
+                        </StackPanel>
+                        <Button Content="Continue"
+                                Width="140"
+                                Style="{StaticResource ContinueButtonStyle}" />
+                        <TextBlock Text="Next: Sat 18:00 vs Man City"
+                                   VerticalAlignment="Center"
+                                   Foreground="{StaticResource NeutralTextBrush}"
+                                   FontSize="13"
+                                   FontWeight="SemiBold">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsCompactHeader}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </StackPanel>
+                </Grid>
+
+                <ScrollViewer Grid.Row="1"
+                              Margin="0,28,0,10"
+                              Style="{StaticResource NavigationScrollViewerStyle}">
+                    <ItemsControl ItemsSource="{Binding Tabs}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Style="{StaticResource CompactNavigationStackStyle}" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:NavigationTabViewModel}">
+                                <Button Command="{Binding DataContext.SelectTabCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                        CommandParameter="{Binding}"
+                                        Padding="18,12"
+                                        Cursor="Hand"
+                                        BorderThickness="1"
+                                        BorderBrush="Transparent"
+                                        Background="Transparent"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        ToolTipService.IsEnabled="{Binding HasAlerts}">
+                                    <Button.ToolTip>
+                                        <ToolTip Style="{StaticResource CardToolTipStyle}" Content="{Binding AlertSummary}" />
+                                    </Button.ToolTip>
+                                    <Button.Style>
+                                    <Style TargetType="Button">
+                                        <Setter Property="Template">
+                                            <Setter.Value>
+                                                <ControlTemplate TargetType="Button">
+                                                    <Grid>
+                                                        <Border x:Name="Highlight"
+                                                                CornerRadius="12"
+                                                                Background="{StaticResource AccentPrimaryBrush}"
+                                                                Opacity="0">
+                                                            <Border.RenderTransform>
+                                                                <ScaleTransform ScaleX="0.9" ScaleY="0.9" />
+                                                            </Border.RenderTransform>
+                                                        </Border>
+                                                        <Border x:Name="Root"
+                                                                CornerRadius="12"
+                                                                Padding="18,12"
+                                                                Background="{TemplateBinding Background}"
+                                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                                BorderThickness="{TemplateBinding BorderThickness}">
+                                                            <ContentPresenter HorizontalAlignment="Center"
+                                                                              VerticalAlignment="Center" />
+                                                        </Border>
+                                                    </Grid>
+                                                    <ControlTemplate.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter TargetName="Root" Property="Background" Value="#332EC4B6" />
+                                                        </Trigger>
+                                                        <Trigger Property="IsPressed" Value="True">
+                                                            <Setter TargetName="Root" Property="Background" Value="#552EC4B6" />
+                                                        </Trigger>
+                                                    </ControlTemplate.Triggers>
+                                                </ControlTemplate>
+                                            </Setter.Value>
+                                        </Setter>
+                                        <Setter Property="Background" Value="Transparent" />
+                                        <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+                                        <Setter Property="BorderThickness" Value="1" />
+                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding DataContext.UseCompactNavigation, RelativeSource={RelativeSource AncestorType=Window}}" Value="True">
+                                                <Setter Property="Padding" Value="14,10" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                <Setter Property="Background" Value="#552EC4B6" />
+                                                <Setter Property="BorderBrush" Value="{StaticResource AccentPrimaryBrush}" />
+                                                <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                                                <DataTrigger.EnterActions>
+                                                    <BeginStoryboard x:Name="TabHighlightIn">
+                                                        <Storyboard>
+                                                            <DoubleAnimation Storyboard.TargetName="Highlight"
+                                                                            Storyboard.TargetProperty="Opacity"
+                                                                            To="0.35"
+                                                                            Duration="0:0:0.25" />
+                                                            <DoubleAnimation Storyboard.TargetName="Highlight"
+                                                                            Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleX)"
+                                                                            To="1"
+                                                                            Duration="0:0:0.25" />
+                                                            <DoubleAnimation Storyboard.TargetName="Highlight"
+                                                                            Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleY)"
+                                                                            To="1"
+                                                                            Duration="0:0:0.25" />
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.EnterActions>
+                                                <DataTrigger.ExitActions>
+                                                    <BeginStoryboard x:Name="TabHighlightOut">
+                                                        <Storyboard>
+                                                            <DoubleAnimation Storyboard.TargetName="Highlight"
+                                                                            Storyboard.TargetProperty="Opacity"
+                                                                            To="0"
+                                                                            Duration="0:0:0.2" />
+                                                            <DoubleAnimation Storyboard.TargetName="Highlight"
+                                                                            Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleX)"
+                                                                            To="0.9"
+                                                                            Duration="0:0:0.2" />
+                                                            <DoubleAnimation Storyboard.TargetName="Highlight"
+                                                                            Storyboard.TargetProperty="RenderTransform.(ScaleTransform.ScaleY)"
+                                                                            To="0.9"
+                                                                            Duration="0:0:0.2" />
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.ExitActions>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                    </Button.Style>
+                                    <Grid>
+                                        <TextBlock Text="{Binding Title}"
+                                                   Style="{StaticResource NavigationTabTextStyle}">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock" BasedOn="{StaticResource NavigationTabTextStyle}">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                                            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                        <Border Style="{StaticResource NavigationTabAlertDotStyle}" />
+                                    </Grid>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <ScrollViewer Grid.Row="2"
+                              Style="{StaticResource NavigationScrollViewerStyle}">
+                    <ItemsControl ItemsSource="{Binding SelectedTab.SubItems}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" Spacing="6" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:NavigationSubItemViewModel}">
+                                <Button Command="{Binding DataContext.SelectedTab.SelectSubItemCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                        CommandParameter="{Binding}"
+                                        Style="{StaticResource SubNavigationButtonStyle}"
+                                        Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                        ToolTipService.IsEnabled="{Binding HasAlert}">
+                                    <Button.ToolTip>
+                                    <ToolTip Style="{StaticResource CardToolTipStyle}" Content="{Binding AlertTooltip}" />
+                                    </Button.ToolTip>
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource SubNavigationButtonStyle}">
+                                            <Setter Property="ToolTipService.IsEnabled" Value="False" />
+                                            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+                                            <Setter Property="Background" Value="Transparent" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding HasAlert}" Value="True">
+                                                    <Setter Property="ToolTipService.IsEnabled" Value="True" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding IsActive}" Value="True">
+                                                    <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                                                    <Setter Property="Background" Value="#552EC4B6" />
+                                                    <DataTrigger.EnterActions>
+                                                        <BeginStoryboard>
+                                                            <Storyboard>
+                                                                <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                                                To="1"
+                                                                                Duration="0:0:0.2" />
+                                                            </Storyboard>
+                                                        </BeginStoryboard>
+                                                    </DataTrigger.EnterActions>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="{Binding Title}" Style="{StaticResource NavigationSubItemTextStyle}" />
+                                        <Border Grid.Column="1"
+                                                Style="{StaticResource NavigationBadgeStyle}">
+                                            <TextBlock Text="{Binding BadgeText}"
+                                                       Foreground="{StaticResource NavigationBadgeForegroundBrush}"
+                                                       FontSize="11"
+                                                       FontWeight="SemiBold"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center" />
+                                        </Border>
+                                    </Grid>
+                                </Button>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="1"
+                Background="{StaticResource ContentGradientBrush}">
+            <Grid Margin="32">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Text="{Binding SelectedTab.ActiveSubItem.Title, FallbackValue=Select a Section}"
+                           Foreground="{StaticResource PrimaryTextBrush}"
+                           FontSize="24"
+                           FontWeight="Bold" />
+
+                <views:CardSurfaceView Grid.Row="1"
+                                       Margin="0,24,0,0"
+                                       DataContext="{Binding CardSurface}" />
+            </Grid>
+        </Border>
+    </Grid>
+</Window>

--- a/WPF/FMUI.Wpf/Views/MainWindow.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/MainWindow.xaml.cs
@@ -1,0 +1,29 @@
+using System.Windows;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Views;
+
+public partial class MainWindow : Window
+{
+    private readonly MainViewModel _viewModel;
+
+    public MainWindow(MainViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel;
+        DataContext = viewModel;
+
+        Loaded += OnLoaded;
+        SizeChanged += OnSizeChanged;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _viewModel.UpdateViewport(ActualWidth);
+    }
+
+    private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        _viewModel.UpdateViewport(e.NewSize.Width);
+    }
+}

--- a/WPF/FMUI.Wpf/Views/MedicalTimelineView.xaml
+++ b/WPF/FMUI.Wpf/Views/MedicalTimelineView.xaml
@@ -1,0 +1,88 @@
+<UserControl x:Class="FMUI.Wpf.Views.MedicalTimelineView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FMUI.Wpf.Controls"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:views="clr-namespace:FMUI.Wpf.Views"
+             MinHeight="240"
+             Focusable="False">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <views:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="{Binding Summary}"
+                   Style="{StaticResource CardListSecondaryTextStyle}" />
+
+        <ScrollViewer Grid.Row="1"
+                      HorizontalScrollBarVisibility="Disabled"
+                      VerticalScrollBarVisibility="Auto"
+                      Margin="0,12,0,0">
+            <ItemsControl ItemsSource="{Binding Entries}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type vm:MedicalTimelineEntryViewModel}">
+                        <Border Background="#111D2B"
+                                BorderBrush="#233447"
+                                BorderThickness="1"
+                                CornerRadius="14"
+                                Padding="16"
+                                Margin="0,0,0,12">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+
+                                <StackPanel Grid.Column="0" Grid.Row="0" Orientation="Horizontal" Spacing="12">
+                                    <Ellipse Width="10"
+                                             Height="10"
+                                             Fill="{Binding AccentBrush}" />
+                                    <TextBlock Text="{Binding Player}"
+                                               Style="{StaticResource CardListPrimaryTextStyle}"
+                                               FontSize="16"
+                                               FontWeight="SemiBold" />
+                                </StackPanel>
+
+                                <TextBlock Grid.Column="0" Grid.Row="1"
+                                           Text="{Binding Diagnosis}"
+                                           Style="{StaticResource CardListSecondaryTextStyle}"
+                                           Margin="22,6,0,0" />
+
+                                <StackPanel Grid.Column="0" Grid.Row="2" Orientation="Horizontal" Spacing="16" Margin="22,8,0,0">
+                                    <TextBlock Text="{Binding Status}" Style="{StaticResource CardListSecondaryTextStyle}" />
+                                    <TextBlock Text="{Binding ExpectedReturn, StringFormat=Return: {0}}"
+                                               Style="{StaticResource CardListSecondaryTextStyle}" />
+                                </StackPanel>
+
+                                <TextBlock Grid.Column="0" Grid.Row="3"
+                                           Text="{Binding Notes}"
+                                           Style="{StaticResource CardListSecondaryTextStyle}"
+                                           TextWrapping="Wrap"
+                                           Margin="22,8,0,0"
+                                           Visibility="{Binding HasNotes, Converter={StaticResource BoolToVisibility}}" />
+
+                                <controls:TimelineControl Grid.Column="1" Grid.Row="0" Grid.RowSpan="4"
+                                                          Items="{Binding Phases}"
+                                                          Margin="24,0,0,0"
+                                                          MinHeight="120" />
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/MedicalTimelineView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/MedicalTimelineView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class MedicalTimelineView : UserControl
+{
+    public MedicalTimelineView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/NullToVisibilityConverter.cs
+++ b/WPF/FMUI.Wpf/Views/NullToVisibilityConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace FMUI.Wpf.Views;
+
+public sealed class NullToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (targetType != typeof(Visibility) && targetType != typeof(object))
+        {
+            throw new NotSupportedException("NullToVisibilityConverter can only target Visibility properties.");
+        }
+
+        return value switch
+        {
+            null => Visibility.Collapsed,
+            string s when string.IsNullOrWhiteSpace(s) => Visibility.Collapsed,
+            _ => Visibility.Visible
+        };
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/WPF/FMUI.Wpf/Views/RelativePositionConverter.cs
+++ b/WPF/FMUI.Wpf/Views/RelativePositionConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace FMUI.Wpf.Views;
+
+public sealed class RelativePositionConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length < 2)
+        {
+            return 0d;
+        }
+
+        if (values[0] is double normalized && values[1] is double size)
+        {
+            var tokenSize = 0d;
+
+            switch (parameter)
+            {
+                case double numeric:
+                    tokenSize = numeric;
+                    break;
+                case string text when double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed):
+                    tokenSize = parsed;
+                    break;
+            }
+
+            var clampedNormalized = Math.Clamp(normalized, 0d, 1d);
+            var available = Math.Max(size, 0d);
+            var offset = tokenSize / 2d;
+            return (clampedNormalized * available) - offset;
+        }
+
+        return 0d;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/WPF/FMUI.Wpf/Views/ScoutAssignmentBoardView.xaml
+++ b/WPF/FMUI.Wpf/Views/ScoutAssignmentBoardView.xaml
@@ -1,0 +1,166 @@
+<UserControl x:Class="FMUI.Wpf.Views.ScoutAssignmentBoardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <UniformGrid Grid.Row="0"
+                     Columns="3"
+                     Margin="0,0,0,12"
+                     HorizontalAlignment="Stretch">
+            <StackPanel Margin="0,0,16,0">
+                <TextBlock Text="Total Assignments"
+                           Style="{DynamicResource CardMetricLabelTextStyle}" />
+                <TextBlock Text="{Binding TotalAssignments}"
+                           Style="{DynamicResource CardMetricValueTextStyle}" />
+            </StackPanel>
+            <StackPanel Margin="0,0,16,0">
+                <TextBlock Text="High Priority"
+                           Style="{DynamicResource CardMetricLabelTextStyle}" />
+                <TextBlock Text="{Binding HighPriorityAssignments}"
+                           Style="{DynamicResource CardMetricValueTextStyle}" />
+            </StackPanel>
+            <StackPanel>
+                <TextBlock Text="Awaiting Reports"
+                           Style="{DynamicResource CardMetricLabelTextStyle}" />
+                <TextBlock Text="{Binding AwaitingReportAssignments}"
+                           Style="{DynamicResource CardMetricValueTextStyle}" />
+            </StackPanel>
+        </UniformGrid>
+
+        <Border Grid.Row="1"
+                Background="{DynamicResource OverlayListBackgroundBrush}"
+                BorderBrush="{DynamicResource OverlayListItemBorderBrush}"
+                BorderThickness="1"
+                CornerRadius="10">
+            <ListView ItemsSource="{Binding Assignments}"
+                      BorderThickness="0"
+                      Background="Transparent"
+                      Foreground="{DynamicResource PrimaryTextBrush}"
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                <ListView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ListView.ItemsPanel>
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="Padding" Value="12,10" />
+                        <Setter Property="Margin" Value="0" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ListViewItem">
+                                    <Border Background="{TemplateBinding Background}">
+                                        <ContentPresenter />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="{DynamicResource OverlayListItemHoverBrush}" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </ListView.ItemContainerStyle>
+                <ListView.View>
+                    <GridView AllowsColumnReorder="False">
+                        <GridViewColumn Width="220" Header="Assignment">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Focus}"
+                                                   FontSize="16"
+                                                   FontWeight="SemiBold"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Text="{Binding Role}"
+                                                   Style="{DynamicResource CardSubtitleTextStyle}"
+                                                   FontSize="13"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="140" Header="Region">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Region}"
+                                               Style="{DynamicResource CardSubtitleTextStyle}"
+                                               TextTrimming="CharacterEllipsis" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="140" Header="Scout">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Scout}"
+                                               Style="{DynamicResource CardSubtitleTextStyle}"
+                                               TextTrimming="CharacterEllipsis" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="120" Header="Priority">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border Background="{Binding PriorityBrush}"
+                                            CornerRadius="6"
+                                            Padding="10,4"
+                                            HorizontalAlignment="Left">
+                                        <TextBlock Text="{Binding Priority}"
+                                                   Foreground="White"
+                                                   FontSize="13"
+                                                   FontWeight="SemiBold" />
+                                    </Border>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="140" Header="Stage">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border Background="{Binding StageBrush}"
+                                            CornerRadius="6"
+                                            Padding="10,4"
+                                            HorizontalAlignment="Left">
+                                        <TextBlock Text="{Binding Stage}"
+                                                   Foreground="White"
+                                                   FontSize="13"
+                                                   FontWeight="SemiBold" />
+                                    </Border>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="120" Header="Deadline">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Deadline}"
+                                               Style="{DynamicResource CardSubtitleTextStyle}" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="220" Header="Notes">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Notes}"
+                                               Style="{DynamicResource CardSubtitleTextStyle}"
+                                               TextTrimming="CharacterEllipsis"
+                                               Visibility="{Binding HasNotes, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                    </GridView>
+                </ListView.View>
+            </ListView>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/ScoutAssignmentBoardView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/ScoutAssignmentBoardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class ScoutAssignmentBoardView : UserControl
+{
+    public ScoutAssignmentBoardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/ShortlistBoardView.xaml
+++ b/WPF/FMUI.Wpf/Views/ShortlistBoardView.xaml
@@ -1,0 +1,156 @@
+<UserControl x:Class="FMUI.Wpf.Views.ShortlistBoardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <UniformGrid Grid.Row="0"
+                     Columns="3"
+                     Margin="0,0,0,12"
+                     HorizontalAlignment="Stretch">
+            <StackPanel Margin="0,0,16,0">
+                <TextBlock Text="Make Offer"
+                           Style="{DynamicResource CardMetricLabelTextStyle}" />
+                <TextBlock Text="{Binding MakeOfferCount}"
+                           Style="{DynamicResource CardMetricValueTextStyle}" />
+            </StackPanel>
+            <StackPanel Margin="0,0,16,0">
+                <TextBlock Text="Scout Follow-ups"
+                           Style="{DynamicResource CardMetricLabelTextStyle}" />
+                <TextBlock Text="{Binding ScoutFollowUpCount}"
+                           Style="{DynamicResource CardMetricValueTextStyle}" />
+            </StackPanel>
+            <StackPanel>
+                <TextBlock Text="Priority Targets"
+                           Style="{DynamicResource CardMetricLabelTextStyle}" />
+                <TextBlock Text="{Binding PriorityTargetCount}"
+                           Style="{DynamicResource CardMetricValueTextStyle}" />
+            </StackPanel>
+        </UniformGrid>
+
+        <Border Grid.Row="1"
+                Background="{DynamicResource OverlayListBackgroundBrush}"
+                BorderBrush="{DynamicResource OverlayListItemBorderBrush}"
+                BorderThickness="1"
+                CornerRadius="10">
+            <ListView ItemsSource="{Binding Players}"
+                      BorderThickness="0"
+                      Background="Transparent"
+                      Foreground="{DynamicResource PrimaryTextBrush}"
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                <ListView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </ListView.ItemsPanel>
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="Padding" Value="12,10" />
+                        <Setter Property="Margin" Value="0" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ListViewItem">
+                                    <Border Background="{TemplateBinding Background}">
+                                        <ContentPresenter />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="{DynamicResource OverlayListItemHoverBrush}" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </ListView.ItemContainerStyle>
+                <ListView.View>
+                    <GridView AllowsColumnReorder="False">
+                        <GridViewColumn Width="220" Header="Player">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Name}"
+                                                   FontSize="16"
+                                                   FontWeight="SemiBold"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Text="{Binding Position}"
+                                                   Style="{DynamicResource CardSubtitleTextStyle}"
+                                                   FontSize="13"
+                                                   TextTrimming="CharacterEllipsis" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="150" Header="Status">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border Background="{Binding StatusBrush}"
+                                            CornerRadius="6"
+                                            Padding="10,4"
+                                            HorizontalAlignment="Left">
+                                        <TextBlock Text="{Binding Status}"
+                                                   Foreground="White"
+                                                   FontSize="13"
+                                                   FontWeight="SemiBold" />
+                                    </Border>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="160" Header="Action">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border Background="{Binding ActionBrush}"
+                                            CornerRadius="6"
+                                            Padding="10,4"
+                                            HorizontalAlignment="Left">
+                                        <TextBlock Text="{Binding Action}"
+                                                   Foreground="White"
+                                                   FontSize="13"
+                                                   FontWeight="SemiBold" />
+                                    </Border>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="140" Header="Priority">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border Background="#FF2B3545"
+                                            CornerRadius="6"
+                                            Padding="10,4"
+                                            HorizontalAlignment="Left"
+                                            Visibility="{Binding HasPriority, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                        <TextBlock Text="{Binding Priority}"
+                                                   Foreground="White"
+                                                   FontSize="13"
+                                                   FontWeight="SemiBold" />
+                                    </Border>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                        <GridViewColumn Width="260" Header="Notes">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Notes}"
+                                               Style="{DynamicResource CardSubtitleTextStyle}"
+                                               TextTrimming="CharacterEllipsis"
+                                               Visibility="{Binding HasNotes, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+                    </GridView>
+                </ListView.View>
+            </ListView>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/ShortlistBoardView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/ShortlistBoardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class ShortlistBoardView : UserControl
+{
+    public ShortlistBoardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/ShotMapView.xaml
+++ b/WPF/FMUI.Wpf/Views/ShotMapView.xaml
@@ -1,0 +1,238 @@
+<UserControl x:Class="FMUI.Wpf.Views.ShotMapView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:views="clr-namespace:FMUI.Wpf.Views"
+             MinHeight="280"
+             Focusable="False">
+    <UserControl.Resources>
+        <views:RelativePositionConverter x:Key="RelativePositionConverter" />
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <views:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+
+        <Style x:Key="ShotFilterToggleStyle" TargetType="ToggleButton">
+            <Setter Property="Background" Value="#151F2D" />
+            <Setter Property="BorderBrush" Value="#233246" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="12" />
+            <Setter Property="Foreground" Value="{StaticResource NeutralTextBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Padding" Value="12,6" />
+            <Setter Property="Margin" Value="0,0,8,8" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border x:Name="Chrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center" />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Chrome" Property="Background" Value="#1A2C40" />
+                                <Setter TargetName="Chrome" Property="BorderBrush" Value="#2EC4B6" />
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Chrome" Property="BorderBrush" Value="#3AA0FF" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="Chrome" Property="Opacity" Value="0.4" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="ShotMapEventButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="HorizontalAlignment" Value="Left" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Ellipse Width="{Binding Diameter}"
+                                 Height="{Binding Diameter}"
+                                 Fill="{Binding FillBrush}"
+                                 Stroke="{Binding StrokeBrush}"
+                                 StrokeThickness="1.5">
+                            <Ellipse.Effect>
+                                <DropShadowEffect BlurRadius="8"
+                                                  Opacity="0.45"
+                                                  Color="#CC0D2133"
+                                                  ShadowDepth="0" />
+                            </Ellipse.Effect>
+                            <Ellipse.Style>
+                                <Style TargetType="Ellipse">
+                                    <Setter Property="Stroke" Value="{Binding StrokeBrush}" />
+                                    <Setter Property="StrokeThickness" Value="1.5" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                            <Setter Property="StrokeThickness" Value="3" />
+                                            <Setter Property="Stroke" Value="#FFFFFFFF" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Ellipse.Style>
+                        </Ellipse>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0">
+            <TextBlock Text="{Binding Summary}"
+                       Style="{StaticResource CardListSecondaryTextStyle}" />
+
+            <ItemsControl ItemsSource="{Binding Filters}"
+                          Margin="0,12,0,0">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type vm:ShotMapFilterViewModel}">
+                        <ToggleButton Style="{StaticResource ShotFilterToggleStyle}"
+                                      IsChecked="{Binding IsEnabled, Mode=TwoWay}">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Ellipse Width="10"
+                                         Height="10"
+                                         Fill="{Binding Brush}"
+                                         StrokeThickness="0" />
+                                <TextBlock Text="{Binding DisplayName}" />
+                            </StackPanel>
+                        </ToggleButton>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+
+        <Border Grid.Row="1"
+                Margin="0,16"
+                Background="#0F1926"
+                BorderBrush="#233446"
+                BorderThickness="1"
+                CornerRadius="18">
+            <Grid ClipToBounds="True">
+                <Border Background="#0E1724"
+                        BorderBrush="#1E2F44"
+                        BorderThickness="1.5"
+                        CornerRadius="18" />
+
+                <Grid Margin="28">
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <Rectangle Grid.Row="1"
+                               Height="1.5"
+                               Fill="#1E2F44" />
+
+                    <Ellipse Grid.Row="1"
+                             Width="26"
+                             Height="26"
+                             Stroke="#1E2F44"
+                             StrokeThickness="1.2"
+                             Fill="Transparent"
+                             HorizontalAlignment="Center"
+                             VerticalAlignment="Center" />
+                </Grid>
+
+                <ItemsControl ItemsSource="{Binding Shots}"
+                              Margin="18"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch"
+                              ClipToBounds="True">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <Canvas />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:ShotMapEventViewModel}">
+                            <Button Style="{StaticResource ShotMapEventButtonStyle}"
+                                    Command="{Binding DataContext.SelectShotCommand, RelativeSource={RelativeSource AncestorType=views:ShotMapView}}"
+                                    CommandParameter="{Binding}"
+                                    ToolTip="{Binding Tooltip}"
+                                    Visibility="{Binding IsVisible, Converter={StaticResource BoolToVisibility}}"
+                                    ToolTipService.ShowDuration="20000">
+                                <Button.RenderTransform>
+                                    <TranslateTransform />
+                                </Button.RenderTransform>
+                            </Button>
+                            <Button.Canvas.Left>
+                                <MultiBinding Converter="{StaticResource RelativePositionConverter}" ConverterParameter="16">
+                                    <Binding Path="NormalizedX" />
+                                    <Binding RelativeSource="{RelativeSource AncestorType=ItemsControl}" Path="ActualWidth" />
+                                </MultiBinding>
+                            </Button.Canvas.Left>
+                            <Button.Canvas.Top>
+                                <MultiBinding Converter="{StaticResource RelativePositionConverter}" ConverterParameter="16">
+                                    <Binding Path="NormalizedY" />
+                                    <Binding RelativeSource="{RelativeSource AncestorType=ItemsControl}" Path="ActualHeight" />
+                                </MultiBinding>
+                            </Button.Canvas.Top>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="2"
+                Background="#101B29"
+                BorderBrush="#253447"
+                BorderThickness="1"
+                CornerRadius="12"
+                Padding="12"
+                Visibility="{Binding HasSelectedShot, Converter={StaticResource BoolToVisibility}}">
+            <StackPanel>
+                <TextBlock Text="{Binding SelectedShot.Player}"
+                           Style="{StaticResource CardListPrimaryTextStyle}"
+                           FontSize="16"
+                           FontWeight="SemiBold" />
+                <TextBlock Text="{Binding SelectedShot.OutcomeDisplay}"
+                           Style="{StaticResource CardListSecondaryTextStyle}" />
+                <StackPanel Orientation="Horizontal"
+                            Margin="0,8,0,0"
+                            Spacing="16">
+                    <TextBlock Text="{Binding SelectedShot.Minute}"
+                               Style="{StaticResource CardListSecondaryTextStyle}" />
+                    <TextBlock Text="{Binding SelectedShot.ExpectedGoals, StringFormat=xG {0:0.00}}"
+                               Style="{StaticResource CardListSecondaryTextStyle}"
+                               Visibility="{Binding SelectedShot.ExpectedGoals, Converter={StaticResource NullToVisibilityConverter}}" />
+                    <TextBlock Text="{Binding SelectedShot.Assist, StringFormat=Assist: {0}}"
+                               Style="{StaticResource CardListSecondaryTextStyle}"
+                               Visibility="{Binding SelectedShot.Assist, Converter={StaticResource NullToVisibilityConverter}}" />
+                </StackPanel>
+                <TextBlock Text="{Binding SelectedShot.Detail}"
+                           Style="{StaticResource CardListSecondaryTextStyle}"
+                           TextWrapping="Wrap"
+                           Margin="0,6,0,0"
+                           Visibility="{Binding SelectedShot.Detail, Converter={StaticResource NullToVisibilityConverter}}" />
+                <Button Content="Clear selection"
+                        Command="{Binding ClearSelectionCommand}"
+                        Style="{StaticResource CardHeaderButtonStyle}"
+                        Margin="0,12,0,0"
+                        HorizontalAlignment="Left" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/ShotMapView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/ShotMapView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class ShotMapView : UserControl
+{
+    public ShotMapView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/TrainingCalendarView.xaml
+++ b/WPF/FMUI.Wpf/Views/TrainingCalendarView.xaml
@@ -1,0 +1,211 @@
+<UserControl x:Class="FMUI.Wpf.Views.TrainingCalendarView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             Focusable="False"
+             MinHeight="300">
+    <UserControl.Resources>
+        <Style x:Key="CalendarSlotBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="#161E2A" />
+            <Setter Property="BorderBrush" Value="#263142" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="12" />
+            <Setter Property="Padding" Value="12" />
+            <Setter Property="Margin" Value="0,12,0,0" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+        </Style>
+
+        <Style x:Key="CalendarSessionBorderStyle" TargetType="Border">
+            <Setter Property="Background" Value="#1F2735" />
+            <Setter Property="BorderBrush" Value="#2E394B" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="10" />
+            <Setter Property="Padding" Value="12" />
+            <Setter Property="Margin" Value="0,8,0,0" />
+            <Setter Property="SnapsToDevicePixels" Value="True" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#273346" />
+                    <Setter Property="BorderBrush" Value="#2EC4B6" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="140" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Grid.Column="0"
+                   Text="Time Slot"
+                   Foreground="{StaticResource NeutralTextBrush}"
+                   FontSize="13"
+                   FontWeight="SemiBold"
+                   Margin="0,0,12,0" />
+
+        <ItemsControl Grid.Row="1"
+                      Grid.Column="0"
+                      ItemsSource="{Binding Slots}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}"
+                               Foreground="{StaticResource NeutralTextBrush}"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               Margin="0,18,12,0" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <ItemsControl Grid.Row="0"
+                      Grid.RowSpan="2"
+                      Grid.Column="1"
+                      ItemsSource="{Binding Days}"
+                      IsEnabled="{Binding DataContext.CanInteract, RelativeSource={RelativeSource AncestorType=UserControl}}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <UniformGrid Rows="1" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate DataType="{x:Type vm:TrainingCalendarDayViewModel}">
+                    <Grid Margin="0,0,16,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <Border Grid.Row="0"
+                                Padding="14,10"
+                                Background="#1B2534"
+                                BorderBrush="#273346"
+                                BorderThickness="1"
+                                CornerRadius="12">
+                            <TextBlock Text="{Binding Day}"
+                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       FontSize="14"
+                                       FontWeight="SemiBold"
+                                       HorizontalAlignment="Center" />
+                        </Border>
+
+                        <ItemsControl Grid.Row="1"
+                                      ItemsSource="{Binding Slots}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type vm:TrainingCalendarSlotViewModel}">
+                                    <Border Style="{StaticResource CalendarSlotBorderStyle}"
+                                            AllowDrop="True"
+                                            DragOver="OnSlotDragOver"
+                                            Drop="OnSlotDrop">
+                                        <Border.Style>
+                                            <Style TargetType="Border" BasedOn="{StaticResource CalendarSlotBorderStyle}">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding HasSessions}" Value="False">
+                                                        <Setter Property="Opacity" Value="0.75" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <Grid>
+                                            <ItemsControl ItemsSource="{Binding Sessions}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate DataType="{x:Type vm:TrainingCalendarSessionViewModel}">
+                                                        <Border Style="{StaticResource CalendarSessionBorderStyle}"
+                                                                PreviewMouseLeftButtonDown="OnSessionPreviewMouseLeftButtonDown"
+                                                                PreviewMouseMove="OnSessionPreviewMouseMove"
+                                                                PreviewMouseLeftButtonUp="OnSessionPreviewMouseLeftButtonUp">
+                                                            <StackPanel>
+                                                                <TextBlock Text="{Binding Activity}"
+                                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                                           FontWeight="SemiBold"
+                                                                           FontSize="14" />
+                                                                <TextBlock Text="{Binding FocusDisplay}"
+                                                                           Foreground="{StaticResource NeutralTextBrush}"
+                                                                           Margin="0,4,0,0"
+                                                                           FontSize="12">
+                                                                    <TextBlock.Style>
+                                                                        <Style TargetType="TextBlock">
+                                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding HasFocus}" Value="True">
+                                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </TextBlock.Style>
+                                                                </TextBlock>
+                                                                <TextBlock Text="{Binding IntensityDisplay}"
+                                                                           Foreground="{StaticResource AccentSecondaryBrush}"
+                                                                           FontSize="12"
+                                                                           FontWeight="SemiBold">
+                                                                    <TextBlock.Style>
+                                                                        <Style TargetType="TextBlock">
+                                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                                            <Style.Triggers>
+                                                                                <DataTrigger Binding="{Binding HasIntensity}" Value="True">
+                                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                                </DataTrigger>
+                                                                            </Style.Triggers>
+                                                                        </Style>
+                                                                    </TextBlock.Style>
+                                                                </TextBlock>
+                                                            </StackPanel>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+
+                                            <TextBlock Text="Drag a session here"
+                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                       FontStyle="Italic"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Center">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding HasSessions}" Value="False">
+                                                                <Setter Property="Visibility" Value="Visible" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Grid>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <Border Grid.Row="2"
+                Grid.ColumnSpan="2"
+                Background="Transparent"
+                Padding="0,12,0,0">
+            <TextBlock Text="{Binding StatusMessage}"
+                       Foreground="{StaticResource NeutralTextBrush}"
+                       FontSize="12">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding HasStatusMessage}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/TrainingCalendarView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/TrainingCalendarView.xaml.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using FMUI.Wpf.ViewModels;
+
+namespace FMUI.Wpf.Views;
+
+public partial class TrainingCalendarView : UserControl
+{
+    private const string DragDataFormat = "FMUI.Wpf.TrainingCalendar.Session";
+    private Point? _dragStartPoint;
+
+    public TrainingCalendarView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnSessionPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        _dragStartPoint = e.GetPosition(this);
+    }
+
+    private void OnSessionPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        _dragStartPoint = null;
+    }
+
+    private void OnSessionPreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (e.LeftButton != MouseButtonState.Pressed || _dragStartPoint is null)
+        {
+            return;
+        }
+
+        var current = e.GetPosition(this);
+        if (Math.Abs(current.X - _dragStartPoint.Value.X) < SystemParameters.MinimumHorizontalDragDistance &&
+            Math.Abs(current.Y - _dragStartPoint.Value.Y) < SystemParameters.MinimumVerticalDragDistance)
+        {
+            return;
+        }
+
+        if (sender is not FrameworkElement element)
+        {
+            return;
+        }
+
+        if (element.DataContext is not TrainingCalendarSessionViewModel session)
+        {
+            return;
+        }
+
+        if (DataContext is not TrainingCalendarViewModel viewModel || !viewModel.CanInteract)
+        {
+            return;
+        }
+
+        _dragStartPoint = null;
+        var data = new DataObject(DragDataFormat, session);
+        DragDrop.DoDragDrop(element, data, DragDropEffects.Move);
+    }
+
+    private void OnSlotDragOver(object sender, DragEventArgs e)
+    {
+        e.Handled = true;
+        if (!ValidatePayload(sender, e, out _))
+        {
+            e.Effects = DragDropEffects.None;
+            return;
+        }
+
+        e.Effects = DragDropEffects.Move;
+    }
+
+    private async void OnSlotDrop(object sender, DragEventArgs e)
+    {
+        e.Handled = true;
+        if (!ValidatePayload(sender, e, out var payload))
+        {
+            return;
+        }
+
+        var (viewModel, session, slot) = payload;
+        var index = slot.Sessions.Count;
+
+        if (e.OriginalSource is FrameworkElement element && element.DataContext is TrainingCalendarSessionViewModel target)
+        {
+            var candidate = slot.Sessions.IndexOf(target);
+            if (candidate >= 0)
+            {
+                index = candidate;
+                var position = e.GetPosition(element);
+                if (position.Y > element.ActualHeight / 2)
+                {
+                    index++;
+                }
+            }
+        }
+
+        await viewModel.MoveSessionAsync(session, slot, index).ConfigureAwait(true);
+    }
+
+    private bool ValidatePayload(object sender, DragEventArgs e, out (TrainingCalendarViewModel ViewModel, TrainingCalendarSessionViewModel Session, TrainingCalendarSlotViewModel Slot) payload)
+    {
+        payload = default;
+        if (DataContext is not TrainingCalendarViewModel viewModel || !viewModel.CanInteract)
+        {
+            return false;
+        }
+
+        if (sender is not FrameworkElement element || element.DataContext is not TrainingCalendarSlotViewModel slot)
+        {
+            return false;
+        }
+
+        if (!e.Data.GetDataPresent(DragDataFormat))
+        {
+            return false;
+        }
+
+        if (e.Data.GetData(DragDataFormat) is not TrainingCalendarSessionViewModel session)
+        {
+            return false;
+        }
+
+        payload = (viewModel, session, slot);
+        return true;
+    }
+}

--- a/WPF/FMUI.Wpf/Views/TrainingProgressionView.xaml
+++ b/WPF/FMUI.Wpf/Views/TrainingProgressionView.xaml
@@ -1,0 +1,158 @@
+<UserControl x:Class="FMUI.Wpf.Views.TrainingProgressionView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:FMUI.Wpf.Controls"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             xmlns:conv="clr-namespace:FMUI.Wpf.Views"
+             Background="Transparent">
+    <UserControl.Resources>
+        <conv:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="{Binding TrainingProgression.Summary}"
+                   TextWrapping="Wrap"
+                   Foreground="{StaticResource NeutralTextBrush}"
+                   Margin="0,0,0,16">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Visibility" Value="Visible" />
+                    <Style.Triggers>
+                        <Trigger Property="Text" Value="">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="Text" Value="{x:Null}">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" />
+                <ColumnDefinition Width="2*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Background="#101A28"
+                    BorderBrush="#1F2D3C"
+                    BorderThickness="1"
+                    CornerRadius="18"
+                    Padding="16"
+                    Margin="0,0,12,0">
+                <controls:LineChartControl Series="{Binding TrainingProgression.ChartSeries}"
+                                           MinHeight="220"
+                                           FillOpacity="0.24" />
+            </Border>
+
+            <StackPanel Grid.Column="1"
+                        Margin="12,0,0,0">
+                <TextBlock Text="Progress Highlights"
+                           Style="{StaticResource CardSectionHeaderTextStyle}" />
+
+                <ItemsControl ItemsSource="{Binding TrainingProgression.Series}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:TrainingProgressionSeriesViewModel}">
+                            <Border Background="#101A28"
+                                    BorderBrush="#1F2D3C"
+                                    BorderThickness="1"
+                                    CornerRadius="14"
+                                    Padding="12"
+                                    Margin="0,8,0,0">
+                                <StackPanel>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <Ellipse Width="12"
+                                                 Height="12"
+                                                 Fill="{Binding Stroke}"
+                                                 Margin="0,0,8,0" />
+                                        <TextBlock Text="{Binding Name}"
+                                                   Style="{StaticResource CardListPrimaryTextStyle}"
+                                                   FontWeight="SemiBold" />
+                                        <Border Background="#1F2D3C"
+                                                CornerRadius="10"
+                                                Padding="8,2"
+                                                Margin="8,0,0,0"
+                                                Visibility="{Binding IsHighlighted, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            <TextBlock Text="Focus"
+                                                       Foreground="{StaticResource AccentTextBrush}"
+                                                       FontSize="11"
+                                                       FontWeight="SemiBold" />
+                                        </Border>
+                                        <Border Background="#233246"
+                                                CornerRadius="10"
+                                                Padding="8,2"
+                                                Margin="8,0,0,0"
+                                                Visibility="{Binding Accent, Converter={StaticResource NullToVisibilityConverter}}">
+                                            <TextBlock Text="{Binding Accent}"
+                                                       Foreground="{StaticResource NeutralTextBrush}"
+                                                       FontSize="11"
+                                                       FontWeight="SemiBold" />
+                                        </Border>
+                                    </StackPanel>
+
+                                    <StackPanel Orientation="Horizontal"
+                                                Margin="0,8,0,0"
+                                                VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding LatestValueDisplay}"
+                                                   Style="{StaticResource CardMetricValueTextStyle}"
+                                                   FontSize="18"
+                                                   FontWeight="SemiBold" />
+                                        <TextBlock Text="Latest"
+                                                   Style="{StaticResource CardMetricLabelTextStyle}"
+                                                   Margin="12,12,0,0" />
+                                    </StackPanel>
+
+                                    <TextBlock Text="{Binding LatestDetail}"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               Margin="0,6,0,0"
+                                               TextWrapping="Wrap"
+                                               Visibility="{Binding HasLatestDetail, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                                    <ItemsControl ItemsSource="{Binding Points}"
+                                                  Margin="0,12,0,0">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <UniformGrid Columns="2" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate DataType="{x:Type vm:TrainingProgressionPointViewModel}">
+                                                <StackPanel Margin="0,4">
+                                                    <TextBlock Text="{Binding Period}"
+                                                               Foreground="{StaticResource NeutralTextBrush}" />
+                                                    <TextBlock Text="{Binding DisplayValue}"
+                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                               FontWeight="SemiBold"
+                                                               Margin="0,2,0,0" />
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <ItemsControl ItemsSource="{Binding ListItems}"
+                              Margin="0,12,0,0">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:CardListItemViewModel}">
+                            <StackPanel Margin="0,6,0,0">
+                                <TextBlock Text="{Binding Primary}" Foreground="{StaticResource PrimaryTextBrush}" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding Secondary}" Foreground="{StaticResource NeutralTextBrush}" />
+                                <TextBlock Text="{Binding Tertiary}" Foreground="{StaticResource NeutralTextBrush}" FontSize="12" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/TrainingProgressionView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/TrainingProgressionView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class TrainingProgressionView : UserControl
+{
+    public TrainingProgressionView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/Views/TrainingUnitBoardView.xaml
+++ b/WPF/FMUI.Wpf/Views/TrainingUnitBoardView.xaml
@@ -1,0 +1,179 @@
+<UserControl x:Class="FMUI.Wpf.Views.TrainingUnitBoardView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:FMUI.Wpf.ViewModels"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=vm:TrainingUnitBoardViewModel}">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Grid.Row="0"
+                      HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Disabled">
+            <ItemsControl ItemsSource="{Binding Units}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal"
+                                    Margin="0,0,16,0" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type vm:TrainingUnitUnitViewModel}">
+                        <Border Width="320"
+                                Margin="0,0,16,0"
+                                Padding="16"
+                                Background="{StaticResource CardPanelBrush}"
+                                BorderBrush="{StaticResource CardBorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="16">
+                            <StackPanel>
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,0,0,12"
+                                            VerticalAlignment="Center">
+                                    <TextBlock Text="{Binding Name}"
+                                               Style="{StaticResource CardTitleTextStyle}" />
+                                    <TextBlock Text="Coach"
+                                               Foreground="{StaticResource AccentSecondaryBrush}"
+                                               FontWeight="SemiBold"
+                                               FontSize="12"
+                                               Margin="8,2,0,0" />
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,0,0,16">
+                                    <TextBlock Text="Lead Coach"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               FontSize="12"
+                                               Margin="0,0,8,0" />
+                                    <TextBlock Text="{Binding CoachName}"
+                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               FontSize="12"
+                                               FontWeight="SemiBold" />
+                                </StackPanel>
+                                <ItemsControl ItemsSource="{Binding Members}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="{x:Type vm:TrainingUnitMemberViewModel}">
+                                            <Border Margin="0,0,0,10"
+                                                    Padding="12"
+                                                    Background="{StaticResource CardListItemBrush}"
+                                                    BorderBrush="{StaticResource CardListItemBorderBrush}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="12">
+                                                <StackPanel>
+                                                    <StackPanel Orientation="Horizontal"
+                                                                VerticalAlignment="Center">
+                                                        <TextBlock Text="{Binding Name}"
+                                                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                                                   FontWeight="SemiBold"
+                                                                   FontSize="14" />
+                                                        <TextBlock Text="{Binding Status}"
+                                                                   Foreground="{StaticResource AccentSecondaryBrush}"
+                                                                   FontSize="12"
+                                                                   FontWeight="SemiBold"
+                                                                   Margin="8,0,0,0" />
+                                                    </StackPanel>
+                                                    <TextBlock Text="{Binding Position}"
+                                                               Foreground="{StaticResource NeutralTextBrush}"
+                                                               FontSize="12"
+                                                               Margin="0,6,0,0" />
+                                                    <TextBlock Text="{Binding Role}"
+                                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                                               FontSize="12"
+                                                               Margin="0,2,0,0" />
+                                                    <TextBlock Text="{Binding Detail}"
+                                                               Foreground="{StaticResource NeutralTextBrush}"
+                                                               FontSize="11"
+                                                               Margin="0,6,0,0"
+                                                               TextWrapping="Wrap"
+                                                               Visibility="{Binding HasDetail, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                    <ItemsControl.Style>
+                                        <Style TargetType="ItemsControl">
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="ItemsControl">
+                                                        <ItemsPresenter />
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </ItemsControl.Style>
+                                </ItemsControl>
+                                <TextBlock Text="No players assigned"
+                                           Foreground="{StaticResource NeutralTextBrush}"
+                                           FontStyle="Italic"
+                                           FontSize="12"
+                                           HorizontalAlignment="Center"
+                                           Margin="0,12,0,0">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding HasMembers}" Value="False">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+        <Border Grid.Row="1"
+                Margin="0,16,0,0"
+                Padding="16"
+                Background="{StaticResource CardPanelBrush}"
+                BorderBrush="{StaticResource CardBorderBrush}"
+                BorderThickness="1"
+                CornerRadius="16"
+                Visibility="{Binding HasAvailablePlayers, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <StackPanel>
+                <TextBlock Text="Available Pool"
+                           Style="{StaticResource CardTitleTextStyle}"
+                           Margin="0,0,0,12" />
+                <ItemsControl ItemsSource="{Binding AvailablePlayers}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vm:TrainingUnitMemberViewModel}">
+                            <Border Margin="0,0,0,8"
+                                    Padding="12"
+                                    Background="{StaticResource CardListItemBrush}"
+                                    BorderBrush="{StaticResource CardListItemBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Name}"
+                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               FontWeight="SemiBold"
+                                               FontSize="13" />
+                                    <TextBlock Text="{Binding Position}"
+                                               Foreground="{StaticResource NeutralTextBrush}"
+                                               FontSize="12"
+                                               Margin="0,4,0,0" />
+                                    <TextBlock Text="{Binding Role}"
+                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               FontSize="12"
+                                               Margin="0,2,0,0" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/WPF/FMUI.Wpf/Views/TrainingUnitBoardView.xaml.cs
+++ b/WPF/FMUI.Wpf/Views/TrainingUnitBoardView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace FMUI.Wpf.Views;
+
+public partial class TrainingUnitBoardView : UserControl
+{
+    public TrainingUnitBoardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/WPF/FMUI.Wpf/app.manifest
+++ b/WPF/FMUI.Wpf/app.manifest
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="FMUI.Wpf.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/WPF/README.md
+++ b/WPF/README.md
@@ -1,0 +1,117 @@
+# FMUI WPF Conversion Scaffold
+
+This directory contains a manually-authored WPF solution that mirrors the Football Manager-style HTML prototype. The project is structured to provide an immediate visual shell — navigation chrome, theming resources, and placeholder tactical grid — so feature teams can iterate on data-driven modules without reworking the application frame.
+
+## Solution Layout
+
+```
+WPF/
+├── FMUI.Wpf.sln
+├── FMUI.Wpf/
+│   ├── App.xaml
+│   ├── App.xaml.cs
+│   ├── FMUI.Wpf.csproj
+│   ├── Controls/
+│   │   ├── CardDragThumb.cs
+│   │   ├── CardResizeThumb.cs
+│   │   ├── FormationPlayerThumb.cs
+│   │   ├── LineChartControl.cs
+│   │   ├── RadialGaugeControl.cs
+│   │   ├── TimelineControl.cs
+│   │   └── VirtualizingCardPanel.cs
+│   ├── Infrastructure/
+│   │   ├── AsyncRelayCommand.cs
+│   │   ├── EventAggregator.cs
+│   │   ├── NavigationSectionChangedEvent.cs
+│   │   ├── ObservableObject.cs
+│   │   └── RelayCommand.cs
+│   ├── Models/
+│   │   ├── CardLayoutStateSnapshot.cs
+│   │   ├── CardModels.cs
+│   │   ├── ClubDataSnapshot.cs
+│   │   └── NavigationModels.cs
+│   ├── Resources/
+│   │   └── Theme.xaml
+│   ├── Services/
+│   │   ├── CardInteractionService.cs
+│   │   ├── CardLayoutCatalog.cs
+│   │   ├── CardLayoutStatePersistence.cs
+│   │   ├── CardLayoutStateService.cs
+│   │   ├── ClubDataService.cs
+│   │   ├── NavigationCatalog.cs
+│   │   ├── NavigationIndicatorService.cs
+│   │   └── NavigationPermissionService.cs
+│   ├── Data/
+│   │   └── club-data.json
+│   ├── ViewModels/
+│   │   ├── CardSurfaceViewModel.cs
+│   │   ├── CardViewModel.cs
+│   │   ├── MainViewModel.cs
+│   │   ├── NavigationSubItemViewModel.cs
+│   │   └── NavigationTabViewModel.cs
+│   └── Views/
+│       ├── CardSurfaceView.xaml
+│       ├── CardSurfaceView.xaml.cs
+│       ├── MainWindow.xaml
+│       └── MainWindow.xaml.cs
+└── README.md
+```
+
+## Implemented Features
+
+- **Dependency-injected MVVM shell** powered by the .NET Generic Host so view models, services, and windows resolve through a single composition root.
+- **Navigation shell** with the seven Football Manager tabs, contextual sub-navigation, and state-aware styling.
+- **Message-driven card surface** that listens for navigation events via an event aggregator and materialises layouts from the catalog without direct coupling.
+- **Theming system** that ports the dark palette, gradients, and control styles from the HTML prototype into reusable WPF Resource Dictionaries.
+- **Interactive card canvas** with drag, resize, and a custom virtualizing panel that keeps only on-screen cards realised while sharing viewport state through the interaction service.
+- **Snapping previews and collision guards** that render drag ghosts for active selections, flag invalid drops in real time, and block commits when card geometry would overlap existing content.
+- **Selection-aware workspace tooling** covering multi-card selection, keyboard nudging, and undo/redo history so layout edits can be grouped, reversed, and persisted like the HTML reference.
+- **Tactical pitch player drag/drop** with draggable formation tokens, collision-aware snapping, and persisted player geometry that flows through undo/redo history and file-backed storage.
+- **Card catalog and mutable layouts** featuring a palette overlay, add/remove commands, and undoable history entries that persist custom cards and hidden defaults per navigation section.
+- **Accessible catalog overlay** with themed controls, keyboard navigation, focus management, and backdrop dismissal so add/remove workflows meet Football Manager UX expectations.
+- **Section-specific palette presets** that introduce curated card templates beyond the default layout, giving analysts ready-made variants for finance, tactics, training, transfers, and fixtures.
+- **Sample layout catalog** that mirrors real Football Manager content, including formation breakdowns, instructional lists, and metric summaries to guide downstream feature parity work across every navigation section.
+- **Interaction guardrails** preventing card removal during active drags or previews so persisted layouts remain consistent even under rapid mutation.
+- **Event-driven club data repository** that hydrates every domain from structured JSON, persists user overrides, and broadcasts snapshot updates so layouts refresh without restarting.
+- **Durable layout state persistence** that stores per-section card geometry on disk so drag and resize edits survive application restarts.
+- **Specialised analytics visuals** with custom line charts, radial gauges, and fixture timelines bound to the live repository so finance, training, transfers, and fixtures cards now reflect the HTML reference interactions.
+- **Shot map analytics workspace** that layers filterable outcome pills, hover tooltips, and an interactive pitch canvas on top of the analytics overview so analysts can inspect location, xG, and assist context directly on the dashboard.
+- **Contextual overlays and animated visuals** delivering hover tooltips, eased entrance animations, and interpolated values across charts, gauges, and timelines for parity with the HTML hover experience.
+- **Finance budget forecasting card** with a slider-driven scenario model, live impact calculations, and repository persistence so analysts can project balance, transfer, and wage outcomes directly from the dashboard.
+- **Finance control centre** bundling a cash-flow drilldown, multi-line budget allocator, and scenario board so finance analysts can explore income/outgoings, rebalance departmental spend with undoable persistence, and model strategic initiatives without leaving the finances tab.
+- **Card editing overlay** with dedicated list, gauge, and training session editors so squad key players, competition expectations, five-year plans, player issues, training intensity, focus areas, weekly schedules, detailed session slots, budget usage, active deals, recent activity, and overall balance can be adjusted through the live repository and persisted to disk.
+- **Club vision roadmap and objectives boards** introducing a strategic milestone timeline and editable competition objective workspace complete with status filters, accent controls, and undo-safe persistence through the live repository.
+- **Training workload heatmap** that mirrors the HTML recovery-to-high intensity grid with interactive cell tooltips, legend scaling, and a dedicated editor for tuning unit loads across every session.
+- **Dressing room morale heatmap** charting morale, support, and resilience by squad cohort with hover-aware tooltips, legend descriptions, and a repository-backed editor embedded in the dynamics overlay.
+- **Weekly training calendar** presented as a drag-enabled grid so analysts can reschedule sessions by dropping them into new day/slot combinations with live repository persistence and inline status messaging.
+- **Training unit assignment board** delivering a column-based workspace with coach badges, per-unit player cards, and an editor overlay for reassigning players or coaches across senior, youth, and goalkeeping groups with undo-safe persistence.
+- **Training progression analytics** combining a multi-series development chart, highlight callouts, and a repository-backed editor so analysts can adjust progression ranges, per-unit trajectories, and milestone summaries directly from the training overview.
+- Training progression editing now includes timeline bucket management, palette-driven colour selection with previews, and validation to prevent invalid hex values before persistence.
+- **Medical injury timeline dashboard** that visualises rehab phases, status notes, and expected returns with a dedicated timeline control so medical staff can track clearance milestones inside the overview tab.
+- **Fixtures calendar workspace** with competition filters, an interactive monthly grid, and repository-backed match detail overlays for managing travel logistics, preparation notes, and status updates without leaving the fixtures tab.
+- **Workload heatmap editor** extending the card overlay catalogue so analysts can rebalance unit intensities, adjust load values, and annotate session details with undo-safe persistence through the live repository.
+- **Formation swap editor** that lets analysts assign any player from the tactical pool to a formation slot with validation, undo integration, and repository-backed persistence.
+- **Squad roster intelligence board** featuring a virtualised, filterable player table with inline comparison overlays so analysts can slice by role, surface minutes and conditioning, and benchmark selected players without leaving the squad tab.
+- **Drag-to-reschedule list editing** – every list-based editor now supports pointer drag/drop reordering in addition to keyboard nudging so training calendars and scouting queues can be reshuffled fluidly.
+- **Dynamic navigation indicators** that derive badge counts and severity pulses from live club data, surfacing fixtures, medical risks, player issues, and transfer activity directly in the tab chrome.
+- **Enhanced list and metric cards** with animated hover treatments and styled tooltips so dense dashboards expose secondary details without expanding every card.
+- **Permission-aware navigation** driven by a live permission service that hides tabs or sections lacking clearance while broadcasting updates as club data changes.
+- **Responsive navigation chrome** with adaptive spacing, animated tab highlights, compact header states, and scrollable overflow so the shell stays usable on narrower window widths.
+- **Transfer negotiation workspace** rendering active deals with per-term progress, status pills, and summary insights sourced from the live repository so analysts can track offer momentum directly on the transfer centre canvas.
+- **Negotiation editor overlay** that drives stage/status combos, slider-based fee, wage, and bonus adjustments, and regenerates active-deal summaries while persisting changes through the event-driven club data service.
+- **Negotiation deal management** with add/remove commands, live validation messaging, and default term templates so recruitment teams can spin up new talks, retire stale negotiations, and expand stage/status vocabularies without editing JSON.
+- **Scouting assignment board** combining a dedicated card, hover metrics, and an editor overlay so recruitment analysts can reprioritise regions, stages, scouts, and deadlines with undo-safe persistence that also refreshes the list summaries.
+- **Shortlist management workspace** featuring an interactive shortlist card, drag-to-order editing overlay, and repository-backed status/action pipelines so analysts can curate target priorities, follow-up actions, and notes without manual JSON edits.
+
+## Next Steps
+
+1. Install the .NET 8 SDK locally if it is not already available.
+2. Restore and build the solution:
+   ```bash
+   dotnet build WPF/FMUI.Wpf.sln
+   ```
+3. Layer preset management and undo grouping onto finance scenario experiments, scouting assignment templates, and shortlist batches so analysts can flip between saved what-if models.
+4. Extend formation and status-specific overlays (role presets, contextual menus) to reuse the shared tooltip/animation system while continuing to harden accessibility semantics.
+5. Build automation and performance coverage (UI/integration tests, telemetry) to protect the growing interaction surface as live data workflows expand.
+
+The scaffold now reflects the navigation, theming, messaging, and interaction patterns required for the full Football Manager UI conversion.


### PR DESCRIPTION
## Summary
- add finance cashflow, budget allocator, and scenario board card kinds with supporting models
- surface the new finance dashboards through the layout catalog, snapshots, and JSON seed data
- implement view models and views for cashflow drilldowns, budget sliders, and scenario toggles

## Testing
- python -m json.tool WPF/FMUI.Wpf/Data/club-data.json >/tmp/club-data.json

------
https://chatgpt.com/codex/tasks/task_e_68dff28123dc8328bc94dbd7a8a22d05