### PR TITLE
Refactor navigation data to use module snapshots and string tokens

### DIFF
--- a/WPF/FMUI.Wpf/App.xaml.cs
+++ b/WPF/FMUI.Wpf/App.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Windows;
+using System.Collections.Generic;
+using FMUI.Wpf.Configuration;
 using FMUI.Wpf.Infrastructure;
 using FMUI.Wpf.Models;
 using FMUI.Wpf.Services;
@@ -45,6 +47,25 @@ public partial class App : Application
     {
         services.AddSingleton<IEventAggregator, EventAggregator>();
         services.AddSingleton<IClubDataService, ClubDataService>();
+        services.AddSingleton<IModuleSnapshotProvider, ModuleSnapshotProvider>();
+
+        var navigationLocalization = NavigationLocalizationConfig.CreateDefault();
+        var indicatorLocalization = IndicatorLocalizationConfig.CreateDefault();
+        services.AddSingleton(navigationLocalization);
+        services.AddSingleton(indicatorLocalization);
+
+        var resources = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var pair in NavigationLocalizationConfig.GetResources(navigationLocalization))
+        {
+            resources[pair.Key] = pair.Value;
+        }
+
+        foreach (var pair in IndicatorLocalizationConfig.GetResources(indicatorLocalization))
+        {
+            resources[pair.Key] = pair.Value;
+        }
+
+        services.AddSingleton<IStringDatabase>(new StringDatabase(resources));
         services.AddSingleton<ICardLayoutCatalog, CardLayoutCatalog>();
         services.AddSingleton<ICardEditorCatalog, CardEditorCatalog>();
         services.AddSingleton<INavigationCatalog, NavigationCatalog>();

--- a/WPF/FMUI.Wpf/Configuration/IndicatorLocalizationConfig.cs
+++ b/WPF/FMUI.Wpf/Configuration/IndicatorLocalizationConfig.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using FMUI.Wpf.Infrastructure;
+
+namespace FMUI.Wpf.Configuration;
+
+public sealed record IndicatorMessageConfig(StringToken Singular, StringToken Plural);
+
+public sealed record IndicatorScheduleMessageConfig(StringToken NextFixture, StringToken MultipleFixtures);
+
+public sealed class IndicatorLocalizationConfig
+{
+    public IndicatorLocalizationConfig(
+        IndicatorMessageConfig clubVision,
+        IndicatorMessageConfig dynamics,
+        IndicatorMessageConfig medical,
+        IndicatorMessageConfig squadSelection,
+        IndicatorMessageConfig squadTransfers,
+        IndicatorMessageConfig trainingMedical,
+        IndicatorMessageConfig transferCentre,
+        IndicatorScheduleMessageConfig fixtureSchedule)
+    {
+        ClubVision = clubVision ?? throw new ArgumentNullException(nameof(clubVision));
+        Dynamics = dynamics ?? throw new ArgumentNullException(nameof(dynamics));
+        Medical = medical ?? throw new ArgumentNullException(nameof(medical));
+        SquadSelection = squadSelection ?? throw new ArgumentNullException(nameof(squadSelection));
+        SquadTransfers = squadTransfers ?? throw new ArgumentNullException(nameof(squadTransfers));
+        TrainingMedical = trainingMedical ?? throw new ArgumentNullException(nameof(trainingMedical));
+        TransferCentre = transferCentre ?? throw new ArgumentNullException(nameof(transferCentre));
+        FixtureSchedule = fixtureSchedule ?? throw new ArgumentNullException(nameof(fixtureSchedule));
+    }
+
+    public IndicatorMessageConfig ClubVision { get; }
+
+    public IndicatorMessageConfig Dynamics { get; }
+
+    public IndicatorMessageConfig Medical { get; }
+
+    public IndicatorMessageConfig SquadSelection { get; }
+
+    public IndicatorMessageConfig SquadTransfers { get; }
+
+    public IndicatorMessageConfig TrainingMedical { get; }
+
+    public IndicatorMessageConfig TransferCentre { get; }
+
+    public IndicatorScheduleMessageConfig FixtureSchedule { get; }
+
+    public static IndicatorLocalizationConfig CreateDefault()
+    {
+        return new IndicatorLocalizationConfig(
+            clubVision: new IndicatorMessageConfig(
+                StringToken.Create("indicator.clubVision.singular", "{0} expectation is off target"),
+                StringToken.Create("indicator.clubVision.plural", "{0} competition expectations need action")),
+            dynamics: new IndicatorMessageConfig(
+                StringToken.Create("indicator.dynamics.singular", "Issue raised by {0}"),
+                StringToken.Create("indicator.dynamics.plural", "{0} player issues require attention")),
+            medical: new IndicatorMessageConfig(
+                StringToken.Create("indicator.medical.singular", "Medical flag for {0}"),
+                StringToken.Create("indicator.medical.plural", "{0} medical cases active")),
+            squadSelection: new IndicatorMessageConfig(
+                StringToken.Create("indicator.selection.singular", "Fitness concern: {0}"),
+                StringToken.Create("indicator.selection.plural", "{0} fitness concerns to manage")),
+            squadTransfers: new IndicatorMessageConfig(
+                StringToken.Create("indicator.squadTransfers.singular", "Transfer interest in {0}"),
+                StringToken.Create("indicator.squadTransfers.plural", "{0} players attracting bids")),
+            trainingMedical: new IndicatorMessageConfig(
+                StringToken.Create("indicator.trainingMedical.singular", "Training risk: {0}"),
+                StringToken.Create("indicator.trainingMedical.plural", "{0} players flagged by medical team")),
+            transferCentre: new IndicatorMessageConfig(
+                StringToken.Create("indicator.transferCentre.singular", "Deal in progress: {0}"),
+                StringToken.Create("indicator.transferCentre.plural", "{0} active deals underway")),
+            fixtureSchedule: new IndicatorScheduleMessageConfig(
+                StringToken.Create("indicator.fixtureSchedule.next", "Next fixture: {0}"),
+                StringToken.Create("indicator.fixtureSchedule.multi", "{0} fixtures this fortnight")));
+    }
+
+    public static IEnumerable<KeyValuePair<string, string>> GetResources(IndicatorLocalizationConfig config)
+    {
+        yield return CreatePair(config.ClubVision.Singular);
+        yield return CreatePair(config.ClubVision.Plural);
+
+        yield return CreatePair(config.Dynamics.Singular);
+        yield return CreatePair(config.Dynamics.Plural);
+
+        yield return CreatePair(config.Medical.Singular);
+        yield return CreatePair(config.Medical.Plural);
+
+        yield return CreatePair(config.SquadSelection.Singular);
+        yield return CreatePair(config.SquadSelection.Plural);
+
+        yield return CreatePair(config.SquadTransfers.Singular);
+        yield return CreatePair(config.SquadTransfers.Plural);
+
+        yield return CreatePair(config.TrainingMedical.Singular);
+        yield return CreatePair(config.TrainingMedical.Plural);
+
+        yield return CreatePair(config.TransferCentre.Singular);
+        yield return CreatePair(config.TransferCentre.Plural);
+
+        yield return CreatePair(config.FixtureSchedule.NextFixture);
+        yield return CreatePair(config.FixtureSchedule.MultipleFixtures);
+    }
+
+    private static KeyValuePair<string, string> CreatePair(StringToken token)
+    {
+        return new KeyValuePair<string, string>(token.Id, token.Fallback ?? token.Id);
+    }
+}

--- a/WPF/FMUI.Wpf/Configuration/NavigationLocalizationConfig.cs
+++ b/WPF/FMUI.Wpf/Configuration/NavigationLocalizationConfig.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using FMUI.Wpf.Infrastructure;
+
+namespace FMUI.Wpf.Configuration;
+
+public sealed record NavigationSectionConfig(string Identifier, StringToken Label);
+
+public sealed record NavigationTabConfig(string Identifier, StringToken Label, IReadOnlyList<NavigationSectionConfig> Sections);
+
+public sealed class NavigationLocalizationConfig
+{
+    public NavigationLocalizationConfig(IReadOnlyList<NavigationTabConfig> tabs)
+    {
+        Tabs = tabs ?? throw new ArgumentNullException(nameof(tabs));
+    }
+
+    public IReadOnlyList<NavigationTabConfig> Tabs { get; }
+
+    public static NavigationLocalizationConfig CreateDefault()
+    {
+        var tabs = new List<NavigationTabConfig>
+        {
+            new(
+                "overview",
+                StringToken.Create("nav.tab.overview", "Overview"),
+                new ReadOnlyCollection<NavigationSectionConfig>(new List<NavigationSectionConfig>
+                {
+                    new("club-vision", StringToken.Create("nav.section.clubVision", "Club Vision")),
+                    new("dynamics", StringToken.Create("nav.section.dynamics", "Dynamics")),
+                    new("medical-centre", StringToken.Create("nav.section.medicalCentre", "Medical Centre")),
+                    new("analytics", StringToken.Create("nav.section.analytics", "Analytics")),
+                })),
+            new(
+                "squad",
+                StringToken.Create("nav.tab.squad", "Squad"),
+                new ReadOnlyCollection<NavigationSectionConfig>(new List<NavigationSectionConfig>
+                {
+                    new("selection-info", StringToken.Create("nav.section.selectionInfo", "Selection Info")),
+                    new("players", StringToken.Create("nav.section.players", "Players")),
+                    new("international", StringToken.Create("nav.section.international", "International")),
+                    new("squad-depth", StringToken.Create("nav.section.squadDepth", "Squad Depth")),
+                })),
+            new(
+                "tactics",
+                StringToken.Create("nav.tab.tactics", "Tactics"),
+                new ReadOnlyCollection<NavigationSectionConfig>(new List<NavigationSectionConfig>
+                {
+                    new("tactics-overview", StringToken.Create("nav.section.tacticsOverview", "Overview")),
+                    new("set-pieces", StringToken.Create("nav.section.setPieces", "Set Pieces")),
+                    new("tactics-analysis", StringToken.Create("nav.section.tacticsAnalysis", "Analysis")),
+                })),
+            new(
+                "training",
+                StringToken.Create("nav.tab.training", "Training"),
+                new ReadOnlyCollection<NavigationSectionConfig>(new List<NavigationSectionConfig>
+                {
+                    new("training-overview", StringToken.Create("nav.section.trainingOverview", "Overview")),
+                    new("training-calendar", StringToken.Create("nav.section.trainingCalendar", "Calendar")),
+                    new("training-units", StringToken.Create("nav.section.trainingUnits", "Units")),
+                })),
+            new(
+                "transfers",
+                StringToken.Create("nav.tab.transfers", "Transfers"),
+                new ReadOnlyCollection<NavigationSectionConfig>(new List<NavigationSectionConfig>
+                {
+                    new("transfer-centre", StringToken.Create("nav.section.transferCentre", "Centre")),
+                    new("scouting", StringToken.Create("nav.section.scouting", "Scouting")),
+                    new("shortlist", StringToken.Create("nav.section.shortlist", "Shortlist")),
+                })),
+            new(
+                "finances",
+                StringToken.Create("nav.tab.finances", "Finances"),
+                new ReadOnlyCollection<NavigationSectionConfig>(new List<NavigationSectionConfig>
+                {
+                    new("finances-summary", StringToken.Create("nav.section.financesSummary", "Summary")),
+                    new("finances-income", StringToken.Create("nav.section.financesIncome", "Income")),
+                    new("finances-expenditure", StringToken.Create("nav.section.financesExpenditure", "Expenditure")),
+                })),
+            new(
+                "fixtures",
+                StringToken.Create("nav.tab.fixtures", "Fixtures"),
+                new ReadOnlyCollection<NavigationSectionConfig>(new List<NavigationSectionConfig>
+                {
+                    new("fixtures-schedule", StringToken.Create("nav.section.fixturesSchedule", "Schedule")),
+                    new("fixtures-results", StringToken.Create("nav.section.fixturesResults", "Results")),
+                    new("fixtures-calendar", StringToken.Create("nav.section.fixturesCalendar", "Calendar")),
+                })),
+        };
+
+        return new NavigationLocalizationConfig(new ReadOnlyCollection<NavigationTabConfig>(tabs));
+    }
+
+    public static IEnumerable<KeyValuePair<string, string>> GetResources(NavigationLocalizationConfig config)
+    {
+        foreach (var tab in config.Tabs)
+        {
+            yield return new KeyValuePair<string, string>(tab.Label.Id, tab.Label.Fallback ?? tab.Label.Id);
+            foreach (var section in tab.Sections)
+            {
+                yield return new KeyValuePair<string, string>(section.Label.Id, section.Label.Fallback ?? section.Label.Id);
+            }
+        }
+    }
+}

--- a/WPF/FMUI.Wpf/Infrastructure/StringDatabase.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/StringDatabase.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public interface IStringDatabase
+{
+    string Resolve(StringToken token);
+}
+
+public sealed class StringDatabase : IStringDatabase
+{
+    private readonly Dictionary<string, string> _resources;
+
+    public StringDatabase(IEnumerable<KeyValuePair<string, string>> resources)
+    {
+        if (resources is null)
+        {
+            throw new ArgumentNullException(nameof(resources));
+        }
+
+        _resources = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var pair in resources)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key))
+            {
+                continue;
+            }
+
+            _resources[pair.Key] = pair.Value ?? string.Empty;
+        }
+    }
+
+    public string Resolve(StringToken token)
+    {
+        if (_resources.TryGetValue(token.Id, out var value))
+        {
+            return value;
+        }
+
+        return token.Fallback ?? token.Id;
+    }
+}

--- a/WPF/FMUI.Wpf/Infrastructure/StringToken.cs
+++ b/WPF/FMUI.Wpf/Infrastructure/StringToken.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace FMUI.Wpf.Infrastructure;
+
+public readonly struct StringToken : IEquatable<StringToken>
+{
+    public StringToken(string id, string? fallback = null)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            throw new ArgumentException("Token identifier cannot be null or whitespace.", nameof(id));
+        }
+
+        Id = id;
+        Fallback = fallback;
+    }
+
+    public string Id { get; }
+
+    public string? Fallback { get; }
+
+    public bool Equals(StringToken other) => string.Equals(Id, other.Id, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is StringToken token && Equals(token);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Id);
+
+    public override string ToString() => Id;
+
+    public static StringToken Create(string id, string fallback) => new(id, fallback);
+}

--- a/WPF/FMUI.Wpf/Services/ClubDataService.cs
+++ b/WPF/FMUI.Wpf/Services/ClubDataService.cs
@@ -11,8 +11,6 @@ public interface IClubDataService
 {
     ClubDataSnapshot Current { get; }
 
-    ClubDataSnapshot GetSnapshot();
-
     event EventHandler<ClubDataSnapshot>? SnapshotChanged;
 
     Task RefreshAsync(CancellationToken cancellationToken = default);
@@ -49,8 +47,6 @@ public sealed class ClubDataService : IClubDataService
     public event EventHandler<ClubDataSnapshot>? SnapshotChanged;
 
     public ClubDataSnapshot Current => _snapshot;
-
-    public ClubDataSnapshot GetSnapshot() => _snapshot;
 
     public async Task RefreshAsync(CancellationToken cancellationToken = default)
     {

--- a/WPF/FMUI.Wpf/Services/ModuleSnapshotProvider.cs
+++ b/WPF/FMUI.Wpf/Services/ModuleSnapshotProvider.cs
@@ -1,0 +1,45 @@
+using System;
+using FMUI.Wpf.Models;
+
+namespace FMUI.Wpf.Services;
+
+public interface IModuleSnapshotProvider
+{
+    OverviewSnapshot GetOverview();
+
+    SquadSnapshot GetSquad();
+
+    TacticalSnapshot GetTactics();
+
+    TrainingSnapshot GetTraining();
+
+    TransfersSnapshot GetTransfers();
+
+    FinanceSnapshot GetFinance();
+
+    FixturesSnapshot GetFixtures();
+}
+
+public sealed class ModuleSnapshotProvider : IModuleSnapshotProvider
+{
+    private readonly IClubDataService _clubDataService;
+
+    public ModuleSnapshotProvider(IClubDataService clubDataService)
+    {
+        _clubDataService = clubDataService ?? throw new ArgumentNullException(nameof(clubDataService));
+    }
+
+    public OverviewSnapshot GetOverview() => _clubDataService.Current.Overview;
+
+    public SquadSnapshot GetSquad() => _clubDataService.Current.Squad;
+
+    public TacticalSnapshot GetTactics() => _clubDataService.Current.Tactics;
+
+    public TrainingSnapshot GetTraining() => _clubDataService.Current.Training;
+
+    public TransfersSnapshot GetTransfers() => _clubDataService.Current.Transfers;
+
+    public FinanceSnapshot GetFinance() => _clubDataService.Current.Finance;
+
+    public FixturesSnapshot GetFixtures() => _clubDataService.Current.Fixtures;
+}

--- a/WPF/FMUI.Wpf/Services/NavigationCatalog.cs
+++ b/WPF/FMUI.Wpf/Services/NavigationCatalog.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using FMUI.Wpf.Configuration;
+using FMUI.Wpf.Infrastructure;
 using FMUI.Wpf.Models;
 
 namespace FMUI.Wpf.Services;
@@ -10,51 +13,29 @@ public interface INavigationCatalog
 
 public sealed class NavigationCatalog : INavigationCatalog
 {
-    public IReadOnlyList<NavigationTab> GetTabs() => new List<NavigationTab>
+    private readonly NavigationLocalizationConfig _config;
+    private readonly IStringDatabase _strings;
+
+    public NavigationCatalog(NavigationLocalizationConfig config, IStringDatabase strings)
     {
-        new("Overview", "overview", new List<NavigationSubItem>
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _strings = strings ?? throw new ArgumentNullException(nameof(strings));
+    }
+
+    public IReadOnlyList<NavigationTab> GetTabs()
+    {
+        var tabs = new List<NavigationTab>(_config.Tabs.Count);
+        foreach (var tab in _config.Tabs)
         {
-            new("Club Vision", "club-vision"),
-            new("Dynamics", "dynamics"),
-            new("Medical Centre", "medical-centre"),
-            new("Analytics", "analytics"),
-        }),
-        new("Squad", "squad", new List<NavigationSubItem>
-        {
-            new("Selection Info", "selection-info"),
-            new("Players", "players"),
-            new("International", "international"),
-            new("Squad Depth", "squad-depth"),
-        }),
-        new("Tactics", "tactics", new List<NavigationSubItem>
-        {
-            new("Overview", "tactics-overview"),
-            new("Set Pieces", "set-pieces"),
-            new("Analysis", "tactics-analysis"),
-        }),
-        new("Training", "training", new List<NavigationSubItem>
-        {
-            new("Overview", "training-overview"),
-            new("Calendar", "training-calendar"),
-            new("Units", "training-units"),
-        }),
-        new("Transfers", "transfers", new List<NavigationSubItem>
-        {
-            new("Centre", "transfer-centre"),
-            new("Scouting", "scouting"),
-            new("Shortlist", "shortlist"),
-        }),
-        new("Finances", "finances", new List<NavigationSubItem>
-        {
-            new("Summary", "finances-summary"),
-            new("Income", "finances-income"),
-            new("Expenditure", "finances-expenditure"),
-        }),
-        new("Fixtures", "fixtures", new List<NavigationSubItem>
-        {
-            new("Schedule", "fixtures-schedule"),
-            new("Results", "fixtures-results"),
-            new("Calendar", "fixtures-calendar"),
-        }),
-    };
+            var sections = new List<NavigationSubItem>(tab.Sections.Count);
+            foreach (var section in tab.Sections)
+            {
+                sections.Add(new NavigationSubItem(_strings.Resolve(section.Label), section.Identifier));
+            }
+
+            tabs.Add(new NavigationTab(_strings.Resolve(tab.Label), tab.Identifier, sections));
+        }
+
+        return tabs;
+    }
 }


### PR DESCRIPTION
## Summary
- add string database infrastructure and localisation configs for navigation and indicator text
- refactor navigation catalog and indicator service to resolve text through the string database
- introduce module snapshot provider and update card layout catalog to rely on live module snapshots

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3acf9cf0c8328baccaf54a453ed02